### PR TITLE
fix(security): verify gitleaks and OPA downloads with pinned SHA-256 digests

### DIFF
--- a/.github/workflows/org-opa.yml
+++ b/.github/workflows/org-opa.yml
@@ -115,8 +115,18 @@ jobs:
           OPA_VERSION: ${{ inputs.opa_version }}
         run: |
           set -eo pipefail
+          # SI-7 integrity: version-keyed SHA-256 map (official opa_linux_amd64_static.sha256 values).
+          # A version without a pinned digest fails CLOSED — add the digest here before bumping.
+          case "${OPA_VERSION}" in
+            0.69.0) OPA_SHA256="c81aa9c1da779d0a8646c837a96d52e1a7040ff562318d9743b8ef51c93b49d6" ;;
+            *)
+              echo "::error::no pinned checksum for OPA version ${OPA_VERSION} — refusing unverified download (add it to the digest map)."
+              exit 1
+              ;;
+          esac
           curl -fsSL --retry 3 -o /usr/local/bin/opa \
             "https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_amd64_static"
+          echo "${OPA_SHA256}  /usr/local/bin/opa" | sha256sum -c -
           chmod +x /usr/local/bin/opa
           opa version
 

--- a/actions/gitleaks/action.yml
+++ b/actions/gitleaks/action.yml
@@ -46,8 +46,21 @@ runs:
         GITLEAKS_VERSION: ${{ inputs.version }}
       run: |
         set -eo pipefail
-        curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-          | tar -xz -C /usr/local/bin gitleaks
+        # SI-7 integrity: version-keyed SHA-256 map (official gitleaks_<v>_checksums.txt values).
+        # A version without a pinned digest fails CLOSED — add the digest here before bumping.
+        case "${GITLEAKS_VERSION}" in
+          8.30.0) GITLEAKS_SHA256="79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e" ;;
+          *)
+            echo "::error::no pinned checksum for gitleaks version ${GITLEAKS_VERSION} — refusing unverified download (add it to the digest map)."
+            exit 1
+            ;;
+        esac
+        TARBALL="$(mktemp -d)/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        curl -sSfL -o "${TARBALL}" \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum -c -
+        tar -xzf "${TARBALL}" -C /usr/local/bin gitleaks
+        rm -f "${TARBALL}"
         echo "Installed gitleaks $(gitleaks version)"
 
     - name: Run gitleaks scan


### PR DESCRIPTION
## Summary
- `actions/gitleaks/action.yml`: download to a temp file, verify `sha256sum -c` against a **version-keyed digest map**, abort before `tar -xz` on mismatch; unknown version → explicit fail-closed error (both installs take caller-overridable version inputs, so a single hardcoded digest would be insufficient).
- `org-opa.yml`: same pattern before `chmod +x`.
- Digests resolved live from the official upstream release checksum files at authoring time (gitleaks `gitleaks_8.30.0_checksums.txt`, OPA `opa_linux_amd64_static.sha256`) — re-verifiable by re-downloading and re-hashing those releases.

## Acceptance criteria (item #3, MTCS grade-A plan)
1–4 all implemented as specified (file-download + verify-before-extract, verify-before-chmod, fail-closed unknown version, published-digest provenance).

## Testing (run locally against the live artifacts)
- ✅ Expected-PASS: correct artifact + pinned digest verifies
- ✅ Expected-FAIL: one corrupted byte → `sha256sum -c` exits 1, install aborts
- ✅ Expected-FAIL: unmapped version (9.99.9) → explicit 'no pinned checksum' error
- ✅ OPA live artifact matches the pinned digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S