### PR TITLE
fix(security): pin gitleaks composite refs and widen N2 guard to composite paths

### DIFF
--- a/.github/workflows/org-gitleaks-pr.yml
+++ b/.github/workflows/org-gitleaks-pr.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Run gitleaks scan
       id: gitleaks
-      uses: Coalfire-CF/Actions/actions/gitleaks@main
+      uses: Coalfire-CF/Actions/actions/gitleaks@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
       with:
         scan-mode: pr
         base-ref: ${{ github.base_ref }}

--- a/.github/workflows/org-gitleaks-release.yml
+++ b/.github/workflows/org-gitleaks-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Run gitleaks scan
       id: gitleaks
-      uses: Coalfire-CF/Actions/actions/gitleaks@main
+      uses: Coalfire-CF/Actions/actions/gitleaks@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
       with:
         scan-mode: full
         report-path: gitleaks_release_results.json

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -68,6 +68,12 @@ jobs:
             echo "::error::N2 regression — an internal sibling call uses @main (use uses: ./.github/workflows/<x>.yml)."
             rc=1
           fi
+          # N2 (composite path): no ACTIVE internal composite-action ref may use @main.
+          # Reusable workflows check out the CONSUMER repo, so ./ refs don't resolve here — pin @<sha> # vX.Y.Z.
+          if grep -rnE '^[[:space:]]*uses: Coalfire-CF/Actions/actions/[^@]+@main' .github/workflows/; then
+            echo "::error::N2 regression — an internal composite action ref uses @main (pin to @<release-sha> # vX.Y.Z)."
+            rc=1
+          fi
           if [ "$rc" -eq 0 ]; then
             echo "OK: no Actions/main raw fetches and no active @main sibling refs."
           fi


### PR DESCRIPTION
## Summary
- Pins the only two active floating refs in the tree — `org-gitleaks-pr.yml:39` and `org-gitleaks-release.yml:28` (`actions/gitleaks@main`) — to the v0.10.0 release SHA with a `# v0.10.0` comment. A local `./actions/gitleaks` ref was rejected because these reusable workflows check out the **consumer** repo, so `./` would not resolve.
- Widens the `test-scripts.yml` N2 guard with a composite-path regex: the existing pattern requires the `/.github/workflows/…yml@main` shape and was structurally blind to `actions/*@main` — which is exactly how these two slipped through.

## Acceptance criteria (item #2, MTCS grade-A plan)
1. ✅ No `Coalfire-CF/Actions/actions/gitleaks@main` remains; both refs are 40-hex SHA + `# vX.Y.Z`.
2. ✅ Tree-wide grep for internal `@main` (workflow + composite paths) returns zero active lines.
3. ✅ N2 step now exits non-zero on any `uses: Coalfire-CF/Actions/actions/*@main`.

## Testing
- Expected-PASS: widened guard clean on this tree ✅ (run locally)
- Expected-FAIL: planted `uses: Coalfire-CF/Actions/actions/gitleaks@main` trips the new regex ✅ (run locally, then removed)
- `tests/*.test.sh` all pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S