### PR TITLE
fix(gates): parse block-style gate-config and fail closed on unparseable strict

### DIFF
--- a/scripts/gate-config-resolve.sh
+++ b/scripts/gate-config-resolve.sh
@@ -6,15 +6,25 @@
 # the central gate-config.yml > false. Any empty/other caller value defers to
 # the central default. Prints exactly "true" or "false" on stdout.
 #
+# FAIL-CLOSED CONTRACT (grade-A plan item #5): if the gate key is PRESENT in the
+# config but its `strict` value cannot be parsed as true/false — e.g. a
+# block-style reformat, a typo'd value, or a missing strict field — the resolver
+# exits non-zero instead of silently printing "false". A silent false would
+# downgrade a strict gate to advisory fleet-wide (this file is read at @main by
+# every gate caller). An ABSENT key still resolves to "false" (documented default).
+#
 # Usage:
 #   gate-config-resolve.sh <gate-key> <caller-strict> [config-path]
 #     <gate-key>       one of: source-pin | uses-pin | version-band | opa
 #     <caller-strict>  the caller's `strict` input verbatim ('' = defer)
 #     [config-path]    defaults to ./gate-config.yml
 #
-# The config is the fixed nested-short-key shape:
+# Accepted config shapes for the central default:
 #   gates:
-#     <key>: { strict: <bool> }
+#     <key>: { strict: <bool> }        # inline-flow (canonical)
+#   gates:
+#     <key>:
+#       strict: <bool>                 # block-style (parsed since item #5)
 
 set -uo pipefail
 
@@ -28,17 +38,43 @@ if [ "$CALLER" = "true" ] || [ "$CALLER" = "false" ]; then
   exit 0
 fi
 
-# 2) Central default for this gate key.
+# 2) Central default for this gate key (inline-flow or block-style).
 val=""
+key_present=0
 if [ -f "$CONFIG" ]; then
-  # Match the gate's line under gates: and extract its strict boolean.
-  line="$(grep -E "^[[:space:]]+${KEY}:[[:space:]]*\{" "$CONFIG" | head -1 || true)"
-  val="$(printf '%s' "$line" | grep -oE 'strict:[[:space:]]*(true|false)' | grep -oE '(true|false)' || true)"
+  key_ln="$(grep -nE "^[[:space:]]+${KEY}:([[:space:]{]|$)" "$CONFIG" | head -1 | cut -d: -f1 || true)"
+  if [ -n "$key_ln" ]; then
+    key_present=1
+    key_line="$(sed -n "${key_ln}p" "$CONFIG")"
+    if printf '%s\n' "$key_line" | grep -q '{'; then
+      # inline-flow: <key>: { strict: bool, ... }
+      val="$(printf '%s\n' "$key_line" | grep -oE 'strict:[[:space:]]*(true|false)' | grep -oE '(true|false)' | head -1 || true)"
+    else
+      # block-style: strict: bool on a more-indented child line, ending at the
+      # first non-blank/non-comment line indented at or above the key's level.
+      key_indent="$(printf '%s' "$key_line" | sed -E 's/^([[:space:]]*).*/\1/' | awk '{ print length($0) }')"
+      [ -n "$key_indent" ] || key_indent=0
+      val="$(awk -v start="$key_ln" -v ki="$key_indent" '
+        NR <= start { next }
+        /^[[:space:]]*$/ { next }
+        /^[[:space:]]*#/ { next }
+        {
+          match($0, /^[[:space:]]*/)
+          if (RLENGTH <= ki) exit
+          if ($0 ~ /^[[:space:]]*strict:[[:space:]]*true([[:space:]]|#|$)/)  { print "true";  exit }
+          if ($0 ~ /^[[:space:]]*strict:[[:space:]]*false([[:space:]]|#|$)/) { print "false"; exit }
+        }' "$CONFIG" || true)"
+    fi
+  fi
 fi
 
-# 3) Fall back to false.
-if [ "$val" = "true" ]; then
-  echo "true"
+# 3) Emit, failing CLOSED on a present-but-unparseable key.
+if [ "$val" = "true" ] || [ "$val" = "false" ]; then
+  echo "$val"
+elif [ "$key_present" -eq 1 ]; then
+  echo "::error::gate-config-resolve: gate '${KEY}' is present in ${CONFIG} but its 'strict' value could not be parsed as true/false — failing closed rather than silently downgrading to advisory. Fix the config (inline '{ strict: true|false }' or block-style 'strict: true|false')." >&2
+  exit 2
 else
+  # Absent key (or absent config file) → documented default.
   echo "false"
 fi

--- a/tests/gate-config-resolve.test.sh
+++ b/tests/gate-config-resolve.test.sh
@@ -42,4 +42,42 @@ eq "missing key -> false" "$("$R" nonexistent '' "$work/gate-config.yml")" "fals
 # missing file -> false
 eq "missing file -> false" "$("$R" source-pin '' "$work/does-not-exist.yml")" "false"
 
+# --- item #5: block-style parsing + fail-closed on unparseable (grade-A plan) ---
+
+# block-style config: a valid-YAML reformat must resolve correctly, not silently false
+cat > "$work/gate-config-block.yml" <<'EOF'
+gates:
+  source-pin:
+    strict: true
+  uses-pin:
+    strict: false
+  opa:
+    # comment inside the block is fine
+    strict: false
+EOF
+eq "block-style strict:true -> true"   "$("$R" source-pin '' "$work/gate-config-block.yml")" "true"
+eq "block-style strict:false -> false" "$("$R" uses-pin '' "$work/gate-config-block.yml")" "false"
+eq "block-style with comment -> false" "$("$R" opa '' "$work/gate-config-block.yml")" "false"
+eq "block-style missing key -> false"  "$("$R" version-band '' "$work/gate-config-block.yml")" "false"
+
+# present-but-unparseable key -> non-zero exit (fail closed), never "false"
+cat > "$work/gate-config-broken.yml" <<'EOF'
+gates:
+  source-pin:
+    enabled: yes
+  uses-pin: { strict: maybe }
+EOF
+if out="$("$R" source-pin '' "$work/gate-config-broken.yml" 2>/dev/null)"; then
+  fail "present key without parseable strict must exit non-zero (got '$out')"
+else
+  echo "OK: present key without strict -> fail-closed (non-zero exit)"
+fi
+if out="$("$R" uses-pin '' "$work/gate-config-broken.yml" 2>/dev/null)"; then
+  fail "present key with garbage strict must exit non-zero (got '$out')"
+else
+  echo "OK: present key with garbage strict -> fail-closed (non-zero exit)"
+fi
+# caller override still bypasses a broken config (precedence preserved)
+eq "caller=true bypasses broken config" "$("$R" source-pin true "$work/gate-config-broken.yml")" "true"
+
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- `scripts/gate-config-resolve.sh` now parses both inline-flow and block-style `strict:` values; a key that is **present but unparseable** exits non-zero (fail-closed) instead of silently printing `false` (which downgraded a strict gate to advisory — and this file is fetched at `@main` by every gate caller, so a reformat would have been a fleet-wide silent downgrade).
- Absent key / absent config still default to `false`; `caller > central > false` precedence unchanged.
- **Fleet-safety proof:** resolution of the live `gate-config.yml` is identical before/after (all four gates `false`) — merging this changes nothing until a config is malformed, at which point it fails loud instead of open.
- Stays pure grep/awk/sed — no yq dependency added (yq is NOT vendored to this script; it's only installed ad-hoc in `org-trivy-exception-review.yml`).

## Acceptance criteria (item #5, MTCS grade-A plan)
1. ✅ block-style `strict: true` resolves `true`
2. ✅ present-but-unparseable → non-zero exit
3. ✅ absent key → `false` (default preserved)
4. ✅ block-style + unparseable fixtures added to `tests/gate-config-resolve.test.sh` (14 assertions total)

## Testing
- ✅ Expected-PASS: all 14 meta-tests green
- ✅ Expected-FAIL (bug demo): the **old** resolver prints `false` for a block-style `strict: true` fixture — the silent fail-open this fixes
- ✅ shellcheck clean; live-config parity shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S