### PR TITLE
feat(terraform): Azure + GCP OIDC parity for org plan/apply (plan #17)

### DIFF
--- a/.github/workflows/org-terraform-apply.yml
+++ b/.github/workflows/org-terraform-apply.yml
@@ -1,5 +1,14 @@
 name: Terraform Apply
 
+# Reusable workflow that runs `terraform apply` for a Terraform module/config.
+# Cloud authentication is OIDC-based and multi-cloud: each provider's auth step
+# runs only when its inputs are supplied, so AWS-only callers are unaffected.
+#   - AWS:   set aws_role_arn (+ aws_region)
+#   - Azure: set azure_client_id / azure_tenant_id / azure_subscription_id
+#            (azure_environment=azureusgovernment for Azure-Gov)
+#   - GCP:   set gcp_workload_identity_provider (+ gcp_service_account)
+# Mirrors the proven per-cloud OIDC pattern in org-terratest.yml.
+
 on:
   workflow_call:
     inputs:
@@ -40,6 +49,36 @@ on:
         type: string
       aws_role_arn:
         description: 'AWS IAM role ARN for OIDC authentication (leave empty to skip AWS auth)'
+        required: false
+        default: ''
+        type: string
+      azure_client_id:
+        description: 'Azure App Registration client ID for OIDC (leave empty to skip Azure auth)'
+        required: false
+        default: ''
+        type: string
+      azure_tenant_id:
+        description: 'Azure AD tenant ID for OIDC'
+        required: false
+        default: ''
+        type: string
+      azure_subscription_id:
+        description: 'Azure subscription ID for OIDC'
+        required: false
+        default: ''
+        type: string
+      azure_environment:
+        description: 'Azure cloud environment: azurecloud or azureusgovernment'
+        required: false
+        default: 'azurecloud'
+        type: string
+      gcp_workload_identity_provider:
+        description: 'GCP Workload Identity Provider resource name (leave empty to skip GCP auth)'
+        required: false
+        default: ''
+        type: string
+      gcp_service_account:
+        description: 'GCP service account email for Workload Identity Federation'
         required: false
         default: ''
         type: string
@@ -165,6 +204,44 @@ jobs:
         with:
           role-to-assume: ${{ inputs.aws_role_arn }}
           aws-region: ${{ inputs.aws_region }}
+
+      - name: Configure Azure credentials (OIDC)
+        if: inputs.azure_client_id != ''
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ inputs.azure_client_id }}
+          tenant-id: ${{ inputs.azure_tenant_id }}
+          subscription-id: ${{ inputs.azure_subscription_id }}
+          environment: ${{ inputs.azure_environment }}
+
+      # The azurerm provider does not read azure/login's CLI session for OIDC auth;
+      # it needs ARM_* env vars. With ARM_USE_OIDC=true the provider auto-detects
+      # GitHub's ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN — no secret material is exported.
+      - name: Export ARM environment for Terraform
+        if: inputs.azure_client_id != ''
+        env:
+          AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
+          AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+          AZURE_SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id }}
+          AZURE_ENVIRONMENT: ${{ inputs.azure_environment }}
+        run: |
+          set -eo pipefail
+          {
+            echo "ARM_USE_OIDC=true"
+            echo "ARM_CLIENT_ID=${AZURE_CLIENT_ID}"
+            echo "ARM_TENANT_ID=${AZURE_TENANT_ID}"
+            echo "ARM_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}"
+          } >> "$GITHUB_ENV"
+          if [ "$AZURE_ENVIRONMENT" = "azureusgovernment" ]; then
+            echo "ARM_ENVIRONMENT=usgovernment" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure GCP credentials (OIDC)
+        if: inputs.gcp_workload_identity_provider != ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
 
       - name: Terraform Init
         env:

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -1,5 +1,14 @@
 name: Terraform Plan
 
+# Reusable workflow that runs `terraform plan` for a Terraform module/config.
+# Cloud authentication is OIDC-based and multi-cloud: each provider's auth step
+# runs only when its inputs are supplied, so AWS-only callers are unaffected.
+#   - AWS:   set aws_role_arn (+ aws_region)
+#   - Azure: set azure_client_id / azure_tenant_id / azure_subscription_id
+#            (azure_environment=azureusgovernment for Azure-Gov)
+#   - GCP:   set gcp_workload_identity_provider (+ gcp_service_account)
+# Mirrors the proven per-cloud OIDC pattern in org-terratest.yml.
+
 on:
   workflow_call:
     inputs:
@@ -30,6 +39,36 @@ on:
         type: string
       aws_role_arn:
         description: 'AWS IAM role ARN for OIDC authentication (leave empty to skip AWS auth)'
+        required: false
+        default: ''
+        type: string
+      azure_client_id:
+        description: 'Azure App Registration client ID for OIDC (leave empty to skip Azure auth)'
+        required: false
+        default: ''
+        type: string
+      azure_tenant_id:
+        description: 'Azure AD tenant ID for OIDC'
+        required: false
+        default: ''
+        type: string
+      azure_subscription_id:
+        description: 'Azure subscription ID for OIDC'
+        required: false
+        default: ''
+        type: string
+      azure_environment:
+        description: 'Azure cloud environment: azurecloud or azureusgovernment'
+        required: false
+        default: 'azurecloud'
+        type: string
+      gcp_workload_identity_provider:
+        description: 'GCP Workload Identity Provider resource name (leave empty to skip GCP auth)'
+        required: false
+        default: ''
+        type: string
+      gcp_service_account:
+        description: 'GCP service account email for Workload Identity Federation'
         required: false
         default: ''
         type: string
@@ -152,6 +191,44 @@ jobs:
         with:
           role-to-assume: ${{ inputs.aws_role_arn }}
           aws-region: ${{ inputs.aws_region }}
+
+      - name: Configure Azure credentials (OIDC)
+        if: inputs.azure_client_id != ''
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ inputs.azure_client_id }}
+          tenant-id: ${{ inputs.azure_tenant_id }}
+          subscription-id: ${{ inputs.azure_subscription_id }}
+          environment: ${{ inputs.azure_environment }}
+
+      # The azurerm provider does not read azure/login's CLI session for OIDC auth;
+      # it needs ARM_* env vars. With ARM_USE_OIDC=true the provider auto-detects
+      # GitHub's ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN — no secret material is exported.
+      - name: Export ARM environment for Terraform
+        if: inputs.azure_client_id != ''
+        env:
+          AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
+          AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+          AZURE_SUBSCRIPTION_ID: ${{ inputs.azure_subscription_id }}
+          AZURE_ENVIRONMENT: ${{ inputs.azure_environment }}
+        run: |
+          set -eo pipefail
+          {
+            echo "ARM_USE_OIDC=true"
+            echo "ARM_CLIENT_ID=${AZURE_CLIENT_ID}"
+            echo "ARM_TENANT_ID=${AZURE_TENANT_ID}"
+            echo "ARM_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}"
+          } >> "$GITHUB_ENV"
+          if [ "$AZURE_ENVIRONMENT" = "azureusgovernment" ]; then
+            echo "ARM_ENVIRONMENT=usgovernment" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure GCP credentials (OIDC)
+        if: inputs.gcp_workload_identity_provider != ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
 
       - name: Terraform Init
         env:


### PR DESCRIPTION
## Summary

Implements **plan item #17 — Azure/GCP plan/apply parity** (governance/reviews/2026-07-06-actions-platform-grade-a-plan.md §17).

`org-terraform-plan.yml` and `org-terraform-apply.yml` were AWS-only. This PR adds Azure + GCP OIDC auth paths, mirroring the **proven per-cloud pattern already shipped in `org-terratest.yml`** (verified E2E green on Azure-Gov at Actions v0.10.0). validate/fmt were already cloud-agnostic; this brings plan/apply to parity.

## Acceptance criteria (item #17)

- [x] **(1)** plan + apply gain inputs `azure_client_id` / `azure_tenant_id` / `azure_subscription_id` / `azure_environment` and `gcp_workload_identity_provider` / `gcp_service_account`, mirroring terratest (descriptions copied verbatim; defaults `''`, `azure_environment` default `azurecloud`).
- [x] **(2)** An Azure OIDC step (`azure/login`, **same pinned SHA as terratest**) + the `ARM_*` export run only when `azure_client_id != ''`.
- [x] **(3)** A GCP WIF step (`google-github-actions/auth`) runs only when `gcp_workload_identity_provider != ''`.
- [x] **(4)** The AWS path is **byte-for-byte unchanged** (diff is 154 insertions / 0 deletions); supplying no cloud inputs runs no auth step (all three `if:` conditions false).
- [x] **(5)** `ARM_ENVIRONMENT=usgovernment` handling preserved for Azure-Gov; `id-token: write` present in both files (unchanged) for all three clouds' OIDC.

## Pin hygiene (SHAs verified against `org-terratest.yml` in this checkout, reused verbatim)

| Action | Pin |
| --- | --- |
| `azure/login` | `@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0` |
| `google-github-actions/auth` | `@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0` |
| `aws-actions/configure-aws-credentials` | `@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1` (unchanged) |

## How `ARM_*` reaches Terraform

The `azurerm` provider does not read `azure/login`'s CLI session for OIDC — it needs `ARM_*` env vars. The "Export ARM environment for Terraform" step writes `ARM_USE_OIDC=true` / `ARM_CLIENT_ID` / `ARM_TENANT_ID` / `ARM_SUBSCRIPTION_ID` (+ `ARM_ENVIRONMENT=usgovernment` for Azure-Gov) to `$GITHUB_ENV`, which persists to subsequent steps. It is inserted **before** Terraform Init/Plan/Apply, so the provider sees the vars at plan/apply time. This is the terratest-proven mechanism, copied verbatim (including the explanatory comment). No secret material is exported — with `ARM_USE_OIDC=true` the provider auto-detects GitHub's `ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN`.

## Validated testing

**`actionlint` (`SHELLCHECK_OPTS="-S warning"`): clean, exit 0** on both files (conditionals + pinned actions parse).

**Diff-proof — AWS path unchanged / purely additive:**
```
 .github/workflows/org-terraform-apply.yml | 77 ++++++++++++++++++++++++++
 .github/workflows/org-terraform-plan.yml  | 77 ++++++++++++++++++++++++++
 2 files changed, 154 insertions(+)
```
0 removed lines — the AWS `Configure AWS credentials (OIDC)` step, its `if:`, and its SHA are untouched; the new steps are inserted immediately after it.

**Expected-FAIL evidence (proves the gap this closes) — on current `main`:**
```
org-terraform-plan.yml  : only  `if: inputs.aws_role_arn != ''`  (:150) — no step consumes azure_client_id
org-terraform-apply.yml : only  `if: inputs.aws_role_arn != ''`  (:163) — no step consumes azure_client_id
```
So on current main, passing `azure_client_id` runs **no** azure login step → the `azurerm` provider errors on missing ARM creds. This PR closes that gap.

## Remaining verification (deferred, per plan)

Full E2E on a live Azure-Gov / GCP repo is deferred to post-release adoption — these workflows are consumed **by SHA**, so nothing runs the new paths until adopters re-pin. This is low-risk because **`org-terratest.yml` already proves the identical auth pattern E2E on Azure-Gov (green at v0.10.0)**; this PR transplants that exact pattern into plan/apply.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S
