### PR TITLE
Add Terraform validation workflow with org-wide PAT

### DIFF
--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -1,6 +1,13 @@
 name: Terraform Validate
+
 on:
-  workflow_call:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
     inputs:
       terraform_version:
         description: 'The version of Terraform to use'
@@ -19,8 +26,14 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: ${{ inputs.terraform_version }}
+        terraform_version: ${{ inputs.terraform_version || '1.5.0' }}
 
+    - name: Configure Git for private modules
+      env:
+        GH_TOKEN: ${{ secrets.ORG_GITHUB_PAT }}
+      run: |
+        git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+        
     - name: Initialise with no backend
       run: terraform init -backend=false
 
@@ -31,11 +44,12 @@ jobs:
         OUTPUT=$(terraform validate)
         CLEAN_OUTPUT=$(echo "$OUTPUT" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
         echo "$CLEAN_OUTPUT"
-        echo "::set-output name=result::$CLEAN_OUTPUT"
+        echo "result=$CLEAN_OUTPUT" >> $GITHUB_OUTPUT
         set -e
       continue-on-error: true
 
     - name: Create comment
+      if: github.event_name == 'pull_request'
       uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Add Terraform Validation Workflow**

This PR introduces a new GitHub Actions workflow for validating Terraform configurations across our repositories.

**Changes**

- Added an updated workflow file: .github/workflows/org-terraform-validate.yml
- The workflow runs on all pushes, pull requests, and can be triggered manually
- It uses the organization-wide GitHub PAT for accessing private modules

**Key Features**

1. **Automatic Triggering:** Runs on every push and pull request to any branch
2. **Manual Triggering:** Can be run manually with a custom Terraform version
3. **Private Module Access:** Uses the ORG_GITHUB_PAT secret for accessing private modules
4. **Comprehensive Validation:** Performs Terraform init and validate operations
5. **Pull Request Integration:** Comments validation results on pull requests

**Implementation Notes**

- The workflow uses the ORG_GITHUB_PAT secret, which should be set up at the organization level
- Default Terraform version is set to 1.5.0, but can be overridden in manual runs

**Testing Checklist**

- [x]  Verify the workflow runs successfully on push
- [x]  Verify the workflow runs successfully on pull requests
- [x]  Confirm access to private Terraform modules
- https://github.com/Coalfire-CF/cs-dev-sandbox/actions/runs/10816124920/job/30006596598

**Security Considerations**

- Ensure the ORG_GITHUB_PAT has the minimum required permissions
- Regularly rotate the PAT as per organization security policies

**Next Steps**

- Monitor the workflow's performance and adjust as needed
- Consider adding more comprehensive Terraform checks in future iterations