### PR TITLE
Set Python @3.11 due to Checkov aiohttp issues on 3.12

### DIFF
--- a/.github/workflows/org-checkov.yml
+++ b/.github/workflows/org-checkov.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.11
 
     - name: Install Checkov
       run: |


### PR DESCRIPTION
AIOHTTP is a dependency of Checkov but doesn't work on Python 3.12. Only <=3.11. Changed Python from 3.x to pin to 3.11