### PR TITLE
fix(security): declare least-privilege permissions on the 6 implicit workflows

### DIFF
--- a/.github/workflows/org-jira-sync.yml
+++ b/.github/workflows/org-jira-sync.yml
@@ -45,6 +45,8 @@ on:
       JIRA_API_VERSION:
         required: false
 
+permissions: {}
+
 jobs:
   create_jira_issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/org-slack-notify.yml
+++ b/.github/workflows/org-slack-notify.yml
@@ -92,6 +92,8 @@ on:
       SLACK_BOT_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   notify:
     name: Send Slack Notification

--- a/.github/workflows/org-terraform-docs.yml
+++ b/.github/workflows/org-terraform-docs.yml
@@ -29,6 +29,9 @@ on:
         description: 'Slack bot token for failure notifications (required if slack_channel_id is set)'
         required: false
 
+permissions:
+  contents: write
+
 jobs:
     docs:
         runs-on: ubuntu-latest

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -27,6 +27,10 @@ on:
         type: string
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   verify:
     name: Check Terraform Formatting

--- a/.github/workflows/org-terraform-source-pin.yml
+++ b/.github/workflows/org-terraform-source-pin.yml
@@ -41,6 +41,9 @@ on:
         default: ''
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   source-pin:
     name: Check Coalfire-CF module source pins

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -32,6 +32,10 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   verify:
     name: Validate Terraform Configuration

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -124,6 +124,13 @@ jobs:
             echo "::error::T1 regression — an infra-mutating job lacks timeout-minutes (grade-A plan item #19)."
             rc=1
           fi
+          # P1: every workflow must declare an explicit permissions: block (least privilege).
+          missing="$(grep -L 'permissions:' .github/workflows/*.yml || true)"
+          if [ -n "$missing" ]; then
+            printf '%s\n' "$missing"
+            echo "::error::P1 regression — a workflow lacks an explicit permissions: block (grade-A plan item #4)."
+            rc=1
+          fi
           if [ "$rc" -eq 0 ]; then
             echo "OK: no Actions/main raw fetches, no active @main sibling refs, all infra jobs time-capped."
           fi


### PR DESCRIPTION
## Summary
- Explicit `permissions:` on the 6 workflows that had none, scoped from **observed token usage**: `org-jira-sync` + `org-slack-notify` → `{}` (external-API secrets only); `org-terraform-source-pin` → `contents: read`; `org-terraform-validate` → `contents: read` + `pull-requests: write` (posts a PR comment via github-script, `:115-119`); `org-terraform-docs` → `contents: write` (terraform-docs git-push); `org-terraform-fmt` → `contents: write` + `pull-requests: write` (auto-commit + failure comment `:81`).
- New **P1 guard** in `test-scripts.yml`: fails when any workflow lacks a `permissions:` block → the whole repo is now pinned at 26/26 explicit.
- AC deviation, documented: the plan inferred bare `contents: read`/`write` for validate/fmt; the code shows both post PR comments with `GITHUB_TOKEN`, so `pull-requests: write` is required — this is precisely the push-path verification the board's #4 concern required before finalizing.

## Acceptance criteria (item #4, MTCS grade-A plan)
1. ✅ jira/slack → `{}`  2. ✅ source-pin/validate read-scoped (validate + PR-comment write)  3. ✅ docs/fmt write-scoped to observed needs  4. ✅ `grep -L 'permissions:'` returns zero files, enforced by the new guard

## Testing
- ✅ Expected-PASS: 0 files lack permissions; actionlint clean
- ✅ Expected-FAIL: stripping `org-jira-sync.yml`'s block → guard names the file and exits non-zero (verified locally, restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S