### PR TITLE
feat(gates): central gate-config.yml strict switch (RFC-0010)

### DIFF
--- a/.github/workflows/org-opa.yml
+++ b/.github/workflows/org-opa.yml
@@ -42,11 +42,16 @@ on:
         required: false
         type: string
         default: '0.69.0'
-      blocking:
-        description: 'Tier-2 opt-in (ADR-0003): fail the pipeline on policy violations. Default false = Tier-1 advisory (warn-only).'
+      actions_ref:
+        description: 'Ref of Coalfire-CF/Actions to read the central gate-config.yml from'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'main'
+      blocking:
+        description: "Tier-2 opt-in (ADR-0003): override the central gate-config.yml opa default. '' (default) = defer to central gates.opa.strict; 'true'/'false' = force. Tier-1 advisory floor is preserved (day-one central default is false)."
+        required: false
+        type: string
+        default: ''
       slack_channel_id:
         description: 'Slack channel ID for failure notifications (optional; only meaningful when blocking is true)'
         required: false
@@ -79,6 +84,13 @@ jobs:
           repository: ${{ inputs.policy_repo }}
           ref: ${{ inputs.policy_ref }}
           path: policies
+
+      - name: Checkout Actions repo (central gate-config)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: Coalfire-CF/Actions
+          ref: ${{ inputs.actions_ref || 'main' }}
+          path: actions-tools
 
       - name: Guard — policies available?
         id: guard
@@ -140,9 +152,19 @@ jobs:
           POLICY_PATH: ${{ inputs.policy_path }}
           PLAN_ARTIFACT: ${{ inputs.plan_json_artifact }}
           WORKDIR: ${{ inputs.working_directory }}
-          BLOCKING: ${{ inputs.blocking && 'true' || 'false' }}
+          CALLER_BLOCKING: ${{ inputs.blocking }}
         run: |
           set -eo pipefail
+          # RFC-0010: caller `blocking` > central gates.opa.strict > false.
+          # (opa Tier-1 stays advisory; the central default ships false — ADR-0003.)
+          RESOLVER=actions-tools/scripts/gate-config-resolve.sh
+          CFG=actions-tools/gate-config.yml
+          if [ -f "$RESOLVER" ]; then
+            BLOCKING="$(bash "$RESOLVER" opa "${CALLER_BLOCKING}" "$CFG")"
+          else
+            BLOCKING="$([ "${CALLER_BLOCKING}" = "true" ] && echo true || echo false)"
+          fi
+          echo "resolved blocking=${BLOCKING} (gate=opa, caller='${CALLER_BLOCKING}')"
           POL="policies/${POLICY_PATH}"
           INPUT=""
           if [ -n "$PLAN_ARTIFACT" ]; then

--- a/.github/workflows/org-terraform-source-pin.yml
+++ b/.github/workflows/org-terraform-source-pin.yml
@@ -19,10 +19,10 @@ on:
         type: string
         default: ''
       strict:
-        description: 'Fail the job on unpinned/unauditable sources. Default false (advisory: warn-only, exit 0). Flip to true on the recorded promotion (RFC-0008).'
+        description: "Override the central gate-config.yml blocking default. '' (default) = defer to central; 'true'/'false' = force. RFC-0010 precedence: caller > central > false."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ''
     secrets:
       SLACK_BOT_TOKEN:
         description: 'Slack bot token for failure notifications (required if slack_channel_id is set)'
@@ -35,10 +35,10 @@ on:
         type: string
         default: '.'
       strict:
-        description: 'Fail the job on unpinned/unauditable sources (default false = advisory).'
+        description: "Override central gate-config.yml ('' defer, 'true'/'false' force)."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ''
   pull_request:
 
 jobs:
@@ -62,15 +62,22 @@ jobs:
       - name: Run Terraform source-pin check
         env:
           SCAN_ROOT: ${{ inputs.scan_root || '.' }}
-          STRICT: ${{ inputs.strict && 'true' || 'false' }}
+          CALLER_STRICT: ${{ inputs.strict }}
         run: |
-          # Prefer the script from the pinned Actions checkout; fall back to the
-          # target's own copy when self-testing this repo's PR (the script isn't
-          # on Actions main until this PR merges).
+          # Prefer the pinned Actions checkout; fall back to the target's own copy
+          # when self-testing this repo's PR (files aren't on Actions main until
+          # this PR merges).
           SCRIPT=actions-tools/scripts/source-pin-check.sh
           [ -f "$SCRIPT" ] || SCRIPT=target/scripts/source-pin-check.sh
+          RESOLVER=actions-tools/scripts/gate-config-resolve.sh
+          [ -f "$RESOLVER" ] || RESOLVER=target/scripts/gate-config-resolve.sh
+          CFG=actions-tools/gate-config.yml
+          [ -f "$CFG" ] || CFG=target/gate-config.yml
+          # RFC-0010 resolution: caller > central gate-config.yml > false.
+          STRICT="$(bash "$RESOLVER" source-pin "${CALLER_STRICT}" "$CFG")"
+          echo "resolved strict=${STRICT} (gate=source-pin, caller='${CALLER_STRICT}', config=${CFG})"
           chmod +x "$SCRIPT"
-          "$SCRIPT" "target/${SCAN_ROOT}"
+          STRICT="$STRICT" "$SCRIPT" "target/${SCAN_ROOT}"
 
   uses-pin:
     name: "Check workflow uses: pins"
@@ -92,14 +99,21 @@ jobs:
       - name: Run workflow uses-pin check
         env:
           SCAN_ROOT: ${{ inputs.scan_root || '.' }}
-          STRICT: ${{ inputs.strict && 'true' || 'false' }}
+          CALLER_STRICT: ${{ inputs.strict }}
         run: |
           # Prefer the pinned Actions checkout; fall back to the target's copy
-          # when self-testing this repo's PR (script not yet on Actions main).
+          # when self-testing this repo's PR (files not yet on Actions main).
           SCRIPT=actions-tools/scripts/uses-pin-check.sh
           [ -f "$SCRIPT" ] || SCRIPT=target/scripts/uses-pin-check.sh
+          RESOLVER=actions-tools/scripts/gate-config-resolve.sh
+          [ -f "$RESOLVER" ] || RESOLVER=target/scripts/gate-config-resolve.sh
+          CFG=actions-tools/gate-config.yml
+          [ -f "$CFG" ] || CFG=target/gate-config.yml
+          # RFC-0010 resolution: caller > central gate-config.yml > false.
+          STRICT="$(bash "$RESOLVER" uses-pin "${CALLER_STRICT}" "$CFG")"
+          echo "resolved strict=${STRICT} (gate=uses-pin, caller='${CALLER_STRICT}', config=${CFG})"
           chmod +x "$SCRIPT"
-          "$SCRIPT" "target/${SCAN_ROOT}"
+          STRICT="$STRICT" "$SCRIPT" "target/${SCAN_ROOT}"
 
   notify-failure:
     needs: [source-pin, uses-pin]

--- a/.github/workflows/org-terraform-version-band.yml
+++ b/.github/workflows/org-terraform-version-band.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: '.'
       actions_ref:
-        description: 'Fallback ref of Coalfire-CF/Actions for the band + script when job_workflow_sha is unavailable'
+        description: "Ref of Coalfire-CF/Actions to read the band + gate-config + scripts from (default 'main'; pin to a release SHA for reproducibility)."
         required: false
         type: string
         default: 'main'

--- a/.github/workflows/org-terraform-version-band.yml
+++ b/.github/workflows/org-terraform-version-band.yml
@@ -26,10 +26,10 @@ on:
         type: string
         default: ''
       strict:
-        description: 'Fail the job on out-of-band/open-ended versions. Default false (advisory). Flip to true on the recorded promotion (ADR-0013).'
+        description: "Override the central gate-config.yml blocking default. '' (default) = defer to central; 'true'/'false' = force. RFC-0010 precedence: caller > central > false."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ''
     secrets:
       SLACK_BOT_TOKEN:
         description: 'Slack bot token for failure notifications (required if slack_channel_id is set)'
@@ -42,10 +42,10 @@ on:
         type: string
         default: '.'
       strict:
-        description: 'Fail the job on out-of-band/open-ended versions (default false = advisory).'
+        description: "Override central gate-config.yml ('' defer, 'true'/'false' force)."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -73,9 +73,17 @@ jobs:
       - name: Resolve band and run version-band check
         env:
           SCAN_ROOT: ${{ inputs.scan_root || '.' }}
-          STRICT: ${{ inputs.strict && 'true' || 'false' }}
+          CALLER_STRICT: ${{ inputs.strict }}
         run: |
           set -eo pipefail
+          RESOLVER=actions-tools/scripts/gate-config-resolve.sh
+          [ -f "$RESOLVER" ] || RESOLVER=target/scripts/gate-config-resolve.sh
+          CFG=actions-tools/gate-config.yml
+          [ -f "$CFG" ] || CFG=target/gate-config.yml
+          # RFC-0010 resolution: caller > central gate-config.yml > false.
+          STRICT="$(bash "$RESOLVER" version-band "${CALLER_STRICT}" "$CFG")"
+          echo "resolved strict=${STRICT} (gate=version-band, caller='${CALLER_STRICT}', config=${CFG})"
+          export STRICT
           BAND="$(tr -d '[:space:]' < actions-tools/.terraform-version-band)"
           FLOOR="$(printf '%s' "$BAND" | sed -E 's/.*>=([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
           CEILING="$(printf '%s' "$BAND" | sed -E 's/.*<([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"

--- a/docs/GATE_CONFIG.md
+++ b/docs/GATE_CONFIG.md
@@ -20,8 +20,8 @@ Each gate resolves its effective blocking flag with this precedence
 
 1. **Caller `strict` input** — if the caller passes `'true'` or `'false'`, it wins
    (a local override, e.g. during a repo's migration).
-2. **Central default** — otherwise `gates.<key>.strict` from this file.
-3. **`false`** — if the key/file is absent.
+1. **Central default** — otherwise `gates.<key>.strict` from this file.
+1. **`false`** — if the key/file is absent.
 
 A caller leaves `strict: ''` (the default) to defer to the central value.
 For `org-opa`, the caller input is named `blocking` and maps to `gates.opa.strict`.
@@ -41,9 +41,9 @@ wants reproducibility can pin `actions_ref` to a release SHA.
 ## Promoting a gate (advisory → blocking)
 
 1. Open a PR that flips the gate's value to `strict: true` here.
-2. The PR body **must cite the recorded promotion decision** (the ADR-0011
+1. The PR body **must cite the recorded promotion decision** (the ADR-0011
    warn→required cycle; RFC-0008/RFC-0010).
-3. Merge on protected `main`. The gate is blocking for every caller on the next
+1. Merge on protected `main`. The gate is blocking for every caller on the next
    run. To roll back, flip it to `false` the same way.
 
 Day-one ships **all `false`** (advisory) — no behavior change on adoption.

--- a/docs/GATE_CONFIG.md
+++ b/docs/GATE_CONFIG.md
@@ -1,0 +1,49 @@
+# gate-config.yml — central advisory→blocking switch (RFC-0010)
+
+`gate-config.yml` at this repo's root is the single place that sets the
+**blocking default** for the org CI gates. It removes the per-caller edit that
+fleet-scaling would otherwise require to promote a gate from warn-only to
+blocking.
+
+```yaml
+gates:
+  source-pin:   { strict: false }
+  uses-pin:     { strict: false }
+  version-band: { strict: false }
+  opa:          { strict: false }  # Tier-2 blocking default only; opa Tier-1 stays advisory (ADR-0003)
+```
+
+## How a gate resolves `strict`
+
+Each gate resolves its effective blocking flag with this precedence
+(`scripts/gate-config-resolve.sh`):
+
+1. **Caller `strict` input** — if the caller passes `'true'` or `'false'`, it wins
+   (a local override, e.g. during a repo's migration).
+2. **Central default** — otherwise `gates.<key>.strict` from this file.
+3. **`false`** — if the key/file is absent.
+
+A caller leaves `strict: ''` (the default) to defer to the central value.
+For `org-opa`, the caller input is named `blocking` and maps to `gates.opa.strict`.
+
+## How the file is read (why not `job_workflow_sha`)
+
+Each gate reads `gate-config.yml` from its own `actions/checkout` of
+`Coalfire-CF/Actions` at `inputs.actions_ref` (**default `main`**) — the same
+mechanism as `.terraform-version-band`. `github.job_workflow_sha` is **not** used:
+a 2026-07-02 spike proved it is empty when a reusable workflow is called
+cross-repo (actions/runner#2417).
+
+**Consequence:** because the default ref is `main`, flipping a value here takes
+effect **fleet-wide immediately** — no consumer needs to re-pin. A consumer that
+wants reproducibility can pin `actions_ref` to a release SHA.
+
+## Promoting a gate (advisory → blocking)
+
+1. Open a PR that flips the gate's value to `strict: true` here.
+2. The PR body **must cite the recorded promotion decision** (the ADR-0011
+   warn→required cycle; RFC-0008/RFC-0010).
+3. Merge on protected `main`. The gate is blocking for every caller on the next
+   run. To roll back, flip it to `false` the same way.
+
+Day-one ships **all `false`** (advisory) — no behavior change on adoption.

--- a/gate-config.yml
+++ b/gate-config.yml
@@ -1,0 +1,19 @@
+# Central gate blocking defaults for Coalfire-CF org CI gates (RFC-0010).
+#
+# Each gate reads this file from its own actions/checkout of Coalfire-CF/Actions
+# at `inputs.actions_ref || 'main'` (the .terraform-version-band mechanism — NOT
+# github.job_workflow_sha, which is empty cross-repo). Because the default ref is
+# `main`, flipping a default here takes effect FLEET-WIDE immediately.
+#
+# Resolution precedence for each gate:
+#   caller `strict` input (non-empty 'true'/'false')  >  gates.<key>.strict  >  false
+# A caller leaves `strict` empty ('') to defer to the central default below.
+#
+# PROMOTION (advisory -> blocking) = flip a value here to `true` in a reviewed PR
+# on protected main; that PR body MUST cite the recorded promotion decision
+# (ADR-0011 warn->required mechanism; RFC-0008/RFC-0010).
+gates:
+  source-pin:   { strict: false }
+  uses-pin:     { strict: false }
+  version-band: { strict: false }
+  opa:          { strict: false }  # Tier-2 blocking default only; opa Tier-1 stays advisory (ADR-0003)

--- a/scripts/gate-config-resolve.sh
+++ b/scripts/gate-config-resolve.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# gate-config-resolve.sh — resolve a gate's effective `strict` boolean (RFC-0010).
+#
+# Precedence: caller input ('true'/'false', non-empty) > gates.<key>.strict in
+# the central gate-config.yml > false. Any empty/other caller value defers to
+# the central default. Prints exactly "true" or "false" on stdout.
+#
+# Usage:
+#   gate-config-resolve.sh <gate-key> <caller-strict> [config-path]
+#     <gate-key>       one of: source-pin | uses-pin | version-band | opa
+#     <caller-strict>  the caller's `strict` input verbatim ('' = defer)
+#     [config-path]    defaults to ./gate-config.yml
+#
+# The config is the fixed nested-short-key shape:
+#   gates:
+#     <key>: { strict: <bool> }
+
+set -uo pipefail
+
+KEY="${1:?gate key required}"
+CALLER="${2-}"
+CONFIG="${3:-gate-config.yml}"
+
+# 1) Explicit caller override wins.
+if [ "$CALLER" = "true" ] || [ "$CALLER" = "false" ]; then
+  echo "$CALLER"
+  exit 0
+fi
+
+# 2) Central default for this gate key.
+val=""
+if [ -f "$CONFIG" ]; then
+  # Match the gate's line under gates: and extract its strict boolean.
+  line="$(grep -E "^[[:space:]]+${KEY}:[[:space:]]*\{" "$CONFIG" | head -1 || true)"
+  val="$(printf '%s' "$line" | grep -oE 'strict:[[:space:]]*(true|false)' | grep -oE '(true|false)' || true)"
+fi
+
+# 3) Fall back to false.
+if [ "$val" = "true" ]; then
+  echo "true"
+else
+  echo "false"
+fi

--- a/tests/gate-config-resolve.test.sh
+++ b/tests/gate-config-resolve.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Meta-test for scripts/gate-config-resolve.sh (RFC-0010 precedence:
+# caller > central > false).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+R="${REPO_ROOT}/scripts/gate-config-resolve.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$R" ] || fail "resolver not found at $R"
+[ -x "$R" ] || chmod +x "$R"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+
+# central config: source-pin true, others false
+cat > "$work/gate-config.yml" <<'EOF'
+gates:
+  source-pin:   { strict: true }
+  uses-pin:     { strict: false }
+  version-band: { strict: false }
+  opa:          { strict: false }
+EOF
+
+eq() { # <desc> <got> <want>
+  [ "$2" = "$3" ] || fail "$1: got '$2' want '$3'"
+  echo "OK: $1 -> $2"
+}
+
+# explicit caller override wins over central
+eq "caller=true beats central-false" "$("$R" uses-pin true "$work/gate-config.yml")" "true"
+eq "caller=false beats central-true" "$("$R" source-pin false "$work/gate-config.yml")" "false"
+# empty caller defers to central
+eq "caller='' -> central true"  "$("$R" source-pin '' "$work/gate-config.yml")" "true"
+eq "caller='' -> central false" "$("$R" uses-pin '' "$work/gate-config.yml")" "false"
+# garbage caller defers to central
+eq "caller=garbage -> central true" "$("$R" source-pin 'yes' "$work/gate-config.yml")" "true"
+# missing key -> false
+eq "missing key -> false" "$("$R" nonexistent '' "$work/gate-config.yml")" "false"
+# missing file -> false
+eq "missing file -> false" "$("$R" source-pin '' "$work/does-not-exist.yml")" "false"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Central `gate-config.yml` strict switch (RFC-0010 fleet-scaling standard, ratification pending)

Adds one central control so promoting a gate advisory→blocking is a **single flip on `main`**, not a per-caller edit across the fleet.

### What's added
- **`gate-config.yml`** (repo root) — nested `gates.<key>.strict` for `source-pin` / `uses-pin` / `version-band` / `opa`, **all `false` day-one** (advisory behavior unchanged on adoption).
- **`scripts/gate-config-resolve.sh`** + meta-test — resolves a gate's effective `strict` with precedence **caller input (`''` sentinel = defer) > `gates.<key>.strict` > `false`**.
- Wired into **`org-terraform-source-pin`** (both `source-pin` and `uses-pin` jobs), **`org-terraform-version-band`**, and **`org-opa`**.
- **`docs/GATE_CONFIG.md`** — resolution, read mechanism, promotion procedure.

### Read mechanism (not `job_workflow_sha`)
Each gate reads `gate-config.yml` from its own `actions/checkout` of `Coalfire-CF/Actions` at `inputs.actions_ref` (**default `main`**) — the `.terraform-version-band` pattern. `github.job_workflow_sha` is **not** usable (spike 2026-07-02 proved it empty cross-repo, actions/runner#2417). **Consequence:** flipping a value here on `main` takes effect **fleet-wide immediately**; a caller pins `actions_ref` for reproducibility.

### ⚠️ Interface change (called out per review)
The gates' `strict` input changes **`type: boolean` → `type: string`** (`''` = defer to central, `'true'`/`'false'` = force). This is what lets a gate distinguish "caller set it" from "defer." **Migration:** a caller that forces blocking now passes `strict: 'true'` (string). **Verified: zero existing callers pass `strict`, so nothing breaks today.** For `org-opa`, the same change applies to its `blocking` input, which maps to `gates.opa.strict`; opa Tier-1 stays advisory (ADR-0003) — the central default ships `false`.

### Promotion
Flip a value to `strict: true` in a reviewed PR on protected `main`; the PR body must cite the recorded promotion decision (ADR-0011 warn→required; RFC-0008/RFC-0010).

### Validation
- `actionlint`: clean on the 3 changed workflows.
- All meta-tests pass, incl. the new `gate-config-resolve.test.sh` (precedence: caller > central > false; missing key/file → false). Auto-wired via `test-scripts.yml`'s `tests/*.test.sh`.
- Self-PR: the gates fall back to the target checkout's copy of the new files (config/resolver aren't on `main` until this merges) → resolve `false` (advisory) — green.

`feat:` → release-please computes **0.8.0**. Config name/shape/semantics are byte-identical to RFC-0010's normative appendix (coordinated with compliance-arch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
