### PR TITLE
fix(docs): SHA-pin all 25 caller examples and guard docs against @main

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -100,6 +100,12 @@ jobs:
             echo "::error::N2 regression — an internal composite action ref uses @main (pin to @<release-sha> # vX.Y.Z)."
             rc=1
           fi
+          # Docs guard: no caller EXAMPLE in README/docs may show @main (org-agnostic — placeholder
+          # orgs like <YOUR_ORG> count too). New-adopter onboarding copies these lines verbatim.
+          if grep -rnE 'uses:.*[^ ]*/Actions/\.github/workflows/[^@]+@main' README.md docs/; then
+            echo "::error::docs regression — a caller example uses @main (write @<release-sha> # vX.Y.Z; RFC-0008)."
+            rc=1
+          fi
           if [ "$rc" -eq 0 ]; then
             echo "OK: no Actions/main raw fetches and no active @main sibling refs."
           fi

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Called on merge to main.
 
 ## Usage
 
+> **Pin by release SHA (RFC-0008).** Always reference these workflows as
+> `@<40-hex-release-sha> # vX.Y.Z` — never `@main` or a bare tag (a moving ref is a
+> supply-chain hole; the SHA makes the reference immutable and auditable). Resolve the
+> SHA from the latest release tag at adoption time
+> (`gh api repos/Coalfire-CF/Actions/git/refs/tags/<tag>`), and bump it deliberately when
+> adopting a new release. All examples below follow this form.
+
 ### Basic Setup
 
 Downstream repos call these workflows via `workflow_call`. Example `.github/workflows/` setup:
@@ -84,7 +91,7 @@ permissions:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
     with:
       slack_channel_id: 'C0123456789'
@@ -98,7 +105,7 @@ Access to private Terraform module repositories is controlled using a GitHub App
 # Private repo — pass app credentials for module access
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
     secrets:
@@ -108,7 +115,7 @@ jobs:
 # Public repo — no app credentials needed
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
 ```
@@ -128,7 +135,7 @@ Wrapper around [terraform-docs GitHub Actions](https://github.com/terraform-docs
 # Root module and submodules
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       recursive: true
 ```

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -154,7 +154,7 @@ Run the label sync workflow on each repo before enabling auto-merge:
 ```yaml
 jobs:
   sync-labels:
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@main
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
 ```
 
@@ -173,7 +173,7 @@ on:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@main
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
 ```
 

--- a/docs/ORG_JIRA_SYNC_SETUP.md
+++ b/docs/ORG_JIRA_SYNC_SETUP.md
@@ -206,7 +206,7 @@ on:
 
 jobs:
   sync_to_jira:
-    uses: Coalfire-CF/Actions/.github/workflows/org-jira-sync.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-jira-sync.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       issue_title: ${{ github.event.issue.title }}
       issue_body: ${{ github.event.issue.body }}
@@ -234,7 +234,7 @@ on:
 
 jobs:
   sync_to_jira:
-    uses: Coalfire-CF/Actions/.github/workflows/org-jira-sync.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-jira-sync.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       issue_title: ${{ github.event.issue.title }}
       issue_body: ${{ github.event.issue.body }}

--- a/docs/ORG_JIRA_SYNC_SETUP.md
+++ b/docs/ORG_JIRA_SYNC_SETUP.md
@@ -20,14 +20,15 @@ The workflow supports two authentication methods. Choose the one that matches yo
 Navigate to your repository Settings → Secrets and variables → Actions → Secrets
 
 #### `JIRA_API_TOKEN` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: Your Jira Cloud API token for authentication
 - **How to get it**:
   1. Log into your Jira account
-  2. Go to https://id.atlassian.com/manage-profile/security/api-tokens
-  3. Click "Create API token"
-  4. Give it a name (e.g., "GitHub Actions")
-  5. Copy the token and save it as a secret
+  1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+  1. Click "Create API token"
+  1. Give it a name (e.g., "GitHub Actions")
+  1. Copy the token and save it as a secret
 - **Note**: API tokens created before December 15, 2024 will expire between March 14 and May 12, 2026
 
 You will also need to set the `JIRA_USER_EMAIL` secret (see below).
@@ -37,15 +38,16 @@ You will also need to set the `JIRA_USER_EMAIL` secret (see below).
 Navigate to your repository Settings → Secrets and variables → Actions → Secrets
 
 #### `JIRA_PAT` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: Your Personal Access Token for Jira Data Center/Server
 - **How to get it**:
   1. Log into your Jira instance
-  2. Click your avatar at the top right and select "Profile"
-  3. Select "Personal access tokens" in the left-hand menu
-  4. Click "Create token"
-  5. Give it a name (e.g., "GitHub Actions") and set expiration as needed
-  6. Copy the token and save it as a secret
+  1. Click your avatar at the top right and select "Profile"
+  1. Select "Personal access tokens" in the left-hand menu
+  1. Click "Create token"
+  1. Give it a name (e.g., "GitHub Actions") and set expiration as needed
+  1. Copy the token and save it as a secret
 - **Note**: PATs are only available for Jira Data Center/Server (v8.14+), not Jira Cloud
 - **Authentication**: Uses Bearer token authentication (no email required)
 
@@ -56,6 +58,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 Navigate to your repository Settings → Secrets and variables → Actions → Secrets
 
 ### 1. `JIRA_BASE_URL` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: Your Jira instance URL
 - **Example Cloud**: `https://yourcompany.atlassian.net`
@@ -64,6 +67,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 - **Required for**: Both authentication methods
 
 ### 2. `JIRA_USER_EMAIL` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: The email address associated with your Jira API token
 - **Example**: `your.email@company.com`
@@ -71,6 +75,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 - **Not needed for**: Jira Data Center/Server (PAT authentication)
 
 ### 3. `JIRA_PROJECT_KEY` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: The project key where issues will be created
 - **Example**: `PROJ` or `DEV`
@@ -78,6 +83,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 - **Required for**: Both authentication methods
 
 ### 4. `JIRA_ISSUE_TYPE_ID` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: The numeric ID of the issue type you want to create
 - **Common values**:
@@ -86,6 +92,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
   - `10003` - Bug
   - `10004` - Epic
 - **How to find it**:
+
   ```bash
   # Use this curl command to list available issue types:
   curl --request GET \
@@ -93,9 +100,11 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
     --header 'Authorization: Basic YOUR_BASE64_ENCODED_CREDENTIALS' \
     --header 'Accept: application/json' | jq '.projects[].issuetypes[] | {id, name}'
   ```
+
 - **Required for**: Both authentication methods
 
 ### 5. `JIRA_LABEL` (Secret)
+
 - **Type**: Repository Secret
 - **Description**: Label to add to all synced Jira issues
 - **Example**: `github-sync`, `automated`, or `from-github`
@@ -103,6 +112,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 - **Required for**: Both authentication methods
 
 ### 6. `JIRA_API_VERSION` (Secret) - Optional
+
 - **Type**: Repository Secret
 - **Description**: Jira REST API version to use
 - **Default**: `3` (used if not specified)
@@ -113,50 +123,57 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 ## Workflow Behavior
 
 When a GitHub issue is opened:
+
 1. The workflow creates a corresponding Jira issue
-2. The Jira issue includes:
+1. The Jira issue includes:
    - Same title as the GitHub issue
    - Same description as the GitHub issue body
    - Link back to the original GitHub issue
    - The specified label
-3. The Jira issue key and URL are logged in the workflow output (visible only to those with repository access)
+1. The Jira issue key and URL are logged in the workflow output (visible only to those with repository access)
 
 ## Testing the Setup
 
 1. Create a test GitHub issue in your repository
-2. Check the Actions tab to see if the workflow runs successfully
-3. Verify the Jira issue was created in your project
-4. Confirm the GitHub issue has a comment with the Jira link
+1. Check the Actions tab to see if the workflow runs successfully
+1. Verify the Jira issue was created in your project
+1. Confirm the GitHub issue has a comment with the Jira link
 
 ## Troubleshooting
 
 ### Authentication Failed (401)
 
 **For Jira Cloud (API Token):**
+
 - Verify `JIRA_API_TOKEN` is correct and hasn't been regenerated
 - Ensure `JIRA_USER_EMAIL` matches the account that created the API token
 - Check that the API token hasn't expired (tokens created before Dec 15, 2024 expire in 2026)
 - Verify Basic Authentication is enabled in your Jira Cloud instance
 
 **For Jira Data Center/Server (PAT):**
+
 - Verify `JIRA_PAT` is correct and hasn't been regenerated
 - Check that the PAT hasn't expired (check expiration date when you created it)
 - Ensure you have Bearer token authentication enabled
 - Verify your Jira version supports PATs (v8.14+ for Jira, v4.15+ for JSM, v7.9+ for Confluence)
 
 ### Project Not Found (404)
+
 - Verify `JIRA_PROJECT_KEY` is correct
 - Ensure your Jira user has permission to create issues in that project
 
 ### Invalid Issue Type
+
 - Use the createmeta API endpoint (shown above) to find valid issue type IDs
 - Ensure the issue type is available in your project
 
 ### Permission Denied
+
 - Verify your Jira user has "Create Issues" permission in the project
 - Check if the project settings allow the specified issue type
 
 ### API Version Issues
+
 - If you get 404 errors on the `/rest/api/3/issue` endpoint, try setting `JIRA_API_VERSION` to `2`
 - Older Jira Data Center/Server instances may only support API v2
 
@@ -167,6 +184,7 @@ All configuration values are **Repository Secrets** (Settings → Secrets and va
 ### For Jira Cloud
 
 **Required Secrets:**
+
 - `JIRA_API_TOKEN` - Your API token from id.atlassian.com
 - `JIRA_BASE_URL` - Your Atlassian URL (e.g., `https://yourcompany.atlassian.net`)
 - `JIRA_USER_EMAIL` - Email associated with the API token
@@ -175,11 +193,13 @@ All configuration values are **Repository Secrets** (Settings → Secrets and va
 - `JIRA_LABEL` - Label for synced issues (e.g., `github-sync`)
 
 **Optional Secrets:**
+
 - `JIRA_API_VERSION` - Set to `2` if needed, defaults to `3`
 
 ### For Jira Data Center/Server
 
 **Required Secrets:**
+
 - `JIRA_PAT` - Your Personal Access Token from Jira profile
 - `JIRA_BASE_URL` - Your Jira instance URL (e.g., `https://jira.yourcompany.com`)
 - `JIRA_PROJECT_KEY` - Project key (e.g., `PROJ`)
@@ -187,6 +207,7 @@ All configuration values are **Repository Secrets** (Settings → Secrets and va
 - `JIRA_LABEL` - Label for synced issues (e.g., `github-sync`)
 
 **Optional Secrets:**
+
 - `JIRA_API_VERSION` - Set to `2` for older instances, defaults to `3`
 
 **Note:** `JIRA_USER_EMAIL` is NOT needed for PAT authentication
@@ -252,6 +273,7 @@ jobs:
 ```
 
 **Important Notes:**
+
 - All secrets must be passed explicitly when calling the reusable workflow
 - You can use **organization secrets** or **repository secrets** - both work identically
 - Even if a secret is not needed for your authentication method (e.g., `JIRA_USER_EMAIL` for PAT auth), you still need to include it in the secrets list (it will simply be ignored)

--- a/docs/ORG_LABEL_TAXONOMY.md
+++ b/docs/ORG_LABEL_TAXONOMY.md
@@ -131,7 +131,7 @@ org:Coalfire-CF is:pr is:open label:dep/github-actions author:app/dependabot
 ```yaml
 jobs:
   sync-labels:
-    uses: Coalfire-CF/Actions/.github/workflows/org-label-sync.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-label-sync.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
 ```
 
@@ -145,7 +145,7 @@ on:
 
 jobs:
   sync-labels:
-    uses: Coalfire-CF/Actions/.github/workflows/org-label-sync.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-label-sync.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
 ```
 

--- a/docs/ORG_LABEL_TAXONOMY.md
+++ b/docs/ORG_LABEL_TAXONOMY.md
@@ -104,7 +104,7 @@ simultaneously on a single PR.
 
 **GitHub search queries for common views:**
 
-```
+```text
 # All blocked Dependabot PRs across the org
 org:Coalfire-CF is:pr is:open label:merge/blocked author:app/dependabot
 

--- a/docs/ORG_RELEASE_CLEAN.md
+++ b/docs/ORG_RELEASE_CLEAN.md
@@ -90,7 +90,7 @@ permissions:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
 ```
 
@@ -108,7 +108,7 @@ Add or change which directories and files are removed:
 ```yaml
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
     with:
       clean_exclude_dirs: '.github,docs,.claude,.ci,tests'
@@ -124,7 +124,7 @@ If you do not want a cleaned tarball attached to your releases:
 ```yaml
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
     with:
       clean_release: false

--- a/docs/ORG_SLACK_NOTIFY.md
+++ b/docs/ORG_SLACK_NOTIFY.md
@@ -31,7 +31,7 @@ Add `slack_channel_id` to any workflow call. The release workflow requires `secr
 # Release workflow — gets both release and failure notifications
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
     with:
       slack_channel_id: 'CXXXXXXXXX'
@@ -41,7 +41,7 @@ jobs:
 # PR workflows — get failure notifications
 jobs:
   trivy-scan:
-    uses: Coalfire-CF/Actions/.github/workflows/org-trivy-pr.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-trivy-pr.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       slack_channel_id: 'CXXXXXXXXX'
 ```
@@ -79,7 +79,7 @@ on:
 
 jobs:
   check:
-    uses: Coalfire-CF/Actions/.github/workflows/org-slack-notify.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-slack-notify.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
     with:
       notification-type: health-check
@@ -95,7 +95,7 @@ The `org-slack-notify.yml` workflow can also be called directly for custom notif
 ```yaml
 jobs:
   notify:
-    uses: Coalfire-CF/Actions/.github/workflows/org-slack-notify.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-slack-notify.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     secrets: inherit
     with:
       notification-type: release    # release, failure, or health-check

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -115,13 +115,13 @@ permissions:
 
 jobs:
   fmt:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
 
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
 
   plan:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-plan.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-plan.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       aws_role_arn: arn:aws:iam::123456789012:role/terratest-ci
       aws_region: us-east-1
@@ -129,7 +129,7 @@ jobs:
 
   terratest:
     needs: [fmt, validate, plan]
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       test_mode: pr
       aws_role_arn: arn:aws:iam::123456789012:role/terratest-ci
@@ -149,7 +149,7 @@ The Azure and GCP callers use the **same top-level `permissions:` block** (inclu
 ```yaml
   terratest:
     needs: [fmt, validate, plan]
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       test_mode: pr
       azure_client_id: 00000000-0000-0000-0000-000000000000
@@ -167,7 +167,7 @@ The Azure and GCP callers use the **same top-level `permissions:` block** (inclu
 ```yaml
   terratest:
     needs: [fmt, validate, plan]
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       test_mode: pr
       gcp_workload_identity_provider: projects/123456/locations/global/workloadIdentityPools/ci-pool/providers/github
@@ -217,7 +217,7 @@ on:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       test_mode: release
       aws_role_arn: arn:aws:iam::123456789012:role/terratest-ci
@@ -225,7 +225,7 @@ jobs:
 
   release-clean:
     needs: terratest
-    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@main
+    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
     with:
       tag_name: ${{ github.event.release.tag_name }}
 ```


### PR DESCRIPTION
## Summary
- Rewrites all **25** caller `uses:…@main` example lines (README ×4, ORG_TERRATEST ×8, ORG_DEPENDABOT_AUTO_MERGE ×2, ORG_JIRA_SYNC_SETUP ×2, ORG_LABEL_TAXONOMY ×2, ORG_RELEASE_CLEAN ×3, ORG_SLACK_NOTIFY ×4) to `@<v0.10.0-sha> # v0.10.0`, including the two `<YOUR_ORG>` placeholder examples.
- Leaves the two **intentional** non-caller `@main` mentions unchanged (`ORG_SOURCE_PIN.md:22` FAIL-table row, `ORG_JIRA_SYNC_SETUP.md:258` prose).
- Adds an RFC-0008 onboarding note to README (pin by release SHA, how to resolve it).
- Extends the `no-main-refs` guard with a **docs-scoped, org-agnostic** grep so placeholder-org examples can't hide a regression.

## Acceptance criteria (item #1, MTCS grade-A plan)
1. ✅ all 25 caller lines rewritten to `@<40-hex> # vX.Y.Z`
2. ✅ org-agnostic grep over README+docs returns 0
3. ✅ 2 non-caller mentions unchanged
4. ✅ onboarding SHA-pin note added

## Testing
- ✅ Expected-PASS: docs guard clean on this tree
- ✅ Expected-FAIL: planted `@main` caller example trips the guard (verified locally, then removed)
- ✅ actionlint clean (`SHELLCHECK_OPTS="-S warning"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S