### PR TITLE
feat(deps): Renovate preset auto-bumping Terraform ?ref= SHAs in gate-PASS shape

### DIFF
--- a/docs/ORG_SOURCE_PIN.md
+++ b/docs/ORG_SOURCE_PIN.md
@@ -42,5 +42,17 @@ jobs:
 ```
 
 Dependabot's `github-actions` ecosystem natively maintains SHA pins and updates
-the adjacent version comment; Terraform module `?ref=` SHAs are updated by the
-release re-pin procedure.
+the adjacent version comment. Terraform module `?ref=` SHAs are auto-bumped by
+**Renovate** via the shared org preset
+[`renovate/terraform-ref-pins.json5`](../renovate/terraform-ref-pins.json5) —
+its custom manager rewrites both the 40-hex SHA and the adjacent `# vX.Y.Z`
+comment, so every Renovate PR is already in this gate's PASS shape. Consume it
+from a module repo's `renovate.json`:
+
+```json
+{ "extends": ["github>Coalfire-CF/Actions//renovate/terraform-ref-pins"] }
+```
+
+(Requires the Renovate app installed on the repo — a separate app from
+Dependabot. Repos without Renovate fall back to the manual release re-pin
+procedure.)

--- a/renovate/terraform-ref-pins.json5
+++ b/renovate/terraform-ref-pins.json5
@@ -1,0 +1,38 @@
+{
+  // Shareable org preset (grade-A plan item #18): auto-bump Coalfire-CF
+  // Terraform module `?ref=` commit SHAs — the one dependency class Dependabot
+  // cannot pin — while keeping the adjacent `# vX.Y.Z` release comment in sync,
+  // so every Renovate-produced line is exactly the shape
+  // scripts/source-pin-check.sh grades PASS (RFC-0008):
+  //
+  //   source = "git::https://github.com/Coalfire-CF/<repo>(.git)(//subdir)?ref=<40-hex>" # vX.Y.Z
+  //   source = "github.com/Coalfire-CF/<repo>?ref=<40-hex>" # vX.Y.Z
+  //
+  // Consume from a module repo's renovate.json:
+  //   { "extends": ["github>Coalfire-CF/Actions//renovate/terraform-ref-pins"] }
+  //
+  // NOTE: inert until the Renovate app is installed on the org/repos (a separate
+  // org-admin step — Renovate is a different app from Dependabot).
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Coalfire-CF git-module sources pinned as ?ref=<sha> # vX.Y.Z (source-pin PASS shape)",
+      "fileMatch": ["\\.tf$"],
+      "matchStrings": [
+        "(?<host>git::https://github\\.com/|github\\.com/)(?<depName>Coalfire-CF/[A-Za-z0-9._-]+?)(?<gitsuffix>\\.git)?(?<subdir>//[^\"?]*)?\\?ref=(?<currentDigest>[a-fA-F0-9]{40})\"(?<sp>[ \\t]*)#[ \\t]*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "autoReplaceStringTemplate": "{{{host}}}{{{depName}}}{{#if gitsuffix}}.git{{/if}}{{#if subdir}}{{{subdir}}}{{/if}}?ref={{{newDigest}}}\"{{{sp}}}# {{{newValue}}}"
+    }
+  ],
+  "packageRules": [
+    {
+      // Majors stay individually reviewable; minors/patches may group.
+      "matchDatasources": ["github-tags"],
+      "matchPackageNames": ["Coalfire-CF/**"],
+      "commitMessagePrefix": "chore(deps):",
+      "separateMajorMinor": true
+    }
+  ]
+}

--- a/tests/fixtures/source-pin/pass_renovate.tf
+++ b/tests/fixtures/source-pin/pass_renovate.tf
@@ -1,0 +1,10 @@
+# Fixture: VALID (PASS) — the exact line shape the Renovate preset
+# (renovate/terraform-ref-pins.json5) produces after a bump: full git:: form
+# with .git suffix + //subdir, 40-hex SHA, adjacent `# vX.Y.Z` comment.
+# The source-pin gate MUST NOT flag it (proves Renovate output is gate-clean
+# by construction — grade-A plan item #18).
+module "vpc" {
+  source = "git::https://github.com/Coalfire-CF/terraform-aws-vpc-nfw.git//modules/vpc?ref=aabbccddeeff00112233445566778899aabbccdd" # v3.1.4
+
+  name = "example"
+}

--- a/tests/source-pin-check.test.sh
+++ b/tests/source-pin-check.test.sh
@@ -29,8 +29,8 @@ fail() { echo "NOT OK: $1"; exit 1; }
 # ---- Case 1: mixed tree, STRICT=true → FAIL, names the 3 fails as errors ----
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
-cp "${FIXTURES}/pass.tf" "${FIXTURES}/warn_tag.tf" "${FIXTURES}/fail_floating.tf" \
-   "${FIXTURES}/fail_branch.tf" "${FIXTURES}/fail_sha.tf" "$work/"
+cp "${FIXTURES}/pass.tf" "${FIXTURES}/pass_renovate.tf" "${FIXTURES}/warn_tag.tf" \
+   "${FIXTURES}/fail_floating.tf" "${FIXTURES}/fail_branch.tf" "${FIXTURES}/fail_sha.tf" "$work/"
 
 out="$(STRICT=true "$CHECK" "$work" 2>&1)"; code=$?
 [ "$code" -eq 1 ] || fail "expected exit 1 on mixed tree (STRICT=true), got $code"
@@ -40,6 +40,7 @@ echo "$out" | grep -q "::error .*fail_sha.tf"      || fail "fail_sha.tf (bare SH
 echo "$out" | grep -q "::warning .*warn_tag.tf"    || fail "warn_tag.tf not emitted as warning"
 echo "$out" | grep -q "::error .*warn_tag.tf"      && fail "warn_tag.tf wrongly emitted as error"
 echo "$out" | grep -q "pass.tf"                    && fail "pass.tf (SHA + comment) was wrongly flagged"
+echo "$out" | grep -q "pass_renovate.tf"           && fail "pass_renovate.tf (Renovate-produced shape) was wrongly flagged"
 echo "OK: strict mixed tree fails, 3 fails as errors, warn_tag as warning, pass spared (exit $code)"
 
 # ---- Case 2: mixed tree, STRICT=false (advisory default) → exit 0, warn-only ----


### PR DESCRIPTION
## Summary
- Shareable org preset `renovate/terraform-ref-pins.json5`: a regex custom manager (github-tags datasource) that bumps `?ref=<40-hex>` **and** rewrites the adjacent `# vX.Y.Z` comment via `autoReplaceStringTemplate` — so Renovate output is `source-pin-check.sh` **PASS by construction**. (This comment templating is the make-or-break AC: default Renovate output lacks the comment and would classify FAIL/WARN.)
- Covers both accepted source shapes (`github.com/Coalfire-CF/...` and `git::https://...(.git)(//subdir)`), Coalfire-CF scoped; majors stay individually reviewable.
- `tests/fixtures/source-pin/pass_renovate.tf` (the exact post-bump shape) wired into the meta-test — must never be flagged.
- `ORG_SOURCE_PIN.md` updated to name Renovate + consumption snippet, replacing the manual 're-pin procedure' reference.
- **Org-admin follow-up:** the preset is inert until the Renovate app is installed (separate app from Dependabot) — noted in preset header + doc.

## Acceptance criteria (item #18, MTCS grade-A plan)
1. ✅ committed Renovate config for the Coalfire-CF terraform git-module class
2. ✅ produces `?ref=<40-hex> # vX.Y.Z` (the PASS shape) — explicit AC, encoded in the template + fixture
3. ✅ Renovate-shaped fixture PASSES; `fail_floating.tf` still FAILs (meta-test asserts both)
4. ✅ ORG_SOURCE_PIN.md names Renovate

## Testing
- ✅ Expected-PASS: `bash tests/source-pin-check.test.sh` — all cases green incl. `pass_renovate.tf` never flagged
- ✅ Expected-FAIL: `fail_floating.tf` (no `?ref=`) still emits a FAIL-class finding — gate not weakened
- ✅ preset parses as JSON5; mdlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S