### PR TITLE
fix(dependabot): two homogeneous github-actions groups (org vs third-party)

### DIFF
--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -274,16 +274,25 @@ jobs:
               labels:
                 - "${dep_label}"
           YAML
-                # Group github-actions version bumps into ONE PR per cycle
-                # (minor+patch only — majors stay individually-reviewable
-                # singletons; the auto-merge pipeline gates them regardless).
+                # Group github-actions version bumps (minor+patch only —
+                # majors stay individually-reviewable singletons; the pipeline
+                # gates them regardless). TWO homogeneous groups: org callers
+                # score 0 on OpenSSF Scorecard (no data), and the first-party
+                # waiver is all-must-match — a mixed group would chronically
+                # block on low-scorecard. Split groups keep waiver semantics
+                # coherent by construction.
                 # NOTE: keep this block byte-identical to the fleet injector's.
                 if [[ "$ecosystem" == "github-actions" ]]; then
                   cat <<'YAML'
               groups:
-                actions:
+                org-actions:
+                  applies-to: version-updates
+                  patterns: ["Coalfire-CF/*"]
+                  update-types: ["minor", "patch"]
+                third-party:
                   applies-to: version-updates
                   patterns: ["*"]
+                  exclude-patterns: ["Coalfire-CF/*"]
                   update-types: ["minor", "patch"]
           YAML
                 fi


### PR DESCRIPTION
Canary finding (plan #147, P2 sandbox): mixed first+third-party groups block chronically — org refs score 0 on Scorecard and the first-party waiver is (correctly) all-must-match, and mixed groups would be the common case in production since org-caller and third-party bumps share the daily cycle.

Fix: the generator emits two homogeneous groups (`org-actions` = `Coalfire-CF/*`, `third-party` = everything else), each minor+patch-only. Waiver semantics stay coherent by construction; pipeline unchanged; worst case 2 PRs/repo/cycle (baseline was 4–8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)