### PR TITLE
chore(ci): lint own workflows with actionlint in test-scripts.yml

### DIFF
--- a/.github/workflows/org-markdown-lint.yml
+++ b/.github/workflows/org-markdown-lint.yml
@@ -82,7 +82,8 @@ jobs:
       shell: bash
       run: |
         set -o pipefail
-        npx --yes markdownlint-cli2@0.21.0 $(cat /tmp/md_files.txt | tr '\n' ' ') 2>&1 | tee .github/md_lint_output.txt
+        mapfile -t md_files < /tmp/md_files.txt
+        npx --yes markdownlint-cli2@0.21.0 "${md_files[@]}" 2>&1 | tee .github/md_lint_output.txt
 
     - name: Create Fail Comment
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -47,6 +47,32 @@ jobs:
           done
           exit "$rc"
 
+  actionlint:
+    name: Lint workflows (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install actionlint (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          ACTIONLINT_VERSION=1.7.12
+          ACTIONLINT_SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+          curl -sSfL -o /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/actionlint.tar.gz -C /usr/local/bin actionlint
+          actionlint --version
+
+      - name: Run actionlint over all workflows
+        env:
+          # Gate at shellcheck warning+ severity. The style/info nits in the large
+          # inline heredocs are deferred to the scripts/*.sh extraction (grade-A plan
+          # item #10), which runs full shellcheck over the extracted files.
+          SHELLCHECK_OPTS: -S warning
+        run: actionlint -color
+
   no-main-refs:
     name: Guard — no mutable main refs (F36/N2 regression)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- New `actionlint` job in `test-scripts.yml` (fires on the existing `.github/workflows/**` path filter): pinned **v1.7.12** with a checksum-verified install (same SI-7 pattern as the binary-download hardening in #159), gated at shellcheck **warning+** severity.
- Triage result: the tree had **zero native actionlint findings**; all 72 findings were shellcheck-sourced (61 info / 10 style / 1 warning). The one real warning — unquoted `$(cat …)` expansion in `org-markdown-lint.yml` (SC2046) — is fixed here with `mapfile` + quoted array. Style/info nits live in the auto-merge heredocs and are deferred to plan item #10's script extraction, which runs full shellcheck on the extracted files.
- zizmor: deliberately not added in this PR (optional/advisory per the AC) — can follow once the gate has soak time.

## Acceptance criteria (item #8, MTCS grade-A plan)
1. ✅ actionlint runs over `.github/workflows/*.yml`, non-zero on findings
2. ✅ triggers on the existing path filter
3. ✅ version-pinned + checksum-verified
4. ✅ zizmor optional (deferred, documented)

## Testing
- ✅ Expected-PASS: gate exits 0 on this tree (run locally with identical SHELLCHECK_OPTS)
- ✅ Expected-FAIL: planted workflow with `github.nonexistent_context` → exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S