### PR TITLE
refactor(auto-merge): extract decision logic to tested scripts/*.sh (grade-A #10)

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -31,6 +31,18 @@ name: Dependabot Auto-Merge
 # IMPORTANT: Use pull_request_target (not pull_request) so the workflow has
 # write permissions on Dependabot PRs. The workflow only checks out metadata,
 # never executes code from the PR branch.
+#
+# Decision logic (grade-A plan #10): the supply-chain, breaking-change, and
+# decide steps run committed, unit-tested, shellcheck-clean scripts under
+# scripts/*.sh instead of inline heredocs. Because this is a reusable workflow
+# that runs in the CONSUMER's checkout, each of those jobs self-checks-out
+# Coalfire-CF/Actions into ./actions-tools at `inputs.actions_ref` (default
+# 'main') and invokes actions-tools/scripts/<name>.sh. This is the same central
+# model the gate workflows (org-opa, org-terraform-source-pin,
+# org-terraform-version-band) already use for scripts/ and gate-config.yml:
+# pinning THIS workflow by SHA does not by itself pin the decision scripts —
+# they resolve at actions_ref. Consumers who want the logic pinned to the same
+# immutable ref pass `actions_ref: <release-sha>  # vX.Y.Z` (see docs).
 
 on:
   workflow_call:
@@ -75,6 +87,19 @@ on:
         required: false
         type: number
         default: 30
+      actions_ref:
+        description: >-
+          Git ref of Coalfire-CF/Actions to load the extracted decision scripts
+          (scripts/supply-chain-check.sh, breaking-change-check.sh,
+          auto-merge-decide.sh) from. Defaults to 'main' — the same central
+          model the gate workflows (org-opa, org-terraform-source-pin,
+          org-terraform-version-band) already use for scripts/ and
+          gate-config.yml. Pin to a release SHA (e.g.
+          "d34db33f...  # v0.10.1") to freeze the decision logic to the same
+          immutable ref you pin this reusable workflow to.
+        required: false
+        type: string
+        default: 'main'
       slack_channel_id:
         description: 'Slack channel ID for failure notifications (optional)'
         required: false
@@ -284,6 +309,13 @@ jobs:
           role-to-assume: ${{ secrets.AUTOMERGE_DEPENDABOT_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}
 
+      - name: Checkout Actions repo (decision scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: Coalfire-CF/Actions
+          ref: ${{ inputs.actions_ref || 'main' }}
+          path: actions-tools
+
       - name: Run supply chain checks
         id: checks
         env:
@@ -297,202 +329,7 @@ jobs:
           SCORECARD_THRESHOLD: ${{ inputs.scorecard_threshold }}
         run: |
           set -euo pipefail
-          cat > /tmp/supply_chain_check.sh <<'BASH'
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          # Grouped-PR support: every dependency in the PR is checked
-          # individually and folded into AND/OR aggregates. Any per-dep
-          # query ERROR (as opposed to a clean result) increments
-          # CHECK_ERRORS and the decide job fails CLOSED to manual review.
-          CHECK_ERRORS=0
-          AGG_OSV_CLEAR="true"
-          AGG_SC_PASS="true"
-          AGG_SC_SCORE=""
-          AGG_CACHE_HIT="true"
-
-          check_one() {
-          local DEP_NAME="$1" TO_VERSION="$2"
-
-          # -----------------------------------------------------------
-          # Normalize dependency name for S3 key (replace / with --)
-          # -----------------------------------------------------------
-          SAFE_DEP_NAME=$(echo "$DEP_NAME" | sed 's|/|--|g')
-          CACHE_KEY="analyses/shared/${SAFE_DEP_NAME}/${TO_VERSION}.json"
-
-          # -----------------------------------------------------------
-          # Check S3 cache (shared — supply chain data is universal)
-          # -----------------------------------------------------------
-          CACHE_HIT="false"
-          OSV_CLEAR="true"
-          SCORECARD_PASS="true"
-          SCORECARD_SCORE="0"
-
-          CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${CACHE_KEY}" /tmp/cached_analysis.json 2>/dev/null && echo "ok" || echo "miss")
-          if [ "$CACHED" = "ok" ]; then
-            # Validate TTL
-            ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json)
-            if [ -n "$ANALYZED_AT" ]; then
-              ANALYZED_EPOCH=$(date -d "$ANALYZED_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$ANALYZED_AT" +%s 2>/dev/null || echo 0)
-              NOW_EPOCH=$(date +%s)
-              AGE_DAYS=$(( (NOW_EPOCH - ANALYZED_EPOCH) / 86400 ))
-              if [ "$AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
-                CACHE_HIT="true"
-                OSV_CLEAR=$(jq -r '.osv.clear // "true"' /tmp/cached_analysis.json)
-                SCORECARD_PASS=$(jq -r '.scorecard.pass // "true"' /tmp/cached_analysis.json)
-                SCORECARD_SCORE=$(jq -r '.scorecard.score // "0"' /tmp/cached_analysis.json)
-                echo "Cache hit for ${DEP_NAME}@${TO_VERSION} (age: ${AGE_DAYS}d)"
-              fi
-            fi
-          fi
-
-          if [ "$CACHE_HIT" = "false" ]; then
-            echo "Cache miss — running live checks for ${DEP_NAME}@${TO_VERSION}"
-
-            # ---------------------------------------------------------
-            # OSV.dev vulnerability check
-            # ---------------------------------------------------------
-            # Map Dependabot ecosystems to OSV ecosystems
-            OSV_ECOSYSTEM=""
-            case "$ECOSYSTEM" in
-              github-actions|github_actions) OSV_ECOSYSTEM="GitHub Actions" ;;
-              npm)            OSV_ECOSYSTEM="npm" ;;
-              pip)            OSV_ECOSYSTEM="PyPI" ;;
-              gomod)          OSV_ECOSYSTEM="Go" ;;
-              cargo)          OSV_ECOSYSTEM="crates.io" ;;
-              nuget)          OSV_ECOSYSTEM="NuGet" ;;
-              *)              OSV_ECOSYSTEM="" ;;
-            esac
-
-            OSV_VULNS="[]"
-            if [ -n "$OSV_ECOSYSTEM" ]; then
-              # Fail CLOSED on query error: a failed OSV call is NOT a clean
-              # result (the old `|| echo` fail-open let vulns through silently).
-              if ! OSV_RESPONSE=$(curl -sf --max-time 30 \
-                -X POST "https://api.osv.dev/v1/query" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n \
-                  --arg pkg "$DEP_NAME" \
-                  --arg ver "$TO_VERSION" \
-                  --arg eco "$OSV_ECOSYSTEM" \
-                  '{package: {name: $pkg, ecosystem: $eco}, version: $ver}')" \
-                2>/dev/null); then
-                echo "::warning::OSV query FAILED for ${DEP_NAME}@${TO_VERSION} — failing closed"
-                CHECK_ERRORS=$((CHECK_ERRORS + 1))
-                OSV_RESPONSE='{"vulns":[]}'
-              fi
-              OSV_VULNS=$(echo "$OSV_RESPONSE" | jq '.vulns // []')
-              VULN_COUNT=$(echo "$OSV_VULNS" | jq 'length')
-              if [ "$VULN_COUNT" -gt 0 ]; then
-                OSV_CLEAR="false"
-                echo "::warning::Found ${VULN_COUNT} known vulnerabilities for ${DEP_NAME}@${TO_VERSION}"
-              fi
-            else
-              echo "No OSV ecosystem mapping for '${ECOSYSTEM}' — skipping OSV check"
-            fi
-
-            # ---------------------------------------------------------
-            # OpenSSF Scorecard check
-            # ---------------------------------------------------------
-            # Extract the GitHub owner/repo from the dependency name
-            SCORECARD_REPO=""
-            case "$ECOSYSTEM" in
-              github-actions|github_actions)
-                # actions/checkout -> github.com/actions/checkout
-                SCORECARD_REPO="github.com/${DEP_NAME}"
-                ;;
-              npm|pip|gomod|cargo)
-                # Attempt to resolve via the dependency name if it looks like a GitHub path
-                if echo "$DEP_NAME" | grep -qE '^github\.com/'; then
-                  SCORECARD_REPO="${DEP_NAME}"
-                elif echo "$DEP_NAME" | grep -qE '^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$'; then
-                  SCORECARD_REPO="github.com/${DEP_NAME}"
-                fi
-                ;;
-            esac
-
-            if [ -n "$SCORECARD_REPO" ]; then
-              SCORECARD_RESPONSE=$(curl -sf --max-time 30 \
-                "https://api.securityscorecards.dev/projects/${SCORECARD_REPO}" \
-                2>/dev/null || echo '{}')
-              SCORECARD_SCORE=$(echo "$SCORECARD_RESPONSE" | jq -r '.score // 0')
-
-              if [ "$(echo "$SCORECARD_SCORE < $SCORECARD_THRESHOLD" | bc -l)" -eq 1 ]; then
-                SCORECARD_PASS="false"
-                echo "::warning::Scorecard ${SCORECARD_SCORE}/10 below threshold ${SCORECARD_THRESHOLD} for ${SCORECARD_REPO}"
-              else
-                echo "Scorecard ${SCORECARD_SCORE}/10 meets threshold for ${SCORECARD_REPO}"
-              fi
-            else
-              echo "Cannot resolve Scorecard repo for '${DEP_NAME}' — skipping Scorecard check"
-              SCORECARD_SCORE="N/A"
-            fi
-
-            # ---------------------------------------------------------
-            # Write to S3 cache (partial — supply chain fields only)
-            # Breaking change check will merge its fields in separately
-            # ---------------------------------------------------------
-            jq -n \
-              --arg dep "$DEP_NAME" \
-              --arg ver "$TO_VERSION" \
-              --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              --argjson osv_clear "$([ "$OSV_CLEAR" = "true" ] && echo true || echo false)" \
-              --argjson osv_vulns "$OSV_VULNS" \
-              --arg sc_score "$SCORECARD_SCORE" \
-              --argjson sc_pass "$([ "$SCORECARD_PASS" = "true" ] && echo true || echo false)" \
-              '{
-                dependency: $dep,
-                version: $ver,
-                analyzed_at: $ts,
-                osv: { clear: $osv_clear, vulns: $osv_vulns },
-                scorecard: { score: $sc_score, pass: $sc_pass }
-              }' > /tmp/supply_chain_result.json
-
-            aws s3 cp /tmp/supply_chain_result.json "s3://${S3_BUCKET}/${CACHE_KEY}" \
-              --content-type "application/json" --quiet
-          fi
-
-          # -----------------------------------------------------------
-          # Fold this dependency into the aggregates
-          # -----------------------------------------------------------
-          [ "$OSV_CLEAR" = "true" ]      || AGG_OSV_CLEAR="false"
-          [ "$SCORECARD_PASS" = "true" ] || AGG_SC_PASS="false"
-          [ "$CACHE_HIT" = "true" ]      || AGG_CACHE_HIT="false"
-          if [ "$SCORECARD_SCORE" != "N/A" ]; then
-            if [ -z "$AGG_SC_SCORE" ] || [ "$(echo "$SCORECARD_SCORE < $AGG_SC_SCORE" | bc -l)" -eq 1 ]; then
-              AGG_SC_SCORE="$SCORECARD_SCORE"
-            fi
-          fi
-          }
-
-          # -----------------------------------------------------------
-          # Iterate every dependency in the PR (grouped-PR support)
-          # -----------------------------------------------------------
-          DEPS_FILE=/tmp/deps.tsv
-          printf '%s' "${DEPS_B64:-}" | base64 -d > "$DEPS_FILE" 2>/dev/null || : > "$DEPS_FILE"
-          if [ "${PARSE_ERROR:-false}" = "true" ] || [ ! -s "$DEPS_FILE" ]; then
-            echo "::warning::dependency list unavailable — failing closed"
-            CHECK_ERRORS=$((CHECK_ERRORS + 1))
-          else
-            # `|| [ -n "$D_NAME" ]` processes a final line with no trailing
-            # newline; fd 3 keeps loop input safe from stdin-reading commands.
-            while IFS=$'\t' read -r -u3 D_NAME D_FROM D_TO || [ -n "${D_NAME:-}" ]; do
-              [ -n "$D_NAME" ] && [ "$D_NAME" != "-" ] || { D_NAME=""; continue; }
-              echo "=== supply-chain check: ${D_NAME}@${D_TO} ==="
-              check_one "$D_NAME" "$D_TO"
-              D_NAME=""
-            done 3< "$DEPS_FILE"
-          fi
-
-          [ -n "$AGG_SC_SCORE" ] || AGG_SC_SCORE="N/A"
-          echo "osv_clear=${AGG_OSV_CLEAR}" >> "$GITHUB_OUTPUT"
-          echo "scorecard_pass=${AGG_SC_PASS}" >> "$GITHUB_OUTPUT"
-          echo "scorecard_score=${AGG_SC_SCORE}" >> "$GITHUB_OUTPUT"
-          echo "cache_hit=${AGG_CACHE_HIT}" >> "$GITHUB_OUTPUT"
-          echo "check_errors=${CHECK_ERRORS}" >> "$GITHUB_OUTPUT"
-          BASH
-          chmod +x /tmp/supply_chain_check.sh
-          bash /tmp/supply_chain_check.sh
+          bash "${GITHUB_WORKSPACE}/actions-tools/scripts/supply-chain-check.sh"
 
       - name: Apply supply chain labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -593,6 +430,13 @@ jobs:
           role-to-assume: ${{ secrets.AUTOMERGE_DEPENDABOT_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}
 
+      - name: Checkout Actions repo (decision scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: Coalfire-CF/Actions
+          ref: ${{ inputs.actions_ref || 'main' }}
+          path: actions-tools
+
       - name: Run breaking change checks
         id: checks
         env:
@@ -608,393 +452,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          cat > /tmp/breaking_change_check.sh <<'BASH'
-          #!/usr/bin/env bash
-          set -euo pipefail
-
-          # Grouped-PR support: each dependency is analyzed individually and
-          # folded into aggregates (semver = max, breaking = OR). Bedrock/API
-          # errors increment CHECK_ERRORS -> decide fails CLOSED to manual
-          # review (replaces the old silent "defaulting to safe" fail-open).
-          CHECK_ERRORS=0
-          AGG_SEMVER="patch"
-          AGG_BREAKING="false"
-          AGG_CONF=""
-          AGG_SUMMARY=""
-          AGG_APPLIES="false"
-
-          semver_rank() {
-            case "$1" in major) echo 3;; minor) echo 2;; patch) echo 1;; *) echo 0;; esac
-          }
-
-          check_one() {
-          local DEP_NAME="$1" FROM_VERSION="$2" TO_VERSION="$3"
-
-          SAFE_DEP_NAME=$(echo "$DEP_NAME" | sed 's|/|--|g')
-          SAFE_REPO_NAME=$(echo "$GITHUB_REPOSITORY" | sed 's|/|--|g')
-          SHARED_CACHE_KEY="analyses/shared/${SAFE_DEP_NAME}/${TO_VERSION}.json"
-          REPO_CACHE_KEY="analyses/repos/${SAFE_REPO_NAME}/${SAFE_DEP_NAME}/${TO_VERSION}.json"
-
-          # -----------------------------------------------------------
-          # Check S3 cache — shared (changelog) and repo-scoped (applicability)
-          # -----------------------------------------------------------
-          SHARED_CACHE_HIT="false"
-          REPO_CACHE_HIT="false"
-          SEMVER_TYPE="unknown"
-          HAS_BREAKING="false"
-          CONFIDENCE="0"
-          RISK_SUMMARY=""
-          APPLIES_TO_REPO="true"
-
-          # Check shared cache for universal changelog analysis
-          CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" /tmp/cached_analysis.json 2>/dev/null && echo "ok" || echo "miss")
-          if [ "$CACHED" = "ok" ]; then
-            BC_EXISTS=$(jq -r '.changelog // empty' /tmp/cached_analysis.json)
-            if [ -n "$BC_EXISTS" ]; then
-              ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json)
-              if [ -n "$ANALYZED_AT" ]; then
-                ANALYZED_EPOCH=$(date -d "$ANALYZED_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$ANALYZED_AT" +%s 2>/dev/null || echo 0)
-                NOW_EPOCH=$(date +%s)
-                AGE_DAYS=$(( (NOW_EPOCH - ANALYZED_EPOCH) / 86400 ))
-                if [ "$AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
-                  SHARED_CACHE_HIT="true"
-                  SEMVER_TYPE=$(jq -r '.semver.type // "unknown"' /tmp/cached_analysis.json)
-                  HAS_BREAKING=$(jq -r '.changelog.breaking // "false"' /tmp/cached_analysis.json)
-                  CONFIDENCE=$(jq -r '.changelog.confidence // "0"' /tmp/cached_analysis.json)
-                  RISK_SUMMARY=$(jq -r '.changelog.summary // ""' /tmp/cached_analysis.json)
-                  echo "Shared cache hit for changelog analysis of ${DEP_NAME}@${TO_VERSION}"
-                fi
-              fi
-            fi
-          fi
-
-          # Check repo-scoped cache for applicability
-          REPO_CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${REPO_CACHE_KEY}" /tmp/cached_repo_analysis.json 2>/dev/null && echo "ok" || echo "miss")
-          if [ "$REPO_CACHED" = "ok" ]; then
-            REPO_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_repo_analysis.json)
-            if [ -n "$REPO_AT" ]; then
-              REPO_EPOCH=$(date -d "$REPO_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$REPO_AT" +%s 2>/dev/null || echo 0)
-              NOW_EPOCH=$(date +%s)
-              REPO_AGE_DAYS=$(( (NOW_EPOCH - REPO_EPOCH) / 86400 ))
-              if [ "$REPO_AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
-                REPO_CACHE_HIT="true"
-                APPLIES_TO_REPO=$(jq -r '.applies_to_repo // "true"' /tmp/cached_repo_analysis.json)
-                RISK_SUMMARY=$(jq -r '.risk_summary // "'"$RISK_SUMMARY"'"' /tmp/cached_repo_analysis.json)
-                echo "Repo cache hit for applicability of ${DEP_NAME}@${TO_VERSION} in ${GITHUB_REPOSITORY}"
-              fi
-            fi
-          fi
-
-          if [ "$SHARED_CACHE_HIT" = "false" ]; then
-            echo "Running breaking change analysis for ${DEP_NAME}: ${FROM_VERSION} -> ${TO_VERSION}"
-
-            # ---------------------------------------------------------
-            # Semver analysis
-            # ---------------------------------------------------------
-            # Strip leading 'v' for comparison
-            FROM_CLEAN=$(echo "$FROM_VERSION" | sed 's/^v//')
-            TO_CLEAN=$(echo "$TO_VERSION" | sed 's/^v//')
-
-            if [ "$FROM_CLEAN" = "-" ] || [ -z "$FROM_CLEAN" ]; then
-              # No previous version available — cannot classify; the
-              # fetch-metadata update-type gate in decide still covers majors.
-              SEMVER_TYPE="unknown"
-            else
-            FROM_MAJOR=$(echo "$FROM_CLEAN" | cut -d. -f1)
-            TO_MAJOR=$(echo "$TO_CLEAN" | cut -d. -f1)
-            FROM_MINOR=$(echo "$FROM_CLEAN" | cut -d. -f2)
-            TO_MINOR=$(echo "$TO_CLEAN" | cut -d. -f2)
-
-            if [ "$TO_MAJOR" != "$FROM_MAJOR" ]; then
-              SEMVER_TYPE="major"
-            elif [ "$TO_MINOR" != "$FROM_MINOR" ]; then
-              SEMVER_TYPE="minor"
-            else
-              SEMVER_TYPE="patch"
-            fi
-            fi
-
-            echo "Semver: ${FROM_VERSION} -> ${TO_VERSION} = ${SEMVER_TYPE}"
-
-            # ---------------------------------------------------------
-            # Fetch release notes from GitHub
-            # ---------------------------------------------------------
-            RELEASE_NOTES=""
-
-            # Determine the upstream repo for release notes
-            UPSTREAM_REPO=""
-            case "$ECOSYSTEM" in
-              github-actions|github_actions)
-                UPSTREAM_REPO="$DEP_NAME"
-                ;;
-              *)
-                # For other ecosystems, try the dep name as a GitHub repo path
-                if echo "$DEP_NAME" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
-                  UPSTREAM_REPO="$DEP_NAME"
-                fi
-                ;;
-            esac
-
-            if [ -n "$UPSTREAM_REPO" ]; then
-              # Build list of candidate tags to try.
-              # Dependabot often reports bare major versions (e.g. "9") while
-              # upstream tags use full semver (e.g. "v9.0.0"), so we expand
-              # short versions into .0 and .0.0 suffixes.
-              CANDIDATE_TAGS=("${TO_VERSION}" "v${TO_VERSION}" "${TO_CLEAN}")
-              DOTS="${TO_CLEAN//[^.]}"
-              if [ "${#DOTS}" -eq 0 ]; then
-                # Bare major (e.g. "9") — also try 9.0.0, v9.0.0, 9.0, v9.0
-                CANDIDATE_TAGS+=("${TO_CLEAN}.0.0" "v${TO_CLEAN}.0.0" "${TO_CLEAN}.0" "v${TO_CLEAN}.0")
-              elif [ "${#DOTS}" -eq 1 ]; then
-                # Major.minor (e.g. "9.1") — also try 9.1.0, v9.1.0
-                CANDIDATE_TAGS+=("${TO_CLEAN}.0" "v${TO_CLEAN}.0")
-              fi
-
-              for TAG_FMT in "${CANDIDATE_TAGS[@]}"; do
-                NOTES=$(curl -sf --max-time 15 \
-                  -H "Authorization: token ${GH_TOKEN}" \
-                  -H "Accept: application/vnd.github+json" \
-                  "https://api.github.com/repos/${UPSTREAM_REPO}/releases/tags/${TAG_FMT}" \
-                  2>/dev/null | jq -r '.body // ""' || echo "")
-                if [ -n "$NOTES" ]; then
-                  echo "Found release notes at tag: ${TAG_FMT}"
-                  RELEASE_NOTES="$NOTES"
-                  break
-                fi
-              done
-            fi
-
-            if [ -z "$RELEASE_NOTES" ]; then
-              RELEASE_NOTES="No release notes available."
-            fi
-
-            # Truncate to ~4000 chars to keep Claude API costs low
-            RELEASE_NOTES=$(echo "$RELEASE_NOTES" | head -c 4000)
-
-            # ---------------------------------------------------------
-            # Bedrock Converse API analysis
-            # ---------------------------------------------------------
-            USAGE_CONTEXT=""
-            if [ -f "/tmp/dep_usage_${SAFE_DEP_NAME}.txt" ]; then
-              USAGE_CONTEXT=$(cat "/tmp/dep_usage_${SAFE_DEP_NAME}.txt")
-            fi
-
-            PROMPT=$(jq -n \
-              --arg dep "$DEP_NAME" \
-              --arg from "$FROM_VERSION" \
-              --arg to "$TO_VERSION" \
-              --arg semver "$SEMVER_TYPE" \
-              --arg notes "$RELEASE_NOTES" \
-              --arg usage "$USAGE_CONTEXT" \
-              '"You are a dependency update analyzer. Analyze this update and determine if it contains breaking changes.\n\nDependency: " + $dep + "\nFrom: " + $from + "\nTo: " + $to + "\nSemver bump type: " + $semver + "\n\nRelease notes:\n" + $notes + "\n\nThis is how the dependency is currently used in the consuming repository:\n" + $usage + "\n\nRespond with ONLY a JSON object (no markdown fencing):\n{\"breaking\": true/false, \"confidence\": 0.0-1.0, \"risks\": [\"list of specific risks if any\"], \"summary\": \"one sentence summary of whether the breaking changes affect this repo based on the actual usage shown above\", \"applies_to_repo\": true/false}"')
-
-            jq -n \
-              --argjson prompt "$PROMPT" \
-              '[{
-                role: "user",
-                content: [{
-                  text: $prompt
-                }]
-              }]' > /tmp/bedrock_messages.json
-
-            echo '{"maxTokens":512}' > /tmp/bedrock_config.json
-
-            # Fail CLOSED on Bedrock error (the old fallback silently
-            # defaulted to breaking=false — an unanalyzed dep is NOT safe).
-            if ! AI_RESPONSE=$(aws bedrock-runtime converse \
-              --model-id "$BEDROCK_MODEL_ID" \
-              --messages file:///tmp/bedrock_messages.json \
-              --inference-config file:///tmp/bedrock_config.json \
-              --output json 2>/tmp/bedrock_err.log); then
-              echo "::warning::Bedrock analysis FAILED for ${DEP_NAME} — failing closed"
-              CHECK_ERRORS=$((CHECK_ERRORS + 1))
-              AI_RESPONSE='{"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":0,\"risks\":[\"API call failed\"],\"summary\":\"Analysis errored — routed to manual review\"}"}]}}}'
-            fi
-
-            if [ -s /tmp/bedrock_err.log ]; then
-              echo "Bedrock stderr: $(cat /tmp/bedrock_err.log)"
-            fi
-
-            # Parse the Bedrock Converse response
-            AI_TEXT=$(echo "$AI_RESPONSE" | jq -r '.output.message.content[0].text // "{}"')
-            # Strip markdown fences if present, then validate JSON
-            AI_TEXT=$(echo "$AI_TEXT" | sed '/^```/d' | sed 's/^[[:space:]]*//')
-            if ! echo "$AI_TEXT" | jq empty 2>/dev/null; then
-              # Try extracting JSON between first { and last }
-              AI_TEXT=$(echo "$AI_TEXT" | sed -n '/^{/,/^}/p' | head -20)
-              if ! echo "$AI_TEXT" | jq empty 2>/dev/null; then
-                echo "::warning::Failed to parse AI response for ${DEP_NAME} — failing closed"
-                CHECK_ERRORS=$((CHECK_ERRORS + 1))
-                AI_TEXT='{"breaking":false,"confidence":0,"risks":["Failed to parse AI response"],"summary":"Analysis unparseable — routed to manual review"}'
-              fi
-            fi
-            HAS_BREAKING=$(echo "$AI_TEXT" | jq -r '.breaking // false')
-            CONFIDENCE=$(echo "$AI_TEXT" | jq -r '.confidence // 0')
-            RISK_SUMMARY=$(echo "$AI_TEXT" | jq -r '.summary // "Analysis unavailable"')
-            AI_RISKS=$(echo "$AI_TEXT" | jq -r '.risks // []')
-            APPLIES_TO_REPO=$(echo "$AI_TEXT" | jq -r '.applies_to_repo // true')
-
-            # Override: major bump is always flagged regardless of AI
-            if [ "$SEMVER_TYPE" = "major" ]; then
-              HAS_BREAKING="true"
-            fi
-
-            # ---------------------------------------------------------
-            # Write shared cache (universal changelog + semver analysis)
-            # ---------------------------------------------------------
-            # Read existing cache entry (from supply chain check) or start fresh
-            if [ -f /tmp/cached_analysis.json ]; then
-              EXISTING=$(cat /tmp/cached_analysis.json)
-            else
-              EXISTING='{}'
-            fi
-
-            echo "$EXISTING" | jq \
-              --arg dep "$DEP_NAME" \
-              --arg ver "$TO_VERSION" \
-              --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              --arg sv_type "$SEMVER_TYPE" \
-              --arg sv_from "$FROM_VERSION" \
-              --arg sv_to "$TO_VERSION" \
-              --argjson breaking "$([ "$HAS_BREAKING" = "true" ] && echo true || echo false)" \
-              --argjson conf "$CONFIDENCE" \
-              --arg summary "$RISK_SUMMARY" \
-              --argjson risks "$AI_RISKS" \
-              '. + {
-                dependency: $dep,
-                version: $ver,
-                analyzed_at: $ts,
-                semver: { type: $sv_type, from: $sv_from, to: $sv_to },
-                changelog: { breaking: $breaking, confidence: ($conf | tonumber), summary: $summary, risks: $risks }
-              }' > /tmp/merged_analysis.json
-
-            aws s3 cp /tmp/merged_analysis.json "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" \
-              --content-type "application/json" --quiet
-          fi
-
-          # ---------------------------------------------------------
-          # Repo-scoped applicability analysis
-          # On shared cache hit + repo miss, run a lightweight Bedrock
-          # call that only assesses whether the known breaking changes
-          # apply to this repo's usage patterns.
-          # ---------------------------------------------------------
-          if [ "$SHARED_CACHE_HIT" = "true" ] && [ "$REPO_CACHE_HIT" = "false" ]; then
-            echo "Shared cache hit but no repo analysis — running applicability check for ${GITHUB_REPOSITORY}"
-            USAGE_CONTEXT=""
-            if [ -f "/tmp/dep_usage_${SAFE_DEP_NAME}.txt" ]; then
-              USAGE_CONTEXT=$(cat "/tmp/dep_usage_${SAFE_DEP_NAME}.txt")
-            fi
-
-            APPLY_PROMPT=$(jq -n \
-              --arg dep "$DEP_NAME" \
-              --arg from "$FROM_VERSION" \
-              --arg to "$TO_VERSION" \
-              --arg summary "$RISK_SUMMARY" \
-              --arg usage "$USAGE_CONTEXT" \
-              '"You are a dependency update analyzer. A previous analysis found these breaking changes:\n\nDependency: " + $dep + "\nFrom: " + $from + "\nTo: " + $to + "\nBreaking change summary: " + $summary + "\n\nHere is how this dependency is actually used in the consuming repository:\n" + $usage + "\n\nBased on the actual usage shown, do the breaking changes affect this repository?\n\nRespond with ONLY a JSON object (no markdown fencing):\n{\"applies_to_repo\": true/false, \"summary\": \"one sentence explaining whether and why the breaking changes affect this specific usage\"}"')
-
-            jq -n \
-              --argjson prompt "$APPLY_PROMPT" \
-              '[{
-                role: "user",
-                content: [{
-                  text: $prompt
-                }]
-              }]' > /tmp/bedrock_apply_messages.json
-
-            echo '{"maxTokens":256}' > /tmp/bedrock_apply_config.json
-
-            # Applicability errors stay conservative (assume it applies) but
-            # do NOT count as CHECK_ERRORS: applies_to_repo never gates the
-            # decision, and defaulting to true is already the safe direction.
-            APPLY_RESPONSE=$(aws bedrock-runtime converse \
-              --model-id "$BEDROCK_MODEL_ID" \
-              --messages file:///tmp/bedrock_apply_messages.json \
-              --inference-config file:///tmp/bedrock_apply_config.json \
-              --output json 2>/tmp/bedrock_apply_err.log \
-              || echo '{"output":{"message":{"content":[{"text":"{\"applies_to_repo\":true,\"summary\":\"Unable to assess applicability — defaulting to assume it applies\"}"}]}}}')
-
-            APPLY_TEXT=$(echo "$APPLY_RESPONSE" | jq -r '.output.message.content[0].text // "{}"')
-            APPLY_TEXT=$(echo "$APPLY_TEXT" | sed '/^```/d' | sed 's/^[[:space:]]*//')
-            if ! echo "$APPLY_TEXT" | jq empty 2>/dev/null; then
-              APPLY_TEXT=$(echo "$APPLY_TEXT" | sed -n '/^{/,/^}/p' | head -20)
-              if ! echo "$APPLY_TEXT" | jq empty 2>/dev/null; then
-                APPLY_TEXT='{"applies_to_repo":true,"summary":"Unable to parse — defaulting to assume it applies"}'
-              fi
-            fi
-            APPLIES_TO_REPO=$(echo "$APPLY_TEXT" | jq -r '.applies_to_repo // true')
-            RISK_SUMMARY=$(echo "$APPLY_TEXT" | jq -r '.summary // "'"$RISK_SUMMARY"'"')
-          fi
-
-          # ---------------------------------------------------------
-          # Write repo-scoped cache (applicability analysis)
-          # ---------------------------------------------------------
-          if [ "$REPO_CACHE_HIT" = "false" ]; then
-            jq -n \
-              --arg dep "$DEP_NAME" \
-              --arg ver "$TO_VERSION" \
-              --arg repo "$GITHUB_REPOSITORY" \
-              --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              --argjson applies "$([ "$APPLIES_TO_REPO" = "true" ] && echo true || echo false)" \
-              --arg summary "$RISK_SUMMARY" \
-              '{
-                dependency: $dep,
-                version: $ver,
-                repository: $repo,
-                analyzed_at: $ts,
-                applies_to_repo: $applies,
-                risk_summary: $summary
-              }' > /tmp/repo_analysis.json
-
-            aws s3 cp /tmp/repo_analysis.json "s3://${S3_BUCKET}/${REPO_CACHE_KEY}" \
-              --content-type "application/json" --quiet
-          fi
-
-          # -----------------------------------------------------------
-          # Fold this dependency into the aggregates
-          # -----------------------------------------------------------
-          if [ "$(semver_rank "$SEMVER_TYPE")" -gt "$(semver_rank "$AGG_SEMVER")" ]; then
-            AGG_SEMVER="$SEMVER_TYPE"
-          fi
-          [ "$HAS_BREAKING" = "true" ]    && AGG_BREAKING="true"
-          [ "$APPLIES_TO_REPO" = "true" ] && AGG_APPLIES="true"
-          if [ -z "$AGG_CONF" ] || [ "$(echo "$CONFIDENCE < $AGG_CONF" | bc -l 2>/dev/null || echo 0)" -eq 1 ]; then
-            AGG_CONF="$CONFIDENCE"
-          fi
-          AGG_SUMMARY="${AGG_SUMMARY}${DEP_NAME}: ${RISK_SUMMARY} | "
-          }
-
-          # -----------------------------------------------------------
-          # Iterate every dependency in the PR (grouped-PR support)
-          # -----------------------------------------------------------
-          DEPS_FILE=/tmp/deps.tsv
-          printf '%s' "${DEPS_B64:-}" | base64 -d > "$DEPS_FILE" 2>/dev/null || : > "$DEPS_FILE"
-          if [ "${PARSE_ERROR:-false}" = "true" ] || [ ! -s "$DEPS_FILE" ]; then
-            echo "::warning::dependency list unavailable — failing closed"
-            CHECK_ERRORS=$((CHECK_ERRORS + 1))
-            AGG_SEMVER="unknown"
-          else
-            while IFS=$'\t' read -r -u3 D_NAME D_FROM D_TO || [ -n "${D_NAME:-}" ]; do
-              [ -n "$D_NAME" ] && [ "$D_NAME" != "-" ] || { D_NAME=""; continue; }
-              echo "=== breaking-change check: ${D_NAME} ${D_FROM} -> ${D_TO} ==="
-              check_one "$D_NAME" "$D_FROM" "$D_TO"
-              D_NAME=""
-            done 3< "$DEPS_FILE"
-          fi
-
-          [ -n "$AGG_CONF" ] || AGG_CONF="0"
-          echo "semver_type=${AGG_SEMVER}" >> "$GITHUB_OUTPUT"
-          echo "has_breaking_changes=${AGG_BREAKING}" >> "$GITHUB_OUTPUT"
-          echo "confidence=${AGG_CONF}" >> "$GITHUB_OUTPUT"
-          echo "applies_to_repo=${AGG_APPLIES}" >> "$GITHUB_OUTPUT"
-          echo "check_errors=${CHECK_ERRORS}" >> "$GITHUB_OUTPUT"
-
-          # Escape newlines + truncate for GITHUB_OUTPUT
-          SAFE_SUMMARY=$(echo "$AGG_SUMMARY" | tr '\n' ' ' | head -c 900)
-          echo "risk_summary=${SAFE_SUMMARY}" >> "$GITHUB_OUTPUT"
-          BASH
-          chmod +x /tmp/breaking_change_check.sh
-          bash /tmp/breaking_change_check.sh
+          bash "${GITHUB_WORKSPACE}/actions-tools/scripts/breaking-change-check.sh"
 
       - name: Apply breaking change labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -1045,6 +503,13 @@ jobs:
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      - name: Checkout Actions repo (decision scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: Coalfire-CF/Actions
+          ref: ${{ inputs.actions_ref || 'main' }}
+          path: actions-tools
+
       - name: Evaluate checks and decide
         id: decision
         env:
@@ -1066,117 +531,7 @@ jobs:
           BC_ERRORS: ${{ needs.breaking_change_check.outputs.check_errors }}
         run: |
           set -euo pipefail
-
-          DECISION="approve"
-          RISK_LEVEL="low"
-          BLOCKED_LABELS=""
-          REASONS=""
-          MANUAL="false"
-
-          # Fail CLOSED: any per-dependency check error or parse ambiguity
-          # means the evaluation is partial — never approve on partial data.
-          if [ "${PARSE_ERROR:-false}" = "true" ] || [ "${SC_ERRORS:-0}" -gt 0 ] || [ "${BC_ERRORS:-0}" -gt 0 ]; then
-            MANUAL="true"
-            RISK_LEVEL="high"
-            REASONS="${REASONS}\n- Per-dependency checks incomplete (parse_error=${PARSE_ERROR:-false}, supply_chain_errors=${SC_ERRORS:-0}, breaking_check_errors=${BC_ERRORS:-0}) — fail-closed to manual review"
-          fi
-
-          # Authoritative group-aware major gate: fetch-metadata's update-type
-          # is the MAX semver across every dependency in the PR. Value format
-          # is "version-update:semver-major" — match the suffix, never a bare
-          # "major" (that comparison would silently never fire).
-          if [[ "${UPDATE_TYPE_META:-}" == *"semver-major"* ]]; then
-            DECISION="block"
-            RISK_LEVEL="high"
-            BLOCKED_LABELS="${BLOCKED_LABELS} blocked/major-bump"
-            REASONS="${REASONS}\n- Major version bump present in this PR (update-type: ${UPDATE_TYPE_META})"
-          fi
-
-          # Check for blockers
-          if [ "$OSV_CLEAR" != "true" ]; then
-            DECISION="block"
-            RISK_LEVEL="high"
-            BLOCKED_LABELS="${BLOCKED_LABELS} blocked/known-vuln"
-            REASONS="${REASONS}\n- Known vulnerability found in target version"
-          fi
-
-          # Scorecard gate is waived for first-party org dependencies: the
-          # Scorecard API has no data for org repos, which would hard-block
-          # every first-party bump (RFC-0010: same-major first-party bumps
-          # auto-merge on green CI). OSV/major/breaking gates still apply.
-          SCORECARD_WAIVED="false"
-          if [ "$SCORECARD_PASS" != "true" ]; then
-            if [ "$IS_FIRST_PARTY" = "true" ]; then
-              SCORECARD_WAIVED="true"
-              echo "First-party dependency (${DEP_NAME}) — scorecard gate waived"
-            else
-              DECISION="block"
-              RISK_LEVEL="high"
-              BLOCKED_LABELS="${BLOCKED_LABELS} blocked/low-scorecard"
-              REASONS="${REASONS}\n- OpenSSF Scorecard below threshold (score: ${SCORECARD_SCORE})"
-            fi
-          fi
-
-          if [ "$SEMVER_TYPE" = "major" ]; then
-            DECISION="block"
-            RISK_LEVEL="high"
-            BLOCKED_LABELS="${BLOCKED_LABELS} blocked/major-bump"
-            REASONS="${REASONS}\n- Major version bump requires manual review"
-          fi
-
-          if [ "$HAS_BREAKING" = "true" ] && [ "$SEMVER_TYPE" != "major" ]; then
-            # Breaking change in a non-major bump — extra concerning
-            DECISION="block"
-            RISK_LEVEL="high"
-            BLOCKED_LABELS="${BLOCKED_LABELS} blocked/breaking-change"
-            REASONS="${REASONS}\n- Breaking change detected: ${RISK_SUMMARY}"
-          fi
-
-          # Fail-closed precedence: check errors downgrade an approve to
-          # manual review. An already-blocked PR stays blocked (stronger).
-          if [ "$MANUAL" = "true" ] && [ "$DECISION" = "approve" ]; then
-            DECISION="manual"
-          fi
-
-          # Determine if medium risk (not blocked but warrants attention)
-          if [ "$DECISION" = "approve" ] && [ "$SEMVER_TYPE" = "minor" ]; then
-            RISK_LEVEL="medium"
-          fi
-
-          echo "decision=${DECISION}" >> "$GITHUB_OUTPUT"
-          echo "risk_level=${RISK_LEVEL}" >> "$GITHUB_OUTPUT"
-          echo "blocked_labels=${BLOCKED_LABELS}" >> "$GITHUB_OUTPUT"
-
-          # Write step summary
-          {
-            echo "## Dependabot Auto-Merge Decision"
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| Dependency | \`${DEP_NAME}\` |"
-            echo "| Version | \`${TO_VERSION}\` |"
-            echo "| Decision | **${DECISION}** |"
-            echo "| Risk | ${RISK_LEVEL} |"
-            echo "| OSV Clear | ${OSV_CLEAR} |"
-            if [ "$SCORECARD_WAIVED" = "true" ]; then
-              echo "| Scorecard Pass | waived — first-party (${SCORECARD_SCORE}) |"
-            else
-              echo "| Scorecard Pass | ${SCORECARD_PASS} (${SCORECARD_SCORE}) |"
-            fi
-            echo "| First Party | ${IS_FIRST_PARTY} |"
-            echo "| Semver (aggregate) | ${SEMVER_TYPE} |"
-            echo "| Update Type (max) | ${UPDATE_TYPE_META:-n/a} |"
-            echo "| Dependency Group | ${DEP_GROUP:-—} |"
-            echo "| Check Errors | supply=${SC_ERRORS:-0} breaking=${BC_ERRORS:-0} parse=${PARSE_ERROR:-false} |"
-            echo "| Breaking Changes | ${HAS_BREAKING} |"
-            echo "| Applies to Repo | ${APPLIES_TO_REPO} |"
-            echo "| Analysis | ${RISK_SUMMARY} |"
-            if [ -n "$REASONS" ]; then
-              echo ""
-              echo "### Blocking Reasons"
-              echo -e "$REASONS"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          bash "${GITHUB_WORKSPACE}/actions-tools/scripts/auto-merge-decide.sh"
 
       - name: Apply decision labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -47,6 +47,31 @@ jobs:
           done
           exit "$rc"
 
+  shellcheck:
+    name: Shellcheck scripts/*.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run shellcheck over all committed scripts
+        run: |
+          set -euo pipefail
+          # Full shellcheck at DEFAULT severity (catches style/info such as
+          # SC2086) over every committed gate/decision script. The inline-heredoc
+          # nits the actionlint job defers (it runs SHELLCHECK_OPTS=-S warning)
+          # are covered here now that the auto-merge decision logic lives in
+          # scripts/*.sh (grade-A plan item #10). shellcheck is preinstalled on
+          # ubuntu-latest runners.
+          shopt -s nullglob
+          scripts=(scripts/*.sh)
+          if [ ${#scripts[@]} -eq 0 ]; then
+            echo "::error::no scripts/*.sh found"
+            exit 1
+          fi
+          shellcheck "${scripts[@]}"
+          echo "OK: shellcheck clean across ${#scripts[@]} script(s)."
+
   actionlint:
     name: Lint workflows (actionlint)
     runs-on: ubuntu-latest

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -184,6 +184,31 @@ jobs:
 Requires the org-level setting **"Send secrets to workflows from pull requests
 created by Dependabot"** to be enabled under Org Settings > Actions > General.
 
+### Pinning the decision logic
+
+The supply-chain, breaking-change, and decision steps run committed scripts
+(`scripts/supply-chain-check.sh`, `breaking-change-check.sh`,
+`auto-merge-decide.sh`) rather than inline heredocs. Because this is a reusable
+workflow that runs in **your** repo's checkout, each of those jobs self-checks-out
+`Coalfire-CF/Actions` and invokes the script from there. By default that checkout
+uses `main` — the same central model the gate workflows (`org-opa`,
+`org-terraform-source-pin`, `org-terraform-version-band`) already use for
+`scripts/` and `gate-config.yml`. **Pinning the `uses:` line by SHA does not by
+itself pin the decision scripts** — they resolve at `actions_ref`.
+
+To freeze the decision logic to the same immutable ref you pin the workflow to,
+pass `actions_ref`:
+
+```yaml
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    with:
+      actions_ref: 72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    secrets: inherit
+```
+
 ## Inputs
 
 | Input | Required | Default | Description |
@@ -195,6 +220,7 @@ created by Dependabot"** to be enabled under Org Settings > Actions > General.
 | `auto_merge_method` | No | `squash` | Merge method: merge, squash, or rebase |
 | `bedrock_model_id` | No | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Bedrock model ID for changelog analysis |
 | `cache_ttl_days` | No | `30` | Days before cached analysis expires |
+| `actions_ref` | No | `main` | Ref of `Coalfire-CF/Actions` the decision scripts (`scripts/*.sh`) are loaded from. Defaults to `main` (same central model as the gate workflows). Pin to a release SHA to freeze the decision logic — see [Pinning the decision logic](#pinning-the-decision-logic) |
 | `slack_channel_id` | No | - | Slack channel for failure alerts |
 
 ## Secrets

--- a/scripts/auto-merge-decide.sh
+++ b/scripts/auto-merge-decide.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2129
+#
+# auto-merge-decide.sh — deterministic auto-merge decision gate for the
+# Dependabot auto-merge workflow (.github/workflows/org-dependabot-auto-merge.yml,
+# job: decide, step "Evaluate checks and decide").
+#
+# EXTRACTED VERBATIM (grade-A plan #10) from the former inline decide `run:` block
+# so the highest-blast-radius, zero-coverage decision logic is committed,
+# unit-testable (see tests/auto-merge-decide.test.sh), and shellcheck-covered.
+# The emitted decision is byte-identical to that inline block — pure refactor, no
+# behavior change. This gate is pure bash (no network / AWS): it reads the
+# upstream jobs' outputs from the environment and reduces them to a verdict.
+# SC2129 (grouped redirects) is a pre-existing style pattern in the verbatim
+# logic; left as-is to keep behavior provably unchanged.
+#
+# Fail-closed precedence (unchanged): any parse/check error downgrades an approve
+# to manual-review; a hard blocker (major / OSV / low-scorecard / breaking) wins
+# over manual. First-party org deps waive only the Scorecard gate (RFC-0010).
+#
+# Inputs (environment, set by the workflow step `env:` block):
+#   OSV_CLEAR SCORECARD_PASS SCORECARD_SCORE     (supply_chain_check.outputs.*)
+#   SEMVER_TYPE HAS_BREAKING CONFIDENCE RISK_SUMMARY APPLIES_TO_REPO
+#                                                (breaking_change_check.outputs.*)
+#   DEP_NAME TO_VERSION IS_FIRST_PARTY UPDATE_TYPE_META DEP_GROUP PARSE_ERROR
+#                                                (classify.outputs.*)
+#   SC_ERRORS BC_ERRORS   per-job check-error counts (fail-closed inputs)
+#   GITHUB_OUTPUT GITHUB_STEP_SUMMARY   (Actions-provided) output/summary files
+#
+# Outputs (appended to $GITHUB_OUTPUT):
+#   decision       one of: approve | block | manual
+#   risk_level     one of: low | medium | high
+#   blocked_labels space-separated blocked/* labels (may be empty)
+# Also writes a human-readable decision table to $GITHUB_STEP_SUMMARY.
+#
+set -euo pipefail
+
+DECISION="approve"
+RISK_LEVEL="low"
+BLOCKED_LABELS=""
+REASONS=""
+MANUAL="false"
+
+# Fail CLOSED: any per-dependency check error or parse ambiguity
+# means the evaluation is partial — never approve on partial data.
+if [ "${PARSE_ERROR:-false}" = "true" ] || [ "${SC_ERRORS:-0}" -gt 0 ] || [ "${BC_ERRORS:-0}" -gt 0 ]; then
+  MANUAL="true"
+  RISK_LEVEL="high"
+  REASONS="${REASONS}\n- Per-dependency checks incomplete (parse_error=${PARSE_ERROR:-false}, supply_chain_errors=${SC_ERRORS:-0}, breaking_check_errors=${BC_ERRORS:-0}) — fail-closed to manual review"
+fi
+
+# Authoritative group-aware major gate: fetch-metadata's update-type
+# is the MAX semver across every dependency in the PR. Value format
+# is "version-update:semver-major" — match the suffix, never a bare
+# "major" (that comparison would silently never fire).
+if [[ "${UPDATE_TYPE_META:-}" == *"semver-major"* ]]; then
+  DECISION="block"
+  RISK_LEVEL="high"
+  BLOCKED_LABELS="${BLOCKED_LABELS} blocked/major-bump"
+  REASONS="${REASONS}\n- Major version bump present in this PR (update-type: ${UPDATE_TYPE_META})"
+fi
+
+# Check for blockers
+if [ "$OSV_CLEAR" != "true" ]; then
+  DECISION="block"
+  RISK_LEVEL="high"
+  BLOCKED_LABELS="${BLOCKED_LABELS} blocked/known-vuln"
+  REASONS="${REASONS}\n- Known vulnerability found in target version"
+fi
+
+# Scorecard gate is waived for first-party org dependencies: the
+# Scorecard API has no data for org repos, which would hard-block
+# every first-party bump (RFC-0010: same-major first-party bumps
+# auto-merge on green CI). OSV/major/breaking gates still apply.
+SCORECARD_WAIVED="false"
+if [ "$SCORECARD_PASS" != "true" ]; then
+  if [ "$IS_FIRST_PARTY" = "true" ]; then
+    SCORECARD_WAIVED="true"
+    echo "First-party dependency (${DEP_NAME}) — scorecard gate waived"
+  else
+    DECISION="block"
+    RISK_LEVEL="high"
+    BLOCKED_LABELS="${BLOCKED_LABELS} blocked/low-scorecard"
+    REASONS="${REASONS}\n- OpenSSF Scorecard below threshold (score: ${SCORECARD_SCORE})"
+  fi
+fi
+
+if [ "$SEMVER_TYPE" = "major" ]; then
+  DECISION="block"
+  RISK_LEVEL="high"
+  BLOCKED_LABELS="${BLOCKED_LABELS} blocked/major-bump"
+  REASONS="${REASONS}\n- Major version bump requires manual review"
+fi
+
+if [ "$HAS_BREAKING" = "true" ] && [ "$SEMVER_TYPE" != "major" ]; then
+  # Breaking change in a non-major bump — extra concerning
+  DECISION="block"
+  RISK_LEVEL="high"
+  BLOCKED_LABELS="${BLOCKED_LABELS} blocked/breaking-change"
+  REASONS="${REASONS}\n- Breaking change detected: ${RISK_SUMMARY}"
+fi
+
+# Fail-closed precedence: check errors downgrade an approve to
+# manual review. An already-blocked PR stays blocked (stronger).
+if [ "$MANUAL" = "true" ] && [ "$DECISION" = "approve" ]; then
+  DECISION="manual"
+fi
+
+# Determine if medium risk (not blocked but warrants attention)
+if [ "$DECISION" = "approve" ] && [ "$SEMVER_TYPE" = "minor" ]; then
+  RISK_LEVEL="medium"
+fi
+
+echo "decision=${DECISION}" >> "$GITHUB_OUTPUT"
+echo "risk_level=${RISK_LEVEL}" >> "$GITHUB_OUTPUT"
+echo "blocked_labels=${BLOCKED_LABELS}" >> "$GITHUB_OUTPUT"
+
+# Write step summary
+{
+  echo "## Dependabot Auto-Merge Decision"
+  echo ""
+  echo "| Field | Value |"
+  echo "|-------|-------|"
+  echo "| Dependency | \`${DEP_NAME}\` |"
+  echo "| Version | \`${TO_VERSION}\` |"
+  echo "| Decision | **${DECISION}** |"
+  echo "| Risk | ${RISK_LEVEL} |"
+  echo "| OSV Clear | ${OSV_CLEAR} |"
+  if [ "$SCORECARD_WAIVED" = "true" ]; then
+    echo "| Scorecard Pass | waived — first-party (${SCORECARD_SCORE}) |"
+  else
+    echo "| Scorecard Pass | ${SCORECARD_PASS} (${SCORECARD_SCORE}) |"
+  fi
+  echo "| First Party | ${IS_FIRST_PARTY} |"
+  echo "| Semver (aggregate) | ${SEMVER_TYPE} |"
+  echo "| Update Type (max) | ${UPDATE_TYPE_META:-n/a} |"
+  echo "| Dependency Group | ${DEP_GROUP:-—} |"
+  echo "| Check Errors | supply=${SC_ERRORS:-0} breaking=${BC_ERRORS:-0} parse=${PARSE_ERROR:-false} |"
+  echo "| Breaking Changes | ${HAS_BREAKING} |"
+  echo "| Applies to Repo | ${APPLIES_TO_REPO} |"
+  echo "| Analysis | ${RISK_SUMMARY} |"
+  if [ -n "$REASONS" ]; then
+    echo ""
+    echo "### Blocking Reasons"
+    echo -e "$REASONS"
+  fi
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2001,SC2129
+# shellcheck disable=SC2001,SC2129,SC2015
+# SC2015: the `[ ... ] && [ ... ] || { ...; continue; }` guard-continue is the
+# original heredoc idiom, intentional (not if-then-else) — kept byte-identical.
 #
 # breaking-change-check.sh — semver + release-note (Bedrock) breaking-change
 # analysis for the Dependabot auto-merge workflow

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2001,SC2129
+#
+# breaking-change-check.sh — semver + release-note (Bedrock) breaking-change
+# analysis for the Dependabot auto-merge workflow
+# (.github/workflows/org-dependabot-auto-merge.yml, job: breaking_change_check).
+#
+# EXTRACTED VERBATIM (grade-A plan #10) from the former inline
+# `/tmp/breaking_change_check.sh` heredoc so the logic is committed,
+# unit-testable, and shellcheck-covered. The emitted decision is byte-identical
+# to that inline heredoc — pure refactor, no behavior change. The disabled codes
+# are pre-existing style patterns in the verbatim logic (SC2001 echo|sed, SC2129
+# grouped redirects); left as-is to keep behavior provably unchanged.
+#
+# Runs after `aws-actions/configure-aws-credentials` (needs AWS creds for Bedrock
+# + the S3 cache) in the consumer's checkout, which supplies the dependency-usage
+# context files (/tmp/dep_usage_*.txt) this script reads. The workflow invokes it
+# from the pinned Coalfire-CF/Actions self-checkout (see the workflow header).
+#
+# Inputs (environment, set by the workflow step `env:` block):
+#   DEP_NAME          primary dependency name          (classify.outputs.dep_name)
+#   FROM_VERSION      previous version                 (classify.outputs.from_version)
+#   TO_VERSION        target version                   (classify.outputs.to_version)
+#   ECOSYSTEM         Dependabot package-ecosystem     (classify.outputs.ecosystem)
+#   DEPS_B64          base64 TSV of every dep in the PR (grouped-PR support)
+#   PARSE_ERROR       "true" if dep list unparseable -> fail closed
+#   S3_BUCKET         shared analysis cache bucket     (inputs.s3_cache_bucket)
+#   CACHE_TTL_DAYS    cache freshness window           (inputs.cache_ttl_days)
+#   BEDROCK_MODEL_ID  Bedrock model id                 (inputs.bedrock_model_id)
+#   GH_TOKEN          token for GitHub release-notes API (github.token)
+#   GITHUB_REPOSITORY (Actions-provided) owner/repo of the consumer
+#   GITHUB_OUTPUT     (Actions-provided) step-output file
+#
+# Outputs (appended to $GITHUB_OUTPUT):
+#   semver_type  has_breaking_changes  confidence  applies_to_repo
+#   check_errors  risk_summary
+#
+set -euo pipefail
+
+# Grouped-PR support: each dependency is analyzed individually and
+# folded into aggregates (semver = max, breaking = OR). Bedrock/API
+# errors increment CHECK_ERRORS -> decide fails CLOSED to manual
+# review (replaces the old silent "defaulting to safe" fail-open).
+CHECK_ERRORS=0
+AGG_SEMVER="patch"
+AGG_BREAKING="false"
+AGG_CONF=""
+AGG_SUMMARY=""
+AGG_APPLIES="false"
+
+semver_rank() {
+  case "$1" in major) echo 3;; minor) echo 2;; patch) echo 1;; *) echo 0;; esac
+}
+
+check_one() {
+local DEP_NAME="$1" FROM_VERSION="$2" TO_VERSION="$3"
+
+SAFE_DEP_NAME=$(echo "$DEP_NAME" | sed 's|/|--|g')
+SAFE_REPO_NAME=$(echo "$GITHUB_REPOSITORY" | sed 's|/|--|g')
+SHARED_CACHE_KEY="analyses/shared/${SAFE_DEP_NAME}/${TO_VERSION}.json"
+REPO_CACHE_KEY="analyses/repos/${SAFE_REPO_NAME}/${SAFE_DEP_NAME}/${TO_VERSION}.json"
+
+# -----------------------------------------------------------
+# Check S3 cache — shared (changelog) and repo-scoped (applicability)
+# -----------------------------------------------------------
+SHARED_CACHE_HIT="false"
+REPO_CACHE_HIT="false"
+SEMVER_TYPE="unknown"
+HAS_BREAKING="false"
+CONFIDENCE="0"
+RISK_SUMMARY=""
+APPLIES_TO_REPO="true"
+
+# Check shared cache for universal changelog analysis
+CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" /tmp/cached_analysis.json 2>/dev/null && echo "ok" || echo "miss")
+if [ "$CACHED" = "ok" ]; then
+  BC_EXISTS=$(jq -r '.changelog // empty' /tmp/cached_analysis.json)
+  if [ -n "$BC_EXISTS" ]; then
+    ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json)
+    if [ -n "$ANALYZED_AT" ]; then
+      ANALYZED_EPOCH=$(date -d "$ANALYZED_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$ANALYZED_AT" +%s 2>/dev/null || echo 0)
+      NOW_EPOCH=$(date +%s)
+      AGE_DAYS=$(( (NOW_EPOCH - ANALYZED_EPOCH) / 86400 ))
+      if [ "$AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
+        SHARED_CACHE_HIT="true"
+        SEMVER_TYPE=$(jq -r '.semver.type // "unknown"' /tmp/cached_analysis.json)
+        HAS_BREAKING=$(jq -r '.changelog.breaking // "false"' /tmp/cached_analysis.json)
+        CONFIDENCE=$(jq -r '.changelog.confidence // "0"' /tmp/cached_analysis.json)
+        RISK_SUMMARY=$(jq -r '.changelog.summary // ""' /tmp/cached_analysis.json)
+        echo "Shared cache hit for changelog analysis of ${DEP_NAME}@${TO_VERSION}"
+      fi
+    fi
+  fi
+fi
+
+# Check repo-scoped cache for applicability
+REPO_CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${REPO_CACHE_KEY}" /tmp/cached_repo_analysis.json 2>/dev/null && echo "ok" || echo "miss")
+if [ "$REPO_CACHED" = "ok" ]; then
+  REPO_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_repo_analysis.json)
+  if [ -n "$REPO_AT" ]; then
+    REPO_EPOCH=$(date -d "$REPO_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$REPO_AT" +%s 2>/dev/null || echo 0)
+    NOW_EPOCH=$(date +%s)
+    REPO_AGE_DAYS=$(( (NOW_EPOCH - REPO_EPOCH) / 86400 ))
+    if [ "$REPO_AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
+      REPO_CACHE_HIT="true"
+      APPLIES_TO_REPO=$(jq -r '.applies_to_repo // "true"' /tmp/cached_repo_analysis.json)
+      RISK_SUMMARY=$(jq -r '.risk_summary // "'"$RISK_SUMMARY"'"' /tmp/cached_repo_analysis.json)
+      echo "Repo cache hit for applicability of ${DEP_NAME}@${TO_VERSION} in ${GITHUB_REPOSITORY}"
+    fi
+  fi
+fi
+
+if [ "$SHARED_CACHE_HIT" = "false" ]; then
+  echo "Running breaking change analysis for ${DEP_NAME}: ${FROM_VERSION} -> ${TO_VERSION}"
+
+  # ---------------------------------------------------------
+  # Semver analysis
+  # ---------------------------------------------------------
+  # Strip leading 'v' for comparison
+  FROM_CLEAN=$(echo "$FROM_VERSION" | sed 's/^v//')
+  TO_CLEAN=$(echo "$TO_VERSION" | sed 's/^v//')
+
+  if [ "$FROM_CLEAN" = "-" ] || [ -z "$FROM_CLEAN" ]; then
+    # No previous version available — cannot classify; the
+    # fetch-metadata update-type gate in decide still covers majors.
+    SEMVER_TYPE="unknown"
+  else
+  FROM_MAJOR=$(echo "$FROM_CLEAN" | cut -d. -f1)
+  TO_MAJOR=$(echo "$TO_CLEAN" | cut -d. -f1)
+  FROM_MINOR=$(echo "$FROM_CLEAN" | cut -d. -f2)
+  TO_MINOR=$(echo "$TO_CLEAN" | cut -d. -f2)
+
+  if [ "$TO_MAJOR" != "$FROM_MAJOR" ]; then
+    SEMVER_TYPE="major"
+  elif [ "$TO_MINOR" != "$FROM_MINOR" ]; then
+    SEMVER_TYPE="minor"
+  else
+    SEMVER_TYPE="patch"
+  fi
+  fi
+
+  echo "Semver: ${FROM_VERSION} -> ${TO_VERSION} = ${SEMVER_TYPE}"
+
+  # ---------------------------------------------------------
+  # Fetch release notes from GitHub
+  # ---------------------------------------------------------
+  RELEASE_NOTES=""
+
+  # Determine the upstream repo for release notes
+  UPSTREAM_REPO=""
+  case "$ECOSYSTEM" in
+    github-actions|github_actions)
+      UPSTREAM_REPO="$DEP_NAME"
+      ;;
+    *)
+      # For other ecosystems, try the dep name as a GitHub repo path
+      if echo "$DEP_NAME" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
+        UPSTREAM_REPO="$DEP_NAME"
+      fi
+      ;;
+  esac
+
+  if [ -n "$UPSTREAM_REPO" ]; then
+    # Build list of candidate tags to try.
+    # Dependabot often reports bare major versions (e.g. "9") while
+    # upstream tags use full semver (e.g. "v9.0.0"), so we expand
+    # short versions into .0 and .0.0 suffixes.
+    CANDIDATE_TAGS=("${TO_VERSION}" "v${TO_VERSION}" "${TO_CLEAN}")
+    DOTS="${TO_CLEAN//[^.]}"
+    if [ "${#DOTS}" -eq 0 ]; then
+      # Bare major (e.g. "9") — also try 9.0.0, v9.0.0, 9.0, v9.0
+      CANDIDATE_TAGS+=("${TO_CLEAN}.0.0" "v${TO_CLEAN}.0.0" "${TO_CLEAN}.0" "v${TO_CLEAN}.0")
+    elif [ "${#DOTS}" -eq 1 ]; then
+      # Major.minor (e.g. "9.1") — also try 9.1.0, v9.1.0
+      CANDIDATE_TAGS+=("${TO_CLEAN}.0" "v${TO_CLEAN}.0")
+    fi
+
+    for TAG_FMT in "${CANDIDATE_TAGS[@]}"; do
+      NOTES=$(curl -sf --max-time 15 \
+        -H "Authorization: token ${GH_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${UPSTREAM_REPO}/releases/tags/${TAG_FMT}" \
+        2>/dev/null | jq -r '.body // ""' || echo "")
+      if [ -n "$NOTES" ]; then
+        echo "Found release notes at tag: ${TAG_FMT}"
+        RELEASE_NOTES="$NOTES"
+        break
+      fi
+    done
+  fi
+
+  if [ -z "$RELEASE_NOTES" ]; then
+    RELEASE_NOTES="No release notes available."
+  fi
+
+  # Truncate to ~4000 chars to keep Claude API costs low
+  RELEASE_NOTES=$(echo "$RELEASE_NOTES" | head -c 4000)
+
+  # ---------------------------------------------------------
+  # Bedrock Converse API analysis
+  # ---------------------------------------------------------
+  USAGE_CONTEXT=""
+  if [ -f "/tmp/dep_usage_${SAFE_DEP_NAME}.txt" ]; then
+    USAGE_CONTEXT=$(cat "/tmp/dep_usage_${SAFE_DEP_NAME}.txt")
+  fi
+
+  PROMPT=$(jq -n \
+    --arg dep "$DEP_NAME" \
+    --arg from "$FROM_VERSION" \
+    --arg to "$TO_VERSION" \
+    --arg semver "$SEMVER_TYPE" \
+    --arg notes "$RELEASE_NOTES" \
+    --arg usage "$USAGE_CONTEXT" \
+    '"You are a dependency update analyzer. Analyze this update and determine if it contains breaking changes.\n\nDependency: " + $dep + "\nFrom: " + $from + "\nTo: " + $to + "\nSemver bump type: " + $semver + "\n\nRelease notes:\n" + $notes + "\n\nThis is how the dependency is currently used in the consuming repository:\n" + $usage + "\n\nRespond with ONLY a JSON object (no markdown fencing):\n{\"breaking\": true/false, \"confidence\": 0.0-1.0, \"risks\": [\"list of specific risks if any\"], \"summary\": \"one sentence summary of whether the breaking changes affect this repo based on the actual usage shown above\", \"applies_to_repo\": true/false}"')
+
+  jq -n \
+    --argjson prompt "$PROMPT" \
+    '[{
+      role: "user",
+      content: [{
+        text: $prompt
+      }]
+    }]' > /tmp/bedrock_messages.json
+
+  echo '{"maxTokens":512}' > /tmp/bedrock_config.json
+
+  # Fail CLOSED on Bedrock error (the old fallback silently
+  # defaulted to breaking=false — an unanalyzed dep is NOT safe).
+  if ! AI_RESPONSE=$(aws bedrock-runtime converse \
+    --model-id "$BEDROCK_MODEL_ID" \
+    --messages file:///tmp/bedrock_messages.json \
+    --inference-config file:///tmp/bedrock_config.json \
+    --output json 2>/tmp/bedrock_err.log); then
+    echo "::warning::Bedrock analysis FAILED for ${DEP_NAME} — failing closed"
+    CHECK_ERRORS=$((CHECK_ERRORS + 1))
+    AI_RESPONSE='{"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":0,\"risks\":[\"API call failed\"],\"summary\":\"Analysis errored — routed to manual review\"}"}]}}}'
+  fi
+
+  if [ -s /tmp/bedrock_err.log ]; then
+    echo "Bedrock stderr: $(cat /tmp/bedrock_err.log)"
+  fi
+
+  # Parse the Bedrock Converse response
+  AI_TEXT=$(echo "$AI_RESPONSE" | jq -r '.output.message.content[0].text // "{}"')
+  # Strip markdown fences if present, then validate JSON
+  AI_TEXT=$(echo "$AI_TEXT" | sed '/^```/d' | sed 's/^[[:space:]]*//')
+  if ! echo "$AI_TEXT" | jq empty 2>/dev/null; then
+    # Try extracting JSON between first { and last }
+    AI_TEXT=$(echo "$AI_TEXT" | sed -n '/^{/,/^}/p' | head -20)
+    if ! echo "$AI_TEXT" | jq empty 2>/dev/null; then
+      echo "::warning::Failed to parse AI response for ${DEP_NAME} — failing closed"
+      CHECK_ERRORS=$((CHECK_ERRORS + 1))
+      AI_TEXT='{"breaking":false,"confidence":0,"risks":["Failed to parse AI response"],"summary":"Analysis unparseable — routed to manual review"}'
+    fi
+  fi
+  HAS_BREAKING=$(echo "$AI_TEXT" | jq -r '.breaking // false')
+  CONFIDENCE=$(echo "$AI_TEXT" | jq -r '.confidence // 0')
+  RISK_SUMMARY=$(echo "$AI_TEXT" | jq -r '.summary // "Analysis unavailable"')
+  AI_RISKS=$(echo "$AI_TEXT" | jq -r '.risks // []')
+  APPLIES_TO_REPO=$(echo "$AI_TEXT" | jq -r '.applies_to_repo // true')
+
+  # Override: major bump is always flagged regardless of AI
+  if [ "$SEMVER_TYPE" = "major" ]; then
+    HAS_BREAKING="true"
+  fi
+
+  # ---------------------------------------------------------
+  # Write shared cache (universal changelog + semver analysis)
+  # ---------------------------------------------------------
+  # Read existing cache entry (from supply chain check) or start fresh
+  if [ -f /tmp/cached_analysis.json ]; then
+    EXISTING=$(cat /tmp/cached_analysis.json)
+  else
+    EXISTING='{}'
+  fi
+
+  echo "$EXISTING" | jq \
+    --arg dep "$DEP_NAME" \
+    --arg ver "$TO_VERSION" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg sv_type "$SEMVER_TYPE" \
+    --arg sv_from "$FROM_VERSION" \
+    --arg sv_to "$TO_VERSION" \
+    --argjson breaking "$([ "$HAS_BREAKING" = "true" ] && echo true || echo false)" \
+    --argjson conf "$CONFIDENCE" \
+    --arg summary "$RISK_SUMMARY" \
+    --argjson risks "$AI_RISKS" \
+    '. + {
+      dependency: $dep,
+      version: $ver,
+      analyzed_at: $ts,
+      semver: { type: $sv_type, from: $sv_from, to: $sv_to },
+      changelog: { breaking: $breaking, confidence: ($conf | tonumber), summary: $summary, risks: $risks }
+    }' > /tmp/merged_analysis.json
+
+  aws s3 cp /tmp/merged_analysis.json "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" \
+    --content-type "application/json" --quiet
+fi
+
+# ---------------------------------------------------------
+# Repo-scoped applicability analysis
+# On shared cache hit + repo miss, run a lightweight Bedrock
+# call that only assesses whether the known breaking changes
+# apply to this repo's usage patterns.
+# ---------------------------------------------------------
+if [ "$SHARED_CACHE_HIT" = "true" ] && [ "$REPO_CACHE_HIT" = "false" ]; then
+  echo "Shared cache hit but no repo analysis — running applicability check for ${GITHUB_REPOSITORY}"
+  USAGE_CONTEXT=""
+  if [ -f "/tmp/dep_usage_${SAFE_DEP_NAME}.txt" ]; then
+    USAGE_CONTEXT=$(cat "/tmp/dep_usage_${SAFE_DEP_NAME}.txt")
+  fi
+
+  APPLY_PROMPT=$(jq -n \
+    --arg dep "$DEP_NAME" \
+    --arg from "$FROM_VERSION" \
+    --arg to "$TO_VERSION" \
+    --arg summary "$RISK_SUMMARY" \
+    --arg usage "$USAGE_CONTEXT" \
+    '"You are a dependency update analyzer. A previous analysis found these breaking changes:\n\nDependency: " + $dep + "\nFrom: " + $from + "\nTo: " + $to + "\nBreaking change summary: " + $summary + "\n\nHere is how this dependency is actually used in the consuming repository:\n" + $usage + "\n\nBased on the actual usage shown, do the breaking changes affect this repository?\n\nRespond with ONLY a JSON object (no markdown fencing):\n{\"applies_to_repo\": true/false, \"summary\": \"one sentence explaining whether and why the breaking changes affect this specific usage\"}"')
+
+  jq -n \
+    --argjson prompt "$APPLY_PROMPT" \
+    '[{
+      role: "user",
+      content: [{
+        text: $prompt
+      }]
+    }]' > /tmp/bedrock_apply_messages.json
+
+  echo '{"maxTokens":256}' > /tmp/bedrock_apply_config.json
+
+  # Applicability errors stay conservative (assume it applies) but
+  # do NOT count as CHECK_ERRORS: applies_to_repo never gates the
+  # decision, and defaulting to true is already the safe direction.
+  APPLY_RESPONSE=$(aws bedrock-runtime converse \
+    --model-id "$BEDROCK_MODEL_ID" \
+    --messages file:///tmp/bedrock_apply_messages.json \
+    --inference-config file:///tmp/bedrock_apply_config.json \
+    --output json 2>/tmp/bedrock_apply_err.log \
+    || echo '{"output":{"message":{"content":[{"text":"{\"applies_to_repo\":true,\"summary\":\"Unable to assess applicability — defaulting to assume it applies\"}"}]}}}')
+
+  APPLY_TEXT=$(echo "$APPLY_RESPONSE" | jq -r '.output.message.content[0].text // "{}"')
+  APPLY_TEXT=$(echo "$APPLY_TEXT" | sed '/^```/d' | sed 's/^[[:space:]]*//')
+  if ! echo "$APPLY_TEXT" | jq empty 2>/dev/null; then
+    APPLY_TEXT=$(echo "$APPLY_TEXT" | sed -n '/^{/,/^}/p' | head -20)
+    if ! echo "$APPLY_TEXT" | jq empty 2>/dev/null; then
+      APPLY_TEXT='{"applies_to_repo":true,"summary":"Unable to parse — defaulting to assume it applies"}'
+    fi
+  fi
+  APPLIES_TO_REPO=$(echo "$APPLY_TEXT" | jq -r '.applies_to_repo // true')
+  RISK_SUMMARY=$(echo "$APPLY_TEXT" | jq -r '.summary // "'"$RISK_SUMMARY"'"')
+fi
+
+# ---------------------------------------------------------
+# Write repo-scoped cache (applicability analysis)
+# ---------------------------------------------------------
+if [ "$REPO_CACHE_HIT" = "false" ]; then
+  jq -n \
+    --arg dep "$DEP_NAME" \
+    --arg ver "$TO_VERSION" \
+    --arg repo "$GITHUB_REPOSITORY" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson applies "$([ "$APPLIES_TO_REPO" = "true" ] && echo true || echo false)" \
+    --arg summary "$RISK_SUMMARY" \
+    '{
+      dependency: $dep,
+      version: $ver,
+      repository: $repo,
+      analyzed_at: $ts,
+      applies_to_repo: $applies,
+      risk_summary: $summary
+    }' > /tmp/repo_analysis.json
+
+  aws s3 cp /tmp/repo_analysis.json "s3://${S3_BUCKET}/${REPO_CACHE_KEY}" \
+    --content-type "application/json" --quiet
+fi
+
+# -----------------------------------------------------------
+# Fold this dependency into the aggregates
+# -----------------------------------------------------------
+if [ "$(semver_rank "$SEMVER_TYPE")" -gt "$(semver_rank "$AGG_SEMVER")" ]; then
+  AGG_SEMVER="$SEMVER_TYPE"
+fi
+[ "$HAS_BREAKING" = "true" ]    && AGG_BREAKING="true"
+[ "$APPLIES_TO_REPO" = "true" ] && AGG_APPLIES="true"
+if [ -z "$AGG_CONF" ] || [ "$(echo "$CONFIDENCE < $AGG_CONF" | bc -l 2>/dev/null || echo 0)" -eq 1 ]; then
+  AGG_CONF="$CONFIDENCE"
+fi
+AGG_SUMMARY="${AGG_SUMMARY}${DEP_NAME}: ${RISK_SUMMARY} | "
+}
+
+# -----------------------------------------------------------
+# Iterate every dependency in the PR (grouped-PR support)
+# -----------------------------------------------------------
+DEPS_FILE=/tmp/deps.tsv
+printf '%s' "${DEPS_B64:-}" | base64 -d > "$DEPS_FILE" 2>/dev/null || : > "$DEPS_FILE"
+if [ "${PARSE_ERROR:-false}" = "true" ] || [ ! -s "$DEPS_FILE" ]; then
+  echo "::warning::dependency list unavailable — failing closed"
+  CHECK_ERRORS=$((CHECK_ERRORS + 1))
+  AGG_SEMVER="unknown"
+else
+  while IFS=$'\t' read -r -u3 D_NAME D_FROM D_TO || [ -n "${D_NAME:-}" ]; do
+    [ -n "$D_NAME" ] && [ "$D_NAME" != "-" ] || { D_NAME=""; continue; }
+    echo "=== breaking-change check: ${D_NAME} ${D_FROM} -> ${D_TO} ==="
+    check_one "$D_NAME" "$D_FROM" "$D_TO"
+    D_NAME=""
+  done 3< "$DEPS_FILE"
+fi
+
+[ -n "$AGG_CONF" ] || AGG_CONF="0"
+echo "semver_type=${AGG_SEMVER}" >> "$GITHUB_OUTPUT"
+echo "has_breaking_changes=${AGG_BREAKING}" >> "$GITHUB_OUTPUT"
+echo "confidence=${AGG_CONF}" >> "$GITHUB_OUTPUT"
+echo "applies_to_repo=${AGG_APPLIES}" >> "$GITHUB_OUTPUT"
+echo "check_errors=${CHECK_ERRORS}" >> "$GITHUB_OUTPUT"
+
+# Escape newlines + truncate for GITHUB_OUTPUT
+SAFE_SUMMARY=$(echo "$AGG_SUMMARY" | tr '\n' ' ' | head -c 900)
+echo "risk_summary=${SAFE_SUMMARY}" >> "$GITHUB_OUTPUT"

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2001,SC2034,SC2129
+#
+# supply-chain-check.sh — OSV + OpenSSF Scorecard supply-chain gate for the
+# Dependabot auto-merge workflow (.github/workflows/org-dependabot-auto-merge.yml,
+# job: supply_chain_check).
+#
+# EXTRACTED VERBATIM (grade-A plan #10) from the former inline
+# `/tmp/supply_chain_check.sh` heredoc so the logic is committed, unit-testable,
+# and shellcheck-covered. The emitted decision is byte-identical to that inline
+# heredoc — this is a pure refactor, no behavior change. The disabled codes are
+# pre-existing style/warning patterns in the verbatim logic (SC2001 echo|sed,
+# SC2034 unused read field, SC2129 grouped redirects); left as-is to keep
+# behavior provably unchanged.
+#
+# Runs after `aws-actions/configure-aws-credentials` (needs AWS creds for the S3
+# analysis cache) in the consumer's checkout; the workflow invokes it from the
+# pinned Coalfire-CF/Actions self-checkout (see the workflow header comment).
+#
+# Inputs (environment, set by the workflow step `env:` block):
+#   DEP_NAME             primary dependency name       (classify.outputs.dep_name)
+#   TO_VERSION           target version                (classify.outputs.to_version)
+#   ECOSYSTEM            Dependabot package-ecosystem  (classify.outputs.ecosystem)
+#   DEPS_B64             base64 TSV of every dep in the PR (grouped-PR support)
+#   PARSE_ERROR          "true" if dep list unparseable -> fail closed
+#   S3_BUCKET            shared analysis cache bucket  (inputs.s3_cache_bucket)
+#   CACHE_TTL_DAYS       cache freshness window        (inputs.cache_ttl_days)
+#   SCORECARD_THRESHOLD  min OpenSSF Scorecard score   (inputs.scorecard_threshold)
+#   GITHUB_OUTPUT        (Actions-provided) step-output file
+#
+# Outputs (appended to $GITHUB_OUTPUT):
+#   osv_clear  scorecard_pass  scorecard_score  cache_hit  check_errors
+#
+set -euo pipefail
+
+# Grouped-PR support: every dependency in the PR is checked
+# individually and folded into AND/OR aggregates. Any per-dep
+# query ERROR (as opposed to a clean result) increments
+# CHECK_ERRORS and the decide job fails CLOSED to manual review.
+CHECK_ERRORS=0
+AGG_OSV_CLEAR="true"
+AGG_SC_PASS="true"
+AGG_SC_SCORE=""
+AGG_CACHE_HIT="true"
+
+check_one() {
+local DEP_NAME="$1" TO_VERSION="$2"
+
+# -----------------------------------------------------------
+# Normalize dependency name for S3 key (replace / with --)
+# -----------------------------------------------------------
+SAFE_DEP_NAME=$(echo "$DEP_NAME" | sed 's|/|--|g')
+CACHE_KEY="analyses/shared/${SAFE_DEP_NAME}/${TO_VERSION}.json"
+
+# -----------------------------------------------------------
+# Check S3 cache (shared — supply chain data is universal)
+# -----------------------------------------------------------
+CACHE_HIT="false"
+OSV_CLEAR="true"
+SCORECARD_PASS="true"
+SCORECARD_SCORE="0"
+
+CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${CACHE_KEY}" /tmp/cached_analysis.json 2>/dev/null && echo "ok" || echo "miss")
+if [ "$CACHED" = "ok" ]; then
+  # Validate TTL
+  ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json)
+  if [ -n "$ANALYZED_AT" ]; then
+    ANALYZED_EPOCH=$(date -d "$ANALYZED_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$ANALYZED_AT" +%s 2>/dev/null || echo 0)
+    NOW_EPOCH=$(date +%s)
+    AGE_DAYS=$(( (NOW_EPOCH - ANALYZED_EPOCH) / 86400 ))
+    if [ "$AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
+      CACHE_HIT="true"
+      OSV_CLEAR=$(jq -r '.osv.clear // "true"' /tmp/cached_analysis.json)
+      SCORECARD_PASS=$(jq -r '.scorecard.pass // "true"' /tmp/cached_analysis.json)
+      SCORECARD_SCORE=$(jq -r '.scorecard.score // "0"' /tmp/cached_analysis.json)
+      echo "Cache hit for ${DEP_NAME}@${TO_VERSION} (age: ${AGE_DAYS}d)"
+    fi
+  fi
+fi
+
+if [ "$CACHE_HIT" = "false" ]; then
+  echo "Cache miss — running live checks for ${DEP_NAME}@${TO_VERSION}"
+
+  # ---------------------------------------------------------
+  # OSV.dev vulnerability check
+  # ---------------------------------------------------------
+  # Map Dependabot ecosystems to OSV ecosystems
+  OSV_ECOSYSTEM=""
+  case "$ECOSYSTEM" in
+    github-actions|github_actions) OSV_ECOSYSTEM="GitHub Actions" ;;
+    npm)            OSV_ECOSYSTEM="npm" ;;
+    pip)            OSV_ECOSYSTEM="PyPI" ;;
+    gomod)          OSV_ECOSYSTEM="Go" ;;
+    cargo)          OSV_ECOSYSTEM="crates.io" ;;
+    nuget)          OSV_ECOSYSTEM="NuGet" ;;
+    *)              OSV_ECOSYSTEM="" ;;
+  esac
+
+  OSV_VULNS="[]"
+  if [ -n "$OSV_ECOSYSTEM" ]; then
+    # Fail CLOSED on query error: a failed OSV call is NOT a clean
+    # result (the old `|| echo` fail-open let vulns through silently).
+    if ! OSV_RESPONSE=$(curl -sf --max-time 30 \
+      -X POST "https://api.osv.dev/v1/query" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n \
+        --arg pkg "$DEP_NAME" \
+        --arg ver "$TO_VERSION" \
+        --arg eco "$OSV_ECOSYSTEM" \
+        '{package: {name: $pkg, ecosystem: $eco}, version: $ver}')" \
+      2>/dev/null); then
+      echo "::warning::OSV query FAILED for ${DEP_NAME}@${TO_VERSION} — failing closed"
+      CHECK_ERRORS=$((CHECK_ERRORS + 1))
+      OSV_RESPONSE='{"vulns":[]}'
+    fi
+    OSV_VULNS=$(echo "$OSV_RESPONSE" | jq '.vulns // []')
+    VULN_COUNT=$(echo "$OSV_VULNS" | jq 'length')
+    if [ "$VULN_COUNT" -gt 0 ]; then
+      OSV_CLEAR="false"
+      echo "::warning::Found ${VULN_COUNT} known vulnerabilities for ${DEP_NAME}@${TO_VERSION}"
+    fi
+  else
+    echo "No OSV ecosystem mapping for '${ECOSYSTEM}' — skipping OSV check"
+  fi
+
+  # ---------------------------------------------------------
+  # OpenSSF Scorecard check
+  # ---------------------------------------------------------
+  # Extract the GitHub owner/repo from the dependency name
+  SCORECARD_REPO=""
+  case "$ECOSYSTEM" in
+    github-actions|github_actions)
+      # actions/checkout -> github.com/actions/checkout
+      SCORECARD_REPO="github.com/${DEP_NAME}"
+      ;;
+    npm|pip|gomod|cargo)
+      # Attempt to resolve via the dependency name if it looks like a GitHub path
+      if echo "$DEP_NAME" | grep -qE '^github\.com/'; then
+        SCORECARD_REPO="${DEP_NAME}"
+      elif echo "$DEP_NAME" | grep -qE '^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$'; then
+        SCORECARD_REPO="github.com/${DEP_NAME}"
+      fi
+      ;;
+  esac
+
+  if [ -n "$SCORECARD_REPO" ]; then
+    SCORECARD_RESPONSE=$(curl -sf --max-time 30 \
+      "https://api.securityscorecards.dev/projects/${SCORECARD_REPO}" \
+      2>/dev/null || echo '{}')
+    SCORECARD_SCORE=$(echo "$SCORECARD_RESPONSE" | jq -r '.score // 0')
+
+    if [ "$(echo "$SCORECARD_SCORE < $SCORECARD_THRESHOLD" | bc -l)" -eq 1 ]; then
+      SCORECARD_PASS="false"
+      echo "::warning::Scorecard ${SCORECARD_SCORE}/10 below threshold ${SCORECARD_THRESHOLD} for ${SCORECARD_REPO}"
+    else
+      echo "Scorecard ${SCORECARD_SCORE}/10 meets threshold for ${SCORECARD_REPO}"
+    fi
+  else
+    echo "Cannot resolve Scorecard repo for '${DEP_NAME}' — skipping Scorecard check"
+    SCORECARD_SCORE="N/A"
+  fi
+
+  # ---------------------------------------------------------
+  # Write to S3 cache (partial — supply chain fields only)
+  # Breaking change check will merge its fields in separately
+  # ---------------------------------------------------------
+  jq -n \
+    --arg dep "$DEP_NAME" \
+    --arg ver "$TO_VERSION" \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson osv_clear "$([ "$OSV_CLEAR" = "true" ] && echo true || echo false)" \
+    --argjson osv_vulns "$OSV_VULNS" \
+    --arg sc_score "$SCORECARD_SCORE" \
+    --argjson sc_pass "$([ "$SCORECARD_PASS" = "true" ] && echo true || echo false)" \
+    '{
+      dependency: $dep,
+      version: $ver,
+      analyzed_at: $ts,
+      osv: { clear: $osv_clear, vulns: $osv_vulns },
+      scorecard: { score: $sc_score, pass: $sc_pass }
+    }' > /tmp/supply_chain_result.json
+
+  aws s3 cp /tmp/supply_chain_result.json "s3://${S3_BUCKET}/${CACHE_KEY}" \
+    --content-type "application/json" --quiet
+fi
+
+# -----------------------------------------------------------
+# Fold this dependency into the aggregates
+# -----------------------------------------------------------
+[ "$OSV_CLEAR" = "true" ]      || AGG_OSV_CLEAR="false"
+[ "$SCORECARD_PASS" = "true" ] || AGG_SC_PASS="false"
+[ "$CACHE_HIT" = "true" ]      || AGG_CACHE_HIT="false"
+if [ "$SCORECARD_SCORE" != "N/A" ]; then
+  if [ -z "$AGG_SC_SCORE" ] || [ "$(echo "$SCORECARD_SCORE < $AGG_SC_SCORE" | bc -l)" -eq 1 ]; then
+    AGG_SC_SCORE="$SCORECARD_SCORE"
+  fi
+fi
+}
+
+# -----------------------------------------------------------
+# Iterate every dependency in the PR (grouped-PR support)
+# -----------------------------------------------------------
+DEPS_FILE=/tmp/deps.tsv
+printf '%s' "${DEPS_B64:-}" | base64 -d > "$DEPS_FILE" 2>/dev/null || : > "$DEPS_FILE"
+if [ "${PARSE_ERROR:-false}" = "true" ] || [ ! -s "$DEPS_FILE" ]; then
+  echo "::warning::dependency list unavailable — failing closed"
+  CHECK_ERRORS=$((CHECK_ERRORS + 1))
+else
+  # `|| [ -n "$D_NAME" ]` processes a final line with no trailing
+  # newline; fd 3 keeps loop input safe from stdin-reading commands.
+  while IFS=$'\t' read -r -u3 D_NAME D_FROM D_TO || [ -n "${D_NAME:-}" ]; do
+    [ -n "$D_NAME" ] && [ "$D_NAME" != "-" ] || { D_NAME=""; continue; }
+    echo "=== supply-chain check: ${D_NAME}@${D_TO} ==="
+    check_one "$D_NAME" "$D_TO"
+    D_NAME=""
+  done 3< "$DEPS_FILE"
+fi
+
+[ -n "$AGG_SC_SCORE" ] || AGG_SC_SCORE="N/A"
+echo "osv_clear=${AGG_OSV_CLEAR}" >> "$GITHUB_OUTPUT"
+echo "scorecard_pass=${AGG_SC_PASS}" >> "$GITHUB_OUTPUT"
+echo "scorecard_score=${AGG_SC_SCORE}" >> "$GITHUB_OUTPUT"
+echo "cache_hit=${AGG_CACHE_HIT}" >> "$GITHUB_OUTPUT"
+echo "check_errors=${CHECK_ERRORS}" >> "$GITHUB_OUTPUT"

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2001,SC2034,SC2129
+# shellcheck disable=SC2001,SC2034,SC2129,SC2015
+# SC2015: the `[ ... ] && [ ... ] || { ...; continue; }` guard-continue is the
+# original heredoc idiom, intentional (not if-then-else) — kept byte-identical.
 #
 # supply-chain-check.sh — OSV + OpenSSF Scorecard supply-chain gate for the
 # Dependabot auto-merge workflow (.github/workflows/org-dependabot-auto-merge.yml,

--- a/scripts/version-band-check.sh
+++ b/scripts/version-band-check.sh
@@ -84,7 +84,10 @@ while IFS= read -r entry; do
   # Ignore commented lines.
   printf '%s' "$content" | grep -Eq '^[[:space:]]*#' && continue
   val="$(printf '%s' "$content" | sed -E "s/.*terraform_version:[[:space:]]*//; s/[\"' ]//g; s/#.*//")"
-  # Skip expression/interpolated pins and empty values.
+  # Skip expression/interpolated pins and empty values. The single-quoted
+  # '${{' is an intentional literal (GitHub Actions expression syntax), not a
+  # variable to expand — SC2016 is a false positive here.
+  # shellcheck disable=SC2016
   [[ -z "$val" || "$val" == *'${{'* ]] && continue
   if [[ ! "$val" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     emit_fail "$file" "$lineno" "terraform_version pin is not a concrete X.Y.Z version: '${val}'"

--- a/tests/auto-merge-decide.test.sh
+++ b/tests/auto-merge-decide.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Characterization meta-test for scripts/auto-merge-decide.sh (grade-A plan #10).
+#
+# This is a CHARACTERIZATION test: it pins the decision + label baseline the
+# auto-merge decide gate produces TODAY, so the extraction from the inline
+# heredoc (and any later change, e.g. the #12 label-wiring pass) is regression
+# guarded. The gate is pure bash — it reads the upstream jobs' outputs from the
+# environment and reduces them to (decision, risk_level, blocked_labels); no
+# network / AWS is involved, so it runs fully offline.
+#
+# Each fixture under tests/fixtures/auto-merge-decide/*.env sets the complete
+# input environment for one of the four decision paths and is asserted against
+# the exact decision AND blocked_labels the gate emits:
+#   major_blocked       -> block   / " blocked/major-bump blocked/major-bump"
+#   osv_blocked         -> block   / " blocked/known-vuln"
+#   parse_error_manual  -> manual  / ""            (fail-closed, no blocker)
+#   first_party_waiver  -> approve / ""            (Scorecard waived, RFC-0010)
+#
+# NOTE on the doubled blocked/major-bump: both the group-aware UPDATE_TYPE_META
+# gate and the aggregate SEMVER_TYPE=major gate append the label. That is the
+# characterized present-day behavior — asserted verbatim, not "fixed" here.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DECIDE="${REPO_ROOT}/scripts/auto-merge-decide.sh"
+FIXTURES="${SCRIPT_DIR}/fixtures/auto-merge-decide"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+
+[ -f "$DECIDE" ] || fail "decide script not found at $DECIDE"
+[ -x "$DECIDE" ] || chmod +x "$DECIDE"
+
+# run_fixture <fixture.env> — source the fixture env, run the decide gate with
+# GITHUB_OUTPUT/GITHUB_STEP_SUMMARY pointed at temp files, print the raw output
+# file. Runs in a subshell so each fixture's env is isolated.
+run_fixture() {
+  local fx="$1" out summ
+  out="$(mktemp)"; summ="$(mktemp)"
+  (
+    set -a
+    # shellcheck disable=SC1090
+    . "${FIXTURES}/${fx}.env"
+    set +a
+    GITHUB_OUTPUT="$out" GITHUB_STEP_SUMMARY="$summ" bash "$DECIDE" >/dev/null 2>&1
+  ) || { rm -f "$out" "$summ"; fail "${fx}: decide script exited non-zero"; }
+  cat "$out"
+  rm -f "$out" "$summ"
+}
+
+getval() { sed -n "s/^$1=//p" <<< "$2" | head -1; }
+
+# <fixture> <want_decision> <want_blocked_labels> <want_risk>
+assert_path() {
+  local fx="$1" wd="$2" wbl="$3" wr="$4" raw d bl r
+  raw="$(run_fixture "$fx")"
+  d="$(getval decision "$raw")"
+  bl="$(getval blocked_labels "$raw")"
+  r="$(getval risk_level "$raw")"
+  [ "$d" = "$wd" ]   || fail "${fx}: decision '${d}' != expected '${wd}'"
+  [ "$bl" = "$wbl" ] || fail "${fx}: blocked_labels '${bl}' != expected '${wbl}'"
+  [ "$r" = "$wr" ]   || fail "${fx}: risk_level '${r}' != expected '${wr}'"
+  echo "OK: ${fx} -> decision=${d} risk=${r} blocked_labels='${bl}'"
+}
+
+# ---- The four characterized decision paths (expected-PASS) ----
+assert_path major_blocked      block   " blocked/major-bump blocked/major-bump" high
+assert_path osv_blocked        block   " blocked/known-vuln"                    high
+assert_path parse_error_manual manual  ""                                       high
+assert_path first_party_waiver approve ""                                       medium
+
+# ---- Sentinel (expected-FAIL guard): a semver-major bump must NEVER approve ----
+# If a future edit wrongly cleared the major gate to merge/approved, this fires.
+major_decision="$(getval decision "$(run_fixture major_blocked)")"
+[ "$major_decision" != "approve" ] \
+  || fail "SENTINEL: semver-major fixture cleared to 'approve' — the major gate no longer fires!"
+echo "OK: sentinel — semver-major never approves (decision=${major_decision})"
+
+echo "ALL TESTS PASSED"

--- a/tests/fixtures/auto-merge-decide/first_party_waiver.env
+++ b/tests/fixtures/auto-merge-decide/first_party_waiver.env
@@ -1,0 +1,18 @@
+# Path 4: first-party org bump with no Scorecard data → the Scorecard gate is
+# WAIVED (RFC-0010) and the PR still approves. Non-major minor bump → risk medium.
+# All other gates (OSV/major/breaking) still apply — they just pass here.
+DEP_NAME='Coalfire-CF/terraform-aws-vpc'
+TO_VERSION='1.4.0'
+UPDATE_TYPE_META='version-update:semver-minor'
+SEMVER_TYPE='minor'
+HAS_BREAKING='false'
+OSV_CLEAR='true'
+SCORECARD_PASS='false'
+SCORECARD_SCORE='N/A'
+IS_FIRST_PARTY='true'
+APPLIES_TO_REPO='true'
+RISK_SUMMARY='No breaking changes'
+DEP_GROUP=''
+PARSE_ERROR='false'
+SC_ERRORS='0'
+BC_ERRORS='0'

--- a/tests/fixtures/auto-merge-decide/major_blocked.env
+++ b/tests/fixtures/auto-merge-decide/major_blocked.env
@@ -1,0 +1,18 @@
+# Path 1: major bump → blocked. Both the group-aware meta gate
+# (UPDATE_TYPE_META *semver-major*) and the aggregate SEMVER_TYPE=major gate fire,
+# so blocked/major-bump is appended twice (characterized baseline, not a bug).
+DEP_NAME='actions/checkout'
+TO_VERSION='5.0.0'
+UPDATE_TYPE_META='version-update:semver-major'
+SEMVER_TYPE='major'
+HAS_BREAKING='true'
+OSV_CLEAR='true'
+SCORECARD_PASS='true'
+SCORECARD_SCORE='8.5'
+IS_FIRST_PARTY='false'
+APPLIES_TO_REPO='true'
+RISK_SUMMARY='Major version bump'
+DEP_GROUP=''
+PARSE_ERROR='false'
+SC_ERRORS='0'
+BC_ERRORS='0'

--- a/tests/fixtures/auto-merge-decide/osv_blocked.env
+++ b/tests/fixtures/auto-merge-decide/osv_blocked.env
@@ -1,0 +1,17 @@
+# Path 2: known OSV vulnerability in the target version → blocked.
+# Non-major, scorecard passes, no breaking — only the OSV gate fires.
+DEP_NAME='lodash'
+TO_VERSION='4.17.20'
+UPDATE_TYPE_META='version-update:semver-patch'
+SEMVER_TYPE='patch'
+HAS_BREAKING='false'
+OSV_CLEAR='false'
+SCORECARD_PASS='true'
+SCORECARD_SCORE='7.0'
+IS_FIRST_PARTY='false'
+APPLIES_TO_REPO='true'
+RISK_SUMMARY='No breaking changes'
+DEP_GROUP=''
+PARSE_ERROR='false'
+SC_ERRORS='0'
+BC_ERRORS='0'

--- a/tests/fixtures/auto-merge-decide/parse_error_manual.env
+++ b/tests/fixtures/auto-merge-decide/parse_error_manual.env
@@ -1,0 +1,18 @@
+# Path 3: dependency-list parse ambiguity / partial checks → fail closed to
+# manual review. Nothing affirmatively failed (no blocker), but PARSE_ERROR=true
+# downgrades the would-be approve to manual (no blocked/* labels).
+DEP_NAME='grouped-update'
+TO_VERSION='n/a'
+UPDATE_TYPE_META=''
+SEMVER_TYPE='unknown'
+HAS_BREAKING='false'
+OSV_CLEAR='true'
+SCORECARD_PASS='true'
+SCORECARD_SCORE='N/A'
+IS_FIRST_PARTY='false'
+APPLIES_TO_REPO='true'
+RISK_SUMMARY='Dependency list unavailable'
+DEP_GROUP='github-actions'
+PARSE_ERROR='true'
+SC_ERRORS='0'
+BC_ERRORS='0'


### PR DESCRIPTION
## Item #10 — Extract + test the auto-merge decision logic

Grade-A plan (`governance/reviews/2026-07-06-actions-platform-grade-a-plan.md`) **item #10**. Pure refactor of `org-dependabot-auto-merge.yml`: the two inline `/tmp` heredocs and the decide gate become committed, unit-tested, shellcheck-clean `scripts/*.sh` invoked from a pinned self-checkout. **No behavior change — decisions are byte-identical.**

### What changed
- **`scripts/supply-chain-check.sh`** (from the `/tmp/supply_chain_check.sh` heredoc), **`scripts/breaking-change-check.sh`** (from `/tmp/breaking_change_check.sh`), **`scripts/auto-merge-decide.sh`** (from the decide `run:` gate). Each carries a doc-comment **input contract** (env vars in / `$GITHUB_OUTPUT` keys out).
- **Workflow**: new `actions_ref` input (default `main`, identical model to `org-opa`/`org-terraform-source-pin`/`org-terraform-version-band`). The `supply_chain_check`, `breaking_change_check`, and `decide` jobs each self-check-out `Coalfire-CF/Actions` into `./actions-tools` (per `org-opa.yml:88-93`) and run `actions-tools/scripts/<name>.sh`. Step `env:` blocks preserved verbatim.
- **`tests/auto-merge-decide.test.sh` + `tests/fixtures/auto-merge-decide/*.env`** — characterize the 4 decision paths, asserting **decision *and* blocked_labels**.
- **`test-scripts.yml`**: new `shellcheck` job (full/default severity) over `scripts/*.sh`.
- **`scripts/version-band-check.sh`**: one justified `# shellcheck disable=SC2016` (intentional literal `${{`) so the new dir-wide full-shellcheck gate is green.

### Byte-identical guarantee
Heredocs are `<<'BASH'` (no interpolation) and the `run: |` block dedents 10 spaces before writing to `/tmp`. Each extracted script body was `diff`'d against the exact `/tmp` content → **IDENTICAL** for all three. The only additions are comment headers + shellcheck-disable comments (non-executing).

### Self-checkout / `actions_ref` (reviewer note)
Moving executable decision logic to a self-checkout means it resolves at `actions_ref` (default `main`) — **the repo's established gate model** (`gate-config.yml` + the three gate callers already do exactly this). Pinning the workflow by SHA does not by itself pin the scripts; consumers who want the logic pinned pass `actions_ref: <release-sha> # vX.Y.Z`. Documented in the workflow header comment **and** `docs/ORG_DEPENDABOT_AUTO_MERGE.md` ("Pinning the decision logic").

### Acceptance criteria
- [x] **AC-1** Two heredocs + decide gate → committed `scripts/*.sh` invoked by the workflow, with a documented `GITHUB_ENV`/env input contract.
- [x] **AC-2** Characterization fixtures under `tests/fixtures/` cover the 4 paths (major-blocked, OSV-blocked, parse-error→manual, first-party-waiver), asserting the **same** verdict the inline logic produces today (+ `blocked_labels` baseline per lead requirement).
- [x] **AC-3** New `tests/auto-merge-decide.test.sh` runs them (mirrors `source-pin-check.test.sh`).
- [x] **AC-4** `shellcheck` runs over `scripts/*.sh` in `test-scripts.yml`.

### Validated testing (local)
```
$ bash tests/*.test.sh
PASS: tests/auto-merge-decide.test.sh
PASS: tests/gate-config-resolve.test.sh
PASS: tests/source-pin-check.test.sh
PASS: tests/uses-pin-check.test.sh
PASS: tests/version-band-check.test.sh

$ shellcheck scripts/*.sh            # exit 0, CLEAN
$ SHELLCHECK_OPTS="-S warning" actionlint    # exit 0, CLEAN
```
Characterization output (expected-PASS):
```
OK: major_blocked      -> decision=block   risk=high   blocked_labels=' blocked/major-bump blocked/major-bump'
OK: osv_blocked        -> decision=block   risk=high   blocked_labels=' blocked/known-vuln'
OK: parse_error_manual -> decision=manual  risk=high   blocked_labels=''
OK: first_party_waiver -> decision=approve risk=medium blocked_labels=''
OK: sentinel — semver-major never approves (decision=block)
ALL TESTS PASSED
```
**Expected-FAIL demonstrations** (both confirmed, not committed):
- Neutralizing the major gate → `NOT OK: major_blocked: decision 'approve' != expected 'block'` (test + sentinel fire).
- Unquoted `echo $x` → `SC2086 (info): Double quote to prevent globbing...` (shellcheck exits non-zero).

Rebased onto latest `main` (`6f8a99b`). **Do not merge — lead merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S
