### PR TITLE
feat(ci): concurrency groups on auto-merge and terraform plan/apply/fmt

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -93,6 +93,11 @@ on:
       SLACK_BOT_TOKEN:
         required: false
 
+# One auto-merge evaluation per PR at a time; never cancel a merge mid-flight.
+concurrency:
+  group: dependabot-auto-merge-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   # ----------------------------------------------------------------
   # Job 1: Classify the dependency and determine auto-merge eligibility

--- a/.github/workflows/org-terraform-apply.yml
+++ b/.github/workflows/org-terraform-apply.yml
@@ -77,6 +77,11 @@ on:
         default: false
         type: boolean
 
+# Serialize applies per repo+ref+dir; never cancel an apply mid-flight.
+concurrency:
+  group: terraform-apply-${{ github.repository }}-${{ github.ref }}-${{ inputs.working_directory }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -27,6 +27,11 @@ on:
         type: string
   pull_request:
 
+# Serialize fmt per repo+ref (fmt has no working_directory input).
+concurrency:
+  group: terraform-fmt-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -62,6 +62,11 @@ on:
         default: '.'
         type: string
 
+# Serialize plans per repo+ref+dir to stop duplicate runs racing on comments/artifacts.
+concurrency:
+  group: terraform-plan-${{ github.repository }}-${{ github.ref }}-${{ inputs.working_directory }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Summary
- `concurrency:` on the 4 race-prone workflows with **parse-time caller-context keys**: auto-merge → `repo + PR-number` (`cancel-in-progress: false` — never cancel a merge mid-flight); plan/apply → `repo + ref + inputs.working_directory`; fmt → `repo + ref` (fmt declares no `working_directory` input — the board's final-gate catch).
- Kills duplicate Bedrock spend, shared-cache write races, and label thrash under the daily Dependabot herd; overlapping applies for the same repo+dir now serialize.
- Item re-scope (board-corrected): the plan's original `repo+dep@version` key is **not implementable** — dep identity is a `classify`-job output, computed after `concurrency` evaluates.

## Acceptance criteria (item #11, MTCS grade-A plan)
1. ✅ auto-merge keyed repo+PR-number, cancel-in-progress false
2. ✅ plan/apply keyed repo+ref+working_directory; fmt repo+ref
3. ✅ keys use only parse-time caller context (negative test below)
4. ✅ scoped to the 4 named workflows

## Testing
- ✅ Expected-PASS: all 4 carry valid blocks; actionlint clean
- ✅ Expected-FAIL: swapping a key for `needs.classify.outputs.dep_name` → actionlint rejects it (verified locally, restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S