### PR TITLE
fix(ci): normalize + bump third-party action pins to latest (pin-latest-at-authoring)

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -103,11 +103,11 @@ jobs:
       dep_label: ${{ steps.decide-eligibility.outputs.dep_label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ github.token }}
 
@@ -421,7 +421,7 @@ jobs:
       applies_to_repo: ${{ steps.checks.outputs.applies_to_repo }}
     steps:
       - name: Checkout default branch (for usage analysis)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.head_branch }}
           fetch-depth: 0

--- a/.github/workflows/org-gitleaks-pr.yml
+++ b/.github/workflows/org-gitleaks-pr.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: ${{ github.head_ref }}

--- a/.github/workflows/org-gitleaks-release.yml
+++ b/.github/workflows/org-gitleaks-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
         report-path: gitleaks_release_results.json
 
     - name: Upload Gitleaks release scan results
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: gitleaks-release-scan-results

--- a/.github/workflows/org-markdown-lint.yml
+++ b/.github/workflows/org-markdown-lint.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 

--- a/.github/workflows/org-opa.yml
+++ b/.github/workflows/org-opa.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           path: target
@@ -79,14 +79,14 @@ jobs:
       - name: Checkout policies
         id: policies
         continue-on-error: true
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.policy_repo }}
           ref: ${{ inputs.policy_ref }}
           path: policies
 
       - name: Checkout Actions repo (central gate-config)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Coalfire-CF/Actions
           ref: ${{ inputs.actions_ref || 'main' }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Download plan JSON (post-plan mode)
         if: steps.guard.outputs.skip == 'false' && inputs.plan_json_artifact != ''
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.plan_json_artifact }}
           path: planjson

--- a/.github/workflows/org-release-clean.yml
+++ b/.github/workflows/org-release-clean.yml
@@ -97,7 +97,7 @@ jobs:
         echo "Input validation passed"
 
     - name: Checkout repository at tag
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ inputs.tag_name }}
 
@@ -270,7 +270,7 @@ jobs:
         gh release upload "${TAG_NAME}" "${ASSETS[@]}" --repo "${GH_REPO}" --clobber
 
     - name: Upload workflow artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: release-clean-archive
         path: |

--- a/.github/workflows/org-terraform-apply.yml
+++ b/.github/workflows/org-terraform-apply.yml
@@ -91,7 +91,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve Terraform version
         id: tf-version
@@ -119,7 +119,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ steps.tf-version.outputs.version }}
           terraform_wrapper: false
@@ -139,7 +139,7 @@ jobs:
       - name: Get GitHub App Token
         id: app-token
         if: steps.check-app-secrets.outputs.has_secrets == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.TF_APPLY_APP_CLIENT_ID }}
           private-key: ${{ secrets.TF_APPLY_APP_PRIVATE_KEY }}
@@ -181,7 +181,7 @@ jobs:
           terraform plan $PLAN_ARGS
 
       - name: Upload plan artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan-apply-${{ github.run_id }}
           path: ${{ inputs.working_directory }}/tfplan

--- a/.github/workflows/org-terraform-docs.yml
+++ b/.github/workflows/org-terraform-docs.yml
@@ -33,7 +33,7 @@ jobs:
     docs:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
             ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: ${{ github.head_ref }}  # Checkout the PR source branch
 
@@ -62,7 +62,7 @@ jobs:
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ steps.tf-version.outputs.version }}
 

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve Terraform version
         id: tf-version
@@ -107,7 +107,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ steps.tf-version.outputs.version }}
 
@@ -126,7 +126,7 @@ jobs:
       - name: Get GitHub App Token
         id: app-token
         if: steps.check-app-secrets.outputs.has_secrets == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.TF_PLAN_APP_CLIENT_ID }}
           private-key: ${{ secrets.TF_PLAN_APP_PRIVATE_KEY }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload plan artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan-${{ github.run_id }}
           path: |

--- a/.github/workflows/org-terraform-source-pin.yml
+++ b/.github/workflows/org-terraform-source-pin.yml
@@ -47,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }} # PR source branch when triggered by pull_request
           path: target
 
       - name: Checkout Actions repo (source-pin check script)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Coalfire-CF/Actions
           ref: ${{ inputs.actions_ref || 'main' }}
@@ -84,13 +84,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }} # PR source branch when triggered by pull_request
           path: target
 
       - name: Checkout Actions repo (uses-pin check script)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Coalfire-CF/Actions
           ref: ${{ inputs.actions_ref || 'main' }}

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Resolve Terraform version
       id: tf-version
@@ -65,7 +65,7 @@ jobs:
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ steps.tf-version.outputs.version }}
 
@@ -84,7 +84,7 @@ jobs:
     - name: Get Checkout Token
       id: checkout-token
       if: steps.check-secrets.outputs.has_secrets == 'true'
-      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ secrets.TF_VALIDATE_APP_CLIENT_ID }}
         private-key: ${{ secrets.TF_VALIDATE_APP_PRIVATE_KEY }}

--- a/.github/workflows/org-terraform-version-band.yml
+++ b/.github/workflows/org-terraform-version-band.yml
@@ -56,13 +56,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }} # PR source branch when triggered by pull_request
           path: target
 
       - name: Checkout Actions repo (band mirror + check script)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Coalfire-CF/Actions
           # Band + script are co-versioned from this checkout. The F36 hermetic

--- a/.github/workflows/org-terraform-version-check.yml
+++ b/.github/workflows/org-terraform-version-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get current version
         id: current

--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -228,7 +228,7 @@ jobs:
           echo "Input validation passed"
 
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Resolve Terraform version
         id: tf-version
@@ -262,7 +262,7 @@ jobs:
           cache-dependency-path: ${{ inputs.working_directory }}/${{ inputs.test_directory }}/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ steps.tf-version.outputs.version }}
           terraform_wrapper: false
@@ -282,7 +282,7 @@ jobs:
       - name: Get GitHub App Token
         id: app-token
         if: steps.check-app-secrets.outputs.has_secrets == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.TERRATEST_APP_CLIENT_ID }}
           private-key: ${{ secrets.TERRATEST_APP_PRIVATE_KEY }}
@@ -316,7 +316,7 @@ jobs:
 
       - name: Configure GCP credentials (OIDC)
         if: inputs.gcp_workload_identity_provider != ''
-        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
           service_account: ${{ inputs.gcp_service_account }}
@@ -361,7 +361,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terratest-results-${{ github.run_id }}
           path: |

--- a/.github/workflows/org-tree-readme.yml
+++ b/.github/workflows/org-tree-readme.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head (downstream repo)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           fetch-depth: 0

--- a/.github/workflows/org-trivy-exception-review.yml
+++ b/.github/workflows/org-trivy-exception-review.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Check for expired exceptions
       id: check_expired

--- a/.github/workflows/org-trivy-pr.yml
+++ b/.github/workflows/org-trivy-pr.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: ${{ github.head_ref }}
@@ -44,7 +44,7 @@ jobs:
 
     - name: Run Trivy scanner
       if: steps.get_changed_files.outputs.has_tf_files == 'true'
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'config'
         scan-ref: '.'
@@ -55,7 +55,7 @@ jobs:
 
     - name: Run Trivy for table output
       if: steps.get_changed_files.outputs.has_tf_files == 'true'
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'config'
         scan-ref: '.'

--- a/.github/workflows/org-trivy-release.yml
+++ b/.github/workflows/org-trivy-release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Run Trivy scanner (JSON)
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'config'
         scan-ref: '.'
@@ -25,7 +25,7 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
     - name: Run Trivy scanner (Table)
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'config'
         scan-ref: '.'
@@ -35,7 +35,7 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
     - name: Generate SBOM (CycloneDX)
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run all script meta-tests
         run: |
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Assert no raw Actions/main fetch and no @main sibling calls
         run: |


### PR DESCRIPTION
## Normalize + bump third-party action pins to latest (pin-latest-at-authoring)

Per Doug's "use good up-to-date versions" directive. Every third-party action is now pinned to its **latest release** as an immutable **SHA + exact `# vX.Y.Z` comment**, with **intra-repo drift eliminated** (one SHA per action org-wide). **Owner merges** (this is a normal PR, not a dependabot auto-merge).

### Drift normalized (was: multiple SHAs / inconsistent comments for the same action)
| Action | Before | After |
|---|---|---|
| `actions/checkout` | 2 SHAs (incl. `9c091bb` mislabeled `# v6` — actually v7.0.0 — and `de0fac2e` v6.0.2) | `9c091bb # v7.0.0` (29 refs) |
| `actions/create-github-app-token` | 3 variants (`1b10c78c`/`bcd2ba49`, `# v3`/`# v3.2.0`) | `bcd2ba49 # v3.2.0` |
| `hashicorp/setup-terraform` | 2 SHAs (`5e8dbf3c`/`dfe3c3f8`) | `dfe3c3f8 # v4.0.1` |
| `aws-actions/configure-aws-credentials` | 4×`v6.2.1` + **1 straggler `@v4`** | `254c19bd # v6.2.1` (5) |
| `trivy-action` / `fetch-metadata` / `upload-artifact` | `# 0.36.0` / `# v3` / `# v7` | `# v0.36.0` / `# v3.1.0` / `# v7.0.1` (exact) |

### Latest bumps — majors breaking-reviewed against our exact usage
| Action | Bump | Where | Verdict |
|---|---|---|---|
| `actions/download-artifact` | v4→**v8.0.1** | org-opa | v5 breaking = download-**by-ID** path; we download **by name** → unaffected. v6–8 = node runtime. ✅ |
| `actions/setup-go` | v5→**v6.5.0** | org-terratest | Node20→24 runtime only. ✅ |
| `azure/login` | v2→**v3.0.0** | org-terratest | Node20→24; OIDC inputs retained. ✅ |
| `google-github-actions/auth` | v2→**v3.0.0** | org-terratest | Node20→24 + legacy params removed; our WIF inputs (`workload_identity_provider`, `service_account`) retained. ✅ |
| `actions/checkout` | v6→**v7.0.0** | repo-wide | plain checkout; no breaking impact. ✅ |

Already-latest (comments made exact): `github-script v9.0.0`, `release-please v5.0.0`, `cosign v4.1.2`, `terraform-docs v1.4.1`, `setup-node v6.4.0`.

> ⚠️ The 4 majors live in `org-opa.yml` / `org-terratest.yml` — **reusable workflows that execute only in consumer context**, so they're verified by release-notes review against our exact inputs (above), not runtime-executed in this repo's CI. Recommend a consumer pilot run of org-terratest after release.

### Validation
`actionlint` clean; `tests/*.test.sh` (4) all pass; every third-party ref is a 40-hex SHA. 21 files, +54/−54.

Rides into the pending **release-please 0.8.0 (#134)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
