### PR TITLE
fix(ci): time-cap infra-mutating jobs and guard against uncapped terraform jobs

### DIFF
--- a/.github/workflows/org-opa.yml
+++ b/.github/workflows/org-opa.yml
@@ -69,6 +69,7 @@ jobs:
   opa:
     name: OPA policy check (advisory)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout target repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/org-terraform-apply.yml
+++ b/.github/workflows/org-terraform-apply.yml
@@ -85,6 +85,7 @@ jobs:
   apply:
     name: Terraform Apply
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: ${{ inputs.environment }}
     defaults:
       run:

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -31,6 +31,7 @@ jobs:
   verify:
     name: Check Terraform Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -71,6 +71,7 @@ jobs:
   plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -106,7 +106,25 @@ jobs:
             echo "::error::docs regression — a caller example uses @main (write @<release-sha> # vX.Y.Z; RFC-0008)."
             rc=1
           fi
+          # T1: every runner job that executes terraform apply/destroy/plan must be
+          # time-capped — an uncapped hung apply burns the 6-hour default and can
+          # hold a state lock. (Reusable-call jobs can't take timeout-minutes.)
+          uncapped="$(awk '
+            function flush() { if (job != "" && infra && runner && !capped) print file ": job \x27" job "\x27 runs terraform apply/destroy/plan without timeout-minutes"; infra=0; capped=0; runner=0 }
+            FNR == 1 { flush(); file = FILENAME; injobs = 0; job = "" }
+            /^jobs:/ { injobs = 1; next }
+            injobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { flush(); job = $1; sub(/:$/, "", job); next }
+            injobs && /^    runs-on:/ { runner = 1 }
+            injobs && /^    timeout-minutes:/ { capped = 1 }
+            injobs && /terraform (apply|destroy|plan)([[:space:]]|$)/ { infra = 1 }
+            END { flush() }
+          ' .github/workflows/*.yml)"
+          if [ -n "$uncapped" ]; then
+            printf '%s\n' "$uncapped"
+            echo "::error::T1 regression — an infra-mutating job lacks timeout-minutes (grade-A plan item #19)."
+            rc=1
+          fi
           if [ "$rc" -eq 0 ]; then
-            echo "OK: no Actions/main raw fetches and no active @main sibling refs."
+            echo "OK: no Actions/main raw fetches, no active @main sibling refs, all infra jobs time-capped."
           fi
           exit "$rc"


### PR DESCRIPTION
## Summary
- `timeout-minutes` on the four uncapped runner jobs: apply **60m**, plan **30m**, fmt **15m**, opa **15m** (`org-terratest` was already capped at 60m — the only one of 26).
- New **T1 guard** in `test-scripts.yml`: an awk job-block parser that fails if any runner job executing `terraform apply|destroy|plan` lacks `timeout-minutes`.
- Scope note: `notify-failure` jobs are reusable-workflow-call jobs (`uses:`) where `timeout-minutes` is syntactically invalid — their runtime is bounded by the callee's jobs. The AC's intent (bound the infra-mutating runner jobs) is fully covered.

## Acceptance criteria (item #19, MTCS grade-A plan — board-added M1)
1. ✅ every runner job in the listed workflows declares `timeout-minutes`
2. ✅ infra-mutating jobs bounded ≤ 60m
3. ✅ T1 assertion fails when a terraform job lacks a cap
4. ✅ scope explicitly listed, not "all 24"

## Testing
- ✅ Expected-PASS: T1 empty on this tree
- ✅ Expected-FAIL: stripping the apply cap → T1 names `org-terraform-apply.yml: job apply` and exits non-zero (verified locally, re-applied)
- ✅ actionlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S