### PR TITLE
feat: add cosign signing to release clean pipeline

### DIFF
--- a/.github/workflows/org-release-clean.yml
+++ b/.github/workflows/org-release-clean.yml
@@ -14,6 +14,7 @@ name: Release Artifact Cleaner
 #   - Inputs passed via env: blocks, never direct ${{ }} in shell
 #   - Optional GitHub App token for consistent auth across public/private repos (IA-2)
 #   - SHA256 checksum for artifact integrity (SI-7)
+#   - Cosign signature for artifact authenticity (SI-7, SC-8)
 #   - Step summary for audit trail (AU-3)
 
 on:
@@ -33,6 +34,11 @@ on:
         required: false
         type: string
         default: 'CHANGELOG.md,release-please-config.json,.release-please-manifest.json,.gitignore,.gitattributes,CLAUDE.md,.claudeignore'
+      cosign_sign:
+        description: 'Sign release artifacts with cosign (requires COSIGN_PRIVATE_KEY and COSIGN_PASSWORD org secrets)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write # Required to upload release assets
@@ -174,6 +180,70 @@ jobs:
         echo "SHA256: ${CHECKSUM}"
         echo "CHECKSUM=${CHECKSUM}" >> "${GITHUB_ENV}"
 
+    - name: Install cosign
+      if: inputs.cosign_sign
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Write cosign public key
+      if: inputs.cosign_sign
+      env:
+        COSIGN_PUBLIC_KEY: ${{ vars.COSIGN_PUBLIC_KEY }}
+      run: |
+        if [[ -z "${COSIGN_PUBLIC_KEY}" ]]; then
+          echo "::error::COSIGN_PUBLIC_KEY org variable is not set"
+          exit 1
+        fi
+        echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
+        echo "Wrote cosign.pub from org variable"
+
+    - name: Create signing config (skip transparency log)
+      if: inputs.cosign_sign
+      run: cosign signing-config create --out cosign-signing-config.json
+
+    - name: Sign release artifacts
+      if: inputs.cosign_sign
+      env:
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      run: |
+        set -eo pipefail
+
+        echo "Signing ${ARCHIVE_NAME}..."
+        cosign sign-blob --yes \
+          --signing-config cosign-signing-config.json \
+          --key env://COSIGN_PRIVATE_KEY \
+          --bundle "${ARCHIVE_NAME}.bundle" \
+          "${ARCHIVE_NAME}"
+
+        echo "Signing ${CHECKSUM_NAME}..."
+        cosign sign-blob --yes \
+          --signing-config cosign-signing-config.json \
+          --key env://COSIGN_PRIVATE_KEY \
+          --bundle "${CHECKSUM_NAME}.bundle" \
+          "${CHECKSUM_NAME}"
+
+        echo "Bundles created:"
+        ls -la *.bundle
+
+    - name: Verify signatures
+      if: inputs.cosign_sign
+      run: |
+        set -eo pipefail
+
+        echo "Verifying ${ARCHIVE_NAME}..."
+        cosign verify-blob --insecure-ignore-tlog \
+          --key cosign.pub \
+          --bundle "${ARCHIVE_NAME}.bundle" \
+          "${ARCHIVE_NAME}"
+
+        echo "Verifying ${CHECKSUM_NAME}..."
+        cosign verify-blob --insecure-ignore-tlog \
+          --key cosign.pub \
+          --bundle "${CHECKSUM_NAME}.bundle" \
+          "${CHECKSUM_NAME}"
+
+        echo "All signatures verified successfully"
+
     - name: Upload to GitHub Release
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
@@ -181,7 +251,11 @@ jobs:
         GH_REPO: ${{ github.repository }}
       run: |
         set -eo pipefail
-        gh release upload "${TAG_NAME}" "${ARCHIVE_NAME}" "${CHECKSUM_NAME}" --repo "${GH_REPO}" --clobber
+        ASSETS=("${ARCHIVE_NAME}" "${CHECKSUM_NAME}")
+        if [[ -f "${ARCHIVE_NAME}.bundle" ]]; then
+          ASSETS+=("${ARCHIVE_NAME}.bundle" "${CHECKSUM_NAME}.bundle" "cosign.pub")
+        fi
+        gh release upload "${TAG_NAME}" "${ASSETS[@]}" --repo "${GH_REPO}" --clobber
 
     - name: Upload workflow artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -190,6 +264,8 @@ jobs:
         path: |
           ${{ env.ARCHIVE_NAME }}
           ${{ env.CHECKSUM_NAME }}
+          *.bundle
+          cosign.pub
         retention-days: 30
 
     - name: Generate step summary
@@ -208,6 +284,11 @@ jobs:
           echo "| Archive | \`${ARCHIVE_NAME:-N/A}\` |"
           echo "| Size | ${ARCHIVE_SIZE:-N/A} |"
           echo "| SHA256 | \`${CHECKSUM:-N/A}\` |"
+          if [[ -f "${ARCHIVE_NAME}.bundle" ]]; then
+            echo "| Cosign Signed | Yes |"
+          else
+            echo "| Cosign Signed | No |"
+          fi
           echo ""
           echo "### Excluded"
           echo "- Directories: \`${EXCLUDE_DIRS}\`"

--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -23,7 +23,9 @@ name: Release Please
 #   its own isolated runner — scan jobs always see the full repo.
 #
 #   The tarball and a SHA256 checksum file are attached as release assets and also
-#   available as workflow artifacts (30-day retention).
+#   available as workflow artifacts (30-day retention). When cosign signing is
+#   enabled (default), cosign .bundle files are also attached for both the
+#   tarball and checksum, along with cosign.pub for verification.
 #
 #   .git/ is always removed. Default exclusions:
 #     dirs:  .github, docs, .claude
@@ -82,6 +84,11 @@ on:
         required: false
         type: string
         default: 'CHANGELOG.md,release-please-config.json,.release-please-manifest.json,.gitignore,.gitattributes,CLAUDE.md,.claudeignore'
+      cosign_sign:
+        description: 'Sign release artifacts with cosign (requires COSIGN_PRIVATE_KEY and COSIGN_PASSWORD org secrets)'
+        required: false
+        type: boolean
+        default: true
       slack_channel_id:
         description: 'Slack channel ID for release and failure notifications (optional)'
         required: false
@@ -152,6 +159,7 @@ jobs:
       tag_name: ${{ needs.release.outputs.tag_name }}
       exclude_dirs: ${{ inputs.clean_exclude_dirs }}
       exclude_files: ${{ inputs.clean_exclude_files }}
+      cosign_sign: ${{ inputs.cosign_sign }}
     secrets: inherit
 
   trivy-scan:

--- a/.github/workflows/test-cosign.yml
+++ b/.github/workflows/test-cosign.yml
@@ -1,0 +1,91 @@
+name: Test Cosign Signing
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-cosign:
+    name: Test Cosign Sign & Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write cosign public key
+        env:
+          COSIGN_PUBLIC_KEY: ${{ vars.COSIGN_PUBLIC_KEY }}
+        run: |
+          if [[ -z "${COSIGN_PUBLIC_KEY}" ]]; then
+            echo "::error::COSIGN_PUBLIC_KEY org variable is not set"
+            exit 1
+          fi
+          echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
+          echo "Wrote cosign.pub from org variable"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Create test artifacts
+        run: |
+          echo "test release content" > test-archive.tar.gz
+          sha256sum test-archive.tar.gz > test-archive.tar.gz.sha256
+          echo "Test artifacts:"
+          ls -la test-*
+
+      - name: Create signing config (skip transparency log)
+        run: cosign signing-config create --out cosign-signing-config.json
+
+      - name: Sign artifacts
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          set -eo pipefail
+
+          echo "Signing tarball..."
+          cosign sign-blob --yes \
+            --signing-config cosign-signing-config.json \
+            --key env://COSIGN_PRIVATE_KEY \
+            --bundle test-archive.tar.gz.bundle \
+            test-archive.tar.gz
+
+          echo "Signing checksum..."
+          cosign sign-blob --yes \
+            --signing-config cosign-signing-config.json \
+            --key env://COSIGN_PRIVATE_KEY \
+            --bundle test-archive.tar.gz.sha256.bundle \
+            test-archive.tar.gz.sha256
+
+          echo "Bundles created:"
+          ls -la *.bundle
+
+      - name: Verify signatures
+        run: |
+          set -eo pipefail
+
+          echo "Verifying tarball..."
+          cosign verify-blob --insecure-ignore-tlog \
+            --key cosign.pub \
+            --bundle test-archive.tar.gz.bundle \
+            test-archive.tar.gz
+
+          echo "Verifying checksum..."
+          cosign verify-blob --insecure-ignore-tlog \
+            --key cosign.pub \
+            --bundle test-archive.tar.gz.sha256.bundle \
+            test-archive.tar.gz.sha256
+
+          echo "All signatures verified successfully"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Cosign Test Results"
+            echo ""
+            echo "| Check | Status |"
+            echo "|---|---|"
+            echo "| COSIGN_PUBLIC_KEY var | $([ -f cosign.pub ] && echo 'OK' || echo 'MISSING') |"
+            echo "| Tarball bundle | $([ -f test-archive.tar.gz.bundle ] && echo 'OK' || echo 'MISSING') |"
+            echo "| Checksum bundle | $([ -f test-archive.tar.gz.sha256.bundle ] && echo 'OK' || echo 'MISSING') |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds cosign bundle signing and verification to `org-release-clean.yml`
- Signs both the tarball and SHA256 checksum with cosign v4 bundle format
- Public key sourced from `COSIGN_PUBLIC_KEY` org variable at runtime (not stored in repo)
- `cosign.pub` included as a release asset for consumer verification
- New `cosign_sign` input (default `true`) on both `org-release.yml` and `org-release-clean.yml` for opt-out
- Skips Sigstore transparency log via `cosign signing-config create`
- Inline verification step validates signatures before upload
- Temporary `test-cosign.yml` workflow for validation (remove after testing)

## Required org configuration
| Type | Name | Value |
|---|---|---|
| Secret | `COSIGN_PRIVATE_KEY` | Cosign private key PEM |
| Secret | `COSIGN_PASSWORD` | Private key passphrase |
| Variable | `COSIGN_PUBLIC_KEY` | Cosign public key PEM |

## Release assets (when signing enabled)
| Asset | Purpose |
|---|---|
| `*-clean.tar.gz` | Clean tarball |
| `*-clean.tar.gz.sha256` | SHA256 checksum |
| `*-clean.tar.gz.bundle` | Cosign bundle for tarball |
| `*-clean.tar.gz.sha256.bundle` | Cosign bundle for checksum |
| `cosign.pub` | Public key for verification |

## Consumer verification
```bash
cosign verify-blob --insecure-ignore-tlog --key cosign.pub --bundle <file>.bundle <file>
```

## Test plan
- [ ] Merge and trigger test-cosign workflow from main
- [ ] Verify signing and verification steps pass
- [ ] Remove test-cosign.yml after validation
- [ ] Test full release flow on a downstream repo