### PR TITLE
feat(terratest): Azure Government support (azure_environment input + ARM_* export)

### DIFF
--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -291,7 +291,7 @@ jobs:
         if: steps.check-app-secrets.outputs.has_secrets == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TERRATEST_APP_CLIENT_ID }}
+          client-id: ${{ secrets.TERRATEST_APP_CLIENT_ID }}
           private-key: ${{ secrets.TERRATEST_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -76,6 +76,11 @@ on:
         required: false
         default: ''
         type: string
+      azure_environment:
+        description: 'Azure cloud environment: azurecloud or azureusgovernment'
+        required: false
+        default: 'azurecloud'
+        type: string
       # GCP OIDC
       gcp_workload_identity_provider:
         description: 'GCP Workload Identity Provider resource name (leave empty to skip GCP auth)'
@@ -175,6 +180,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
           AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
           AZURE_SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id }}
+          AZURE_ENVIRONMENT: ${{ inputs.azure_environment }}
           GCP_WI_PROVIDER: ${{ inputs.gcp_workload_identity_provider }}
           GCP_SA: ${{ inputs.gcp_service_account }}
         run: |
@@ -222,6 +228,7 @@ jobs:
           validate_input "azure_client_id" "$AZURE_CLIENT_ID" '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
           validate_input "azure_tenant_id" "$AZURE_TENANT_ID" '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
           validate_input "azure_subscription_id" "$AZURE_SUBSCRIPTION_ID" '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+          validate_input "azure_environment" "$AZURE_ENVIRONMENT" '^(azurecloud|azureusgovernment)$'
           validate_input "gcp_workload_identity_provider" "$GCP_WI_PROVIDER" '^projects/[0-9]+/locations/[a-z-]+/workloadIdentityPools/[a-zA-Z0-9._-]+/providers/[a-zA-Z0-9._-]+$'
           validate_input "gcp_service_account" "$GCP_SA" '^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.iam\.gserviceaccount\.com$'
 
@@ -313,6 +320,29 @@ jobs:
           client-id: ${{ inputs.azure_client_id }}
           tenant-id: ${{ inputs.azure_tenant_id }}
           subscription-id: ${{ inputs.azure_subscription_id }}
+          environment: ${{ inputs.azure_environment }}
+
+      # The azurerm provider does not read azure/login's CLI session for OIDC auth;
+      # it needs ARM_* env vars. With ARM_USE_OIDC=true the provider auto-detects
+      # GitHub's ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN — no secret material is exported.
+      - name: Export ARM environment for Terraform
+        if: inputs.azure_client_id != ''
+        env:
+          AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
+          AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+          AZURE_SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id }}
+          AZURE_ENVIRONMENT: ${{ inputs.azure_environment }}
+        run: |
+          set -eo pipefail
+          {
+            echo "ARM_USE_OIDC=true"
+            echo "ARM_CLIENT_ID=${AZURE_CLIENT_ID}"
+            echo "ARM_TENANT_ID=${AZURE_TENANT_ID}"
+            echo "ARM_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}"
+          } >> "$GITHUB_ENV"
+          if [ "$AZURE_ENVIRONMENT" = "azureusgovernment" ]; then
+            echo "ARM_ENVIRONMENT=usgovernment" >> "$GITHUB_ENV"
+          fi
 
       - name: Configure GCP credentials (OIDC)
         if: inputs.gcp_workload_identity_provider != ''

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -182,6 +182,11 @@ The Azure and GCP callers use the **same top-level `permissions:` block** (inclu
 ### Azure Government caller
 
 ```yaml
+permissions:
+  contents: read # checkout
+  id-token: write # cloud OIDC
+  pull-requests: write # PR results comment
+
 jobs:
   terratest:
     uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@<sha> # vX.Y.Z
@@ -189,9 +194,12 @@ jobs:
       test_mode: pr
       test_directory: test/azure/src
       azure_environment: azureusgovernment
-      azure_client_id: ${{ secrets.AZURE_TERRATEST_CLIENT_ID }}
-      azure_tenant_id: ${{ secrets.AZURE_TERRATEST_TENANT_ID }}
-      azure_subscription_id: ${{ secrets.AZURE_TERRATEST_SUBSCRIPTION_ID }}
+      # Azure identity UUIDs are identifiers, not secrets — and the `secrets`
+      # context is not permitted in a reusable-workflow `with:` block, so pass
+      # them as inline literals.
+      azure_client_id: 00000000-0000-0000-0000-000000000000 # app registration client ID
+      azure_tenant_id: 00000000-0000-0000-0000-000000000000 # Entra tenant ID
+      azure_subscription_id: 00000000-0000-0000-0000-000000000000 # target subscription
 ```
 
 `azure_environment` defaults to `azurecloud`. For Azure Government the workflow logs in to

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -179,6 +179,25 @@ The Azure and GCP callers use the **same top-level `permissions:` block** (inclu
       # SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
+### Azure Government caller
+
+```yaml
+jobs:
+  terratest:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@<sha> # vX.Y.Z
+    with:
+      test_mode: pr
+      test_directory: test/azure/src
+      azure_environment: azureusgovernment
+      azure_client_id: ${{ secrets.AZURE_TERRATEST_CLIENT_ID }}
+      azure_tenant_id: ${{ secrets.AZURE_TERRATEST_TENANT_ID }}
+      azure_subscription_id: ${{ secrets.AZURE_TERRATEST_SUBSCRIPTION_ID }}
+```
+
+`azure_environment` defaults to `azurecloud`. For Azure Government the workflow logs in to
+the Gov cloud and exports `ARM_ENVIRONMENT=usgovernment` (plus `ARM_USE_OIDC` and the three
+IDs) so the azurerm provider authenticates via the same GitHub OIDC token.
+
 ### Release Gate
 
 ```yaml
@@ -308,6 +327,7 @@ secrets are stored in GitHub.
 | `azure_client_id` | No | | Azure App Registration client ID |
 | `azure_tenant_id` | No | | Azure AD tenant ID |
 | `azure_subscription_id` | No | | Azure subscription ID |
+| `azure_environment` | No | `azurecloud` | Azure cloud environment: `azurecloud` or `azureusgovernment` |
 | `gcp_workload_identity_provider` | No | | GCP Workload Identity Provider |
 | `gcp_service_account` | No | | GCP service account email |
 | `slack_channel_id` | No | | Slack channel for failure notifications |


### PR DESCRIPTION
Adds azure_environment (azurecloud|azureusgovernment, validated) wired to azure/login, and exports ARM_USE_OIDC/ARM_CLIENT_ID/ARM_TENANT_ID/ARM_SUBSCRIPTION_ID(+ARM_ENVIRONMENT for Gov) when Azure auth is active. Empty Azure inputs = byte-identical behavior. Canary: cs-terratest-poc Azure pilot pins this branch SHA pre-release (OQ4 pattern). Design: MTCS .superpowers/sdd/azure-terratest/DESIGN.md