### PR TITLE
fix(dependabot): github_actions underscore — OSV/Scorecard/release-notes gates were dead for the actions ecosystem

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -350,7 +350,7 @@ jobs:
             # Map Dependabot ecosystems to OSV ecosystems
             OSV_ECOSYSTEM=""
             case "$ECOSYSTEM" in
-              github-actions) OSV_ECOSYSTEM="GitHub Actions" ;;
+              github-actions|github_actions) OSV_ECOSYSTEM="GitHub Actions" ;;
               npm)            OSV_ECOSYSTEM="npm" ;;
               pip)            OSV_ECOSYSTEM="PyPI" ;;
               gomod)          OSV_ECOSYSTEM="Go" ;;
@@ -392,7 +392,7 @@ jobs:
             # Extract the GitHub owner/repo from the dependency name
             SCORECARD_REPO=""
             case "$ECOSYSTEM" in
-              github-actions)
+              github-actions|github_actions)
                 # actions/checkout -> github.com/actions/checkout
                 SCORECARD_REPO="github.com/${DEP_NAME}"
                 ;;
@@ -719,7 +719,7 @@ jobs:
             # Determine the upstream repo for release notes
             UPSTREAM_REPO=""
             case "$ECOSYSTEM" in
-              github-actions)
+              github-actions|github_actions)
                 UPSTREAM_REPO="$DEP_NAME"
                 ;;
               *)


### PR DESCRIPTION
Canary finding (plan #147): dependabot emits `package-ecosystem=github_actions` (underscore) at runtime; three case arms matched only `github-actions` (hyphen) — so for the exact ecosystem this pipeline mostly serves, **OSV and Scorecard silently default-passed** (labels cosmetic) and **release notes were never fetched** (Bedrock analyzed empty input). Runtime-log evidence on sandbox PRs #16/#17/#20.

One-line-per-arm fix mirroring the classify job's dual-form match.

**Expected behavior change once released**: Scorecard genuinely activates for third-party actions — sub-threshold ones will now correctly land in review (`scorecard_threshold` is the tuning knob). OSV activates too but remains range-advisory-blind (#153, backlogged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)