### PR TITLE
fix(docs): truth-up label/permission/dependabot drift; dogfood grouped config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,22 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Dogfoods the grouped config org-dependabot.yml generates for consumer repos
+# (two groups: Coalfire-CF minors/patches vs third-party; majors arrive as
+# individually-reviewable singleton PRs).
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      org-actions:
+        applies-to: version-updates
+        patterns: ["Coalfire-CF/*"]
+        update-types: ["minor", "patch"]
+      third-party:
+        applies-to: version-updates
+        patterns: ["*"]
+        exclude-patterns: ["Coalfire-CF/*"]
+        update-types: ["minor", "patch"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  actions: read
 
 jobs:
   create-release:

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -288,9 +288,14 @@ The recommended repo config groups **minor+patch only** (majors arrive as indivi
 
 ```yaml
 groups:
-  actions:
+  org-actions:
+    applies-to: version-updates
+    patterns: ["Coalfire-CF/*"]
+    update-types: ["minor", "patch"]
+  third-party:
     applies-to: version-updates
     patterns: ["*"]
+    exclude-patterns: ["Coalfire-CF/*"]
     update-types: ["minor", "patch"]
 ```
 

--- a/docs/ORG_RELEASE_CLEAN.md
+++ b/docs/ORG_RELEASE_CLEAN.md
@@ -86,7 +86,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  actions: read
 
 jobs:
   create-release:
@@ -156,7 +155,7 @@ When configured as **org-level secrets**, the workflow generates short-lived app
 | GitHub App authentication | IA-2 | Optional app token for consistent permissions across public/private repos; falls back to `github.token` |
 | SHA256 checksum | SI-7 | Integrity verification for the released artifact |
 | Step summary | AU-3 | Audit trail of what was built, excluded, and uploaded |
-| Least privilege | AC-6 | Only requires `contents: write` and `actions: read` |
+| Least privilege | AC-6 | Only requires `contents: write` (+ `pull-requests`/`issues` write for release-please) |
 
 ## Verifying a Download
 


### PR DESCRIPTION
## Summary
- `actions: read` removed from all 3 doc sites (README caller example, ORG_RELEASE_CLEAN example + AC-6 table) — contradicted `org-release.yml`'s own deliberately-dropped scope.
- `ORG_DEPENDABOT_AUTO_MERGE.md` example now shows the **two-group** (`org-actions`/`third-party`) config matching the generator (`org-dependabot.yml:287-297`).
- Own `.github/dependabot.yml` dogfoods the generated grouped shape (was hand-written, ungrouped).
- Phantom labels `check/changelog-risk` + `blocked/analysis-error`: **wire** decision (owner-call per AC — either satisfies): `changelog-risk` becomes item #12's AI audit label and `analysis-error` marks the fail-closed analysis path — wired in the Wave-2 auto-merge PR (that file is under refactor in item #10; wiring here would collide).

## Acceptance criteria (item #7, MTCS grade-A plan)
1. 🔜 labels wired in the Wave-2 auto-merge PR (wire chosen over delete)
2. ✅ `grep -rn 'actions: read' README.md docs/` → 0
3. ✅ doc example ≡ generator two-group block
4. ✅ own dependabot.yml carries the grouped config

## Testing
- ✅ Expected-PASS: `actions: read` grep = 0; two-group diff parity with generator; mdlint clean on all touched docs
- ✅ Expected-FAIL: re-adding an `actions: read` line → grep gate >0 (the grep is the reviewable assertion; label-wiring negative lands with the Wave-2 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S