### PR TITLE
feat(auto-merge): scheduled reconcile sweeper for wedged approved PRs (grade-A #14)

### DIFF
--- a/.github/workflows/org-dependabot-reconcile.yml
+++ b/.github/workflows/org-dependabot-reconcile.yml
@@ -1,0 +1,114 @@
+name: Dependabot Reconcile Sweeper
+
+# Scheduled safety net (grade-A plan #14) for wedged Dependabot PRs.
+#
+# The auto-merge engine's direct-merge fallback runs only inside a PR-triggered
+# run. A PR that goes GREEN *after* its last event — with auto-merge un-latched
+# (repos without required status checks) — is never re-driven and sits
+# approved-but-unmerged. This sweep converges them: it enumerates open org PRs
+# labeled `merge/approved` and, for each, re-applies the SAME green gate as the
+# auto-merge fallback (scripts/pr-green-merge.sh) and direct-merges the green
+# ones. It re-checks freshness live and never merges a red/pending/draft/closed
+# or unlabeled PR.
+#
+# SAFETY: dry_run defaults to TRUE everywhere (scheduled runs included) — the
+# sweep logs would-merge decisions and performs ZERO mutating calls. To enable
+# live healing, dispatch manually with dry_run=false (validate first), or flip
+# the schedule default once the dry-run window looks correct.
+#
+# The auto-merge fallback's own adoption of scripts/pr-green-merge.sh is owned by
+# the #9/#12/#13 follow-up chain on org-dependabot-auto-merge.yml (option B) —
+# this workflow ships the shared helper; it does not modify that file.
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'   # every 6h at :17 past — offset off the top-of-hour herd
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log would-merge decisions only; perform NO merges (default true)'
+        type: boolean
+        default: true
+      merge_method:
+        description: 'Merge method for green PRs: merge | squash | rebase'
+        type: string
+        default: 'squash'
+
+# Least privilege: checkout only. Cross-repo merges across the org use the
+# GitHub App token generated below, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
+concurrency:
+  # One sweep at a time. Per-PR keying (repo+number, the corrected #11 key) is
+  # not expressible on a batch scheduled workflow with no single PR in context;
+  # per-PR race safety instead comes from (a) idempotent merges — a PR already
+  # merged/closed re-reads as non-OPEN and is SKIPped — and (b)
+  # org-dependabot-auto-merge.yml's own per-PR concurrency group. This group
+  # serializes overlapping sweeps.
+  group: dependabot-reconcile-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile wedged merge/approved PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (decision scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate GitHub App token (org-wide)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.AUTOMERGE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Sweep open merge/approved PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          # dry_run defaults to true; only a manual dispatch with dry_run=false
+          # (unchecked) performs merges. Scheduled runs are always dry-run.
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) && 'false' || 'true' }}
+          MERGE_METHOD: ${{ inputs.merge_method || 'squash' }}
+          MAX_PRS: '200'
+        run: |
+          set -euo pipefail
+          : "${GH_TOKEN:?missing app token}"
+          echo "Reconcile sweep — owner=${OWNER} dry_run=${DRY_RUN} method=${MERGE_METHOD} cap=${MAX_PRS}"
+
+          # Enumerate open org PRs labeled merge/approved (capped). Bounded retry
+          # on a transient search blip (minimal guard, not #13's full backoff).
+          attempt=1
+          until PRS="$(gh search prs --owner "$OWNER" --state open --label 'merge/approved' --limit "$MAX_PRS" --json repository,number 2>/dev/null)"; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::gh search failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "transient gh search failure (attempt ${attempt}/3); retrying"
+            attempt=$((attempt + 1))
+            sleep "$attempt"
+          done
+
+          COUNT="$(printf '%s' "$PRS" | jq 'length')"
+          echo "Found ${COUNT} open merge/approved PR(s)."
+          if [ "$COUNT" -ge "$MAX_PRS" ]; then
+            echo "::warning::sweep hit the ${MAX_PRS}-PR cap — some approved PRs may be unprocessed this run (no silent truncation; re-run or raise MAX_PRS)."
+          fi
+
+          rc=0
+          while IFS=$'\t' read -r repo num; do
+            [ -n "$repo" ] && [ -n "$num" ] || continue
+            echo "::group::${repo}#${num}"
+            if ! PR_NUMBER="$num" REPO="$repo" MERGE_METHOD="$MERGE_METHOD" DRY_RUN="$DRY_RUN" \
+                 bash "${GITHUB_WORKSPACE}/scripts/pr-green-merge.sh"; then
+              echo "::warning::pr-green-merge failed for ${repo}#${num}"
+              rc=1
+            fi
+            echo "::endgroup::"
+          done < <(printf '%s' "$PRS" | jq -r '.[] | [.repository.nameWithOwner, (.number | tostring)] | @tsv')
+
+          exit "$rc"

--- a/scripts/pr-green-merge.sh
+++ b/scripts/pr-green-merge.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# pr-green-merge.sh — shared green-gate + direct-merge for one Dependabot PR
+# (grade-A plan #14). Single source of truth for "is this PR safe to merge right
+# now, and if so merge it" used by the reconcile sweeper
+# (.github/workflows/org-dependabot-reconcile.yml).
+#
+# It re-applies the SAME green gate as the auto-merge fallback
+# (org-dependabot-auto-merge.yml "Approve and auto-merge" step) — no failing and
+# no pending check — re-checking freshness live rather than trusting a label:
+#   FAIL   — any check failed / errored / timed-out / cancelled / action-required
+#   PENDING— any check queued / in-progress / expected (not yet complete)
+#   GREEN  — all checks complete & non-failing, OR no checks configured (the
+#            wedged-PR case: a clean PR on a repo with no required status checks,
+#            which is exactly what this sweeper exists to converge)
+# Classification is FAIL > PENDING > GREEN and is computed from the PR's
+# statusCheckRollup (structured JSON) rather than parsing `gh pr checks` text, so
+# a transient API error can never masquerade as GREEN. NOTE (option B): the
+# auto-merge fallback's adoption of this helper is owned by the #9/#12/#13
+# follow-up chain on org-dependabot-auto-merge.yml — this PR does not touch that
+# file. The bounded retry below is a minimal transient-blip guard, NOT #13's full
+# backoff+jitter; it converges onto #13's shared retry helper when that lands.
+#
+# A closed or draft PR is NEVER merged (defence-in-depth beyond the sweeper's
+# label/state search filter).
+#
+# Inputs (environment):
+#   PR_NUMBER     required — PR number to evaluate
+#   REPO          required — owner/name the PR belongs to (passed to gh --repo)
+#   MERGE_METHOD  optional — merge|squash|rebase (default: squash)
+#   DRY_RUN       optional — "true" (default) logs the would-merge decision and
+#                 performs ZERO mutating calls; "false" performs the merge
+#   RETRY_MAX     optional — max attempts for a transient gh read (default: 3)
+#
+# Output: a single decision line on stdout, one of:
+#   MERGED #<n>        (DRY_RUN=false, was GREEN)
+#   WOULD-MERGE #<n>   (DRY_RUN=true, was GREEN)
+#   SKIP #<n> (<reason>)
+# Exit status is 0 for any well-formed decision (including SKIP); non-zero only
+# on a usage error or an unrecoverable merge failure.
+#
+set -euo pipefail
+
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER required}"
+REPO="${REPO:?REPO required (owner/name)}"
+MERGE_METHOD="${MERGE_METHOD:-squash}"
+DRY_RUN="${DRY_RUN:-true}"
+RETRY_MAX="${RETRY_MAX:-3}"
+
+log() { echo "[pr-green-merge] $*"; }
+
+# Bounded-retry wrapper for a transient gh READ failure (rate blips / 5xx). Only
+# used for read calls; a merge is issued at most once. Prints command stdout on
+# success; returns the last non-zero code after RETRY_MAX attempts.
+gh_read() {
+  local out rc attempt=1
+  while :; do
+    if out="$(gh "$@" 2>/dev/null)"; then
+      printf '%s' "$out"
+      return 0
+    fi
+    rc=$?
+    if [ "$attempt" -ge "$RETRY_MAX" ]; then
+      log "gh $* failed after ${attempt} attempt(s) (rc=${rc})"
+      return "$rc"
+    fi
+    log "transient gh read failure (attempt ${attempt}/${RETRY_MAX}); retrying"
+    attempt=$((attempt + 1))
+    sleep "$attempt"
+  done
+}
+
+# One combined read: PR state + draft flag + structured check rollup.
+if ! PR_JSON="$(gh_read pr view "$PR_NUMBER" --repo "$REPO" --json state,isDraft,statusCheckRollup)"; then
+  log "SKIP #${PR_NUMBER} (could not read PR — failing closed, no merge)"
+  echo "SKIP #${PR_NUMBER} (pr-view-unavailable)"
+  exit 0
+fi
+
+STATE="$(printf '%s' "$PR_JSON" | jq -r '.state // "UNKNOWN"')"
+IS_DRAFT="$(printf '%s' "$PR_JSON" | jq -r '.isDraft // false')"
+
+if [ "$STATE" != "OPEN" ] || [ "$IS_DRAFT" = "true" ]; then
+  log "SKIP #${PR_NUMBER} (state=${STATE} draft=${IS_DRAFT}) — never merge a closed/draft PR"
+  echo "SKIP #${PR_NUMBER} (state=${STATE},draft=${IS_DRAFT})"
+  exit 0
+fi
+
+# Green gate: FAIL > PENDING > GREEN over the statusCheckRollup. Empty rollup
+# (no checks configured) classifies GREEN — the wedged-PR case.
+CHECK_STATE="$(printf '%s' "$PR_JSON" | jq -r '
+  [ .statusCheckRollup[]? | ((.conclusion // .state // .status // "") | ascii_upcase) ] as $c
+  | if   ($c | map(select(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE")) | length) > 0 then "FAIL"
+    elif ($c | map(select(. == "PENDING" or . == "EXPECTED" or . == "QUEUED" or . == "IN_PROGRESS" or . == "WAITING" or . == "REQUESTED" or . == "")) | length) > 0 then "PENDING"
+    else "GREEN" end')"
+
+if [ "$CHECK_STATE" != "GREEN" ]; then
+  log "SKIP #${PR_NUMBER} (checks ${CHECK_STATE}) — leave for auto-merge/next event"
+  echo "SKIP #${PR_NUMBER} (checks-${CHECK_STATE})"
+  exit 0
+fi
+
+if [ "$DRY_RUN" != "false" ]; then
+  log "WOULD-MERGE #${PR_NUMBER} (checks GREEN) — dry-run, no mutation performed"
+  echo "WOULD-MERGE #${PR_NUMBER}"
+  exit 0
+fi
+
+log "MERGE #${PR_NUMBER} (checks GREEN) via --${MERGE_METHOD}"
+gh pr merge "$PR_NUMBER" "--${MERGE_METHOD}" --repo "$REPO"
+echo "MERGED #${PR_NUMBER}"

--- a/scripts/pr-green-merge.sh
+++ b/scripts/pr-green-merge.sh
@@ -21,16 +21,20 @@
 # file. The bounded retry below is a minimal transient-blip guard, NOT #13's full
 # backoff+jitter; it converges onto #13's shared retry helper when that lands.
 #
-# A closed or draft PR is NEVER merged (defence-in-depth beyond the sweeper's
-# label/state search filter).
+# A PR is NEVER merged (defence-in-depth beyond the sweeper's label/state search
+# filter) when it is closed/draft, authored by anyone outside AUTHOR_ALLOWLIST
+# (the label alone is not trust — a triager can apply it; they cannot forge the
+# author), or its reviewDecision is REVIEW_REQUIRED / CHANGES_REQUESTED.
 #
 # Inputs (environment):
-#   PR_NUMBER     required — PR number to evaluate
-#   REPO          required — owner/name the PR belongs to (passed to gh --repo)
-#   MERGE_METHOD  optional — merge|squash|rebase (default: squash)
-#   DRY_RUN       optional — "true" (default) logs the would-merge decision and
-#                 performs ZERO mutating calls; "false" performs the merge
-#   RETRY_MAX     optional — max attempts for a transient gh read (default: 3)
+#   PR_NUMBER        required — PR number to evaluate
+#   REPO             required — owner/name the PR belongs to (passed to gh --repo)
+#   MERGE_METHOD     optional — merge|squash|rebase (default: squash)
+#   DRY_RUN          optional — "true" (default) logs the would-merge decision and
+#                    performs ZERO mutating calls; "false" performs the merge
+#   RETRY_MAX        optional — max attempts for a transient gh read (default: 3)
+#   AUTHOR_ALLOWLIST optional — space-separated trusted author logins
+#                    (default: "app/dependabot dependabot[bot]")
 #
 # Output: a single decision line on stdout, one of:
 #   MERGED #<n>        (DRY_RUN=false, was GREEN)
@@ -46,22 +50,33 @@ REPO="${REPO:?REPO required (owner/name)}"
 MERGE_METHOD="${MERGE_METHOD:-squash}"
 DRY_RUN="${DRY_RUN:-true}"
 RETRY_MAX="${RETRY_MAX:-3}"
+# Space-separated allowlist of trusted PR-author logins. NOTE: `gh --json author`
+# reports Dependabot as `app/dependabot` (the GitHub App identity); the webhook
+# `pull_request.user.login` form is `dependabot[bot]`. Both are accepted so the
+# gate matches regardless of representation. A human/triager cannot forge these.
+AUTHOR_ALLOWLIST="${AUTHOR_ALLOWLIST:-app/dependabot dependabot[bot]}"
 
-log() { echo "[pr-green-merge] $*"; }
+# log to STDERR so a retry message never contaminates a $(gh_read ...) capture.
+log() { echo "[pr-green-merge] $*" >&2; }
 
 # Bounded-retry wrapper for a transient gh READ failure (rate blips / 5xx). Only
 # used for read calls; a merge is issued at most once. Prints command stdout on
-# success; returns the last non-zero code after RETRY_MAX attempts.
+# success; returns the last non-zero code after RETRY_MAX attempts (surfacing the
+# last stderr line for diagnosability).
 gh_read() {
-  local out rc attempt=1
+  local out rc attempt=1 errf
+  errf="$(mktemp)"
   while :; do
-    if out="$(gh "$@" 2>/dev/null)"; then
+    if out="$(gh "$@" 2>"$errf")"; then
+      rm -f "$errf"
       printf '%s' "$out"
       return 0
+    else
+      rc=$?
     fi
-    rc=$?
     if [ "$attempt" -ge "$RETRY_MAX" ]; then
-      log "gh $* failed after ${attempt} attempt(s) (rc=${rc})"
+      log "gh $* failed after ${attempt} attempt(s) (rc=${rc}): $(tail -n1 "$errf" 2>/dev/null)"
+      rm -f "$errf"
       return "$rc"
     fi
     log "transient gh read failure (attempt ${attempt}/${RETRY_MAX}); retrying"
@@ -70,8 +85,9 @@ gh_read() {
   done
 }
 
-# One combined read: PR state + draft flag + structured check rollup.
-if ! PR_JSON="$(gh_read pr view "$PR_NUMBER" --repo "$REPO" --json state,isDraft,statusCheckRollup)"; then
+# One combined read: PR state + draft + author + review decision + check rollup.
+if ! PR_JSON="$(gh_read pr view "$PR_NUMBER" --repo "$REPO" \
+      --json state,isDraft,author,reviewDecision,statusCheckRollup)"; then
   log "SKIP #${PR_NUMBER} (could not read PR — failing closed, no merge)"
   echo "SKIP #${PR_NUMBER} (pr-view-unavailable)"
   exit 0
@@ -79,10 +95,38 @@ fi
 
 STATE="$(printf '%s' "$PR_JSON" | jq -r '.state // "UNKNOWN"')"
 IS_DRAFT="$(printf '%s' "$PR_JSON" | jq -r '.isDraft // false')"
+AUTHOR="$(printf '%s' "$PR_JSON" | jq -r '.author.login // ""')"
+REVIEW="$(printf '%s' "$PR_JSON" | jq -r '.reviewDecision // ""')"
 
 if [ "$STATE" != "OPEN" ] || [ "$IS_DRAFT" = "true" ]; then
   log "SKIP #${PR_NUMBER} (state=${STATE} draft=${IS_DRAFT}) — never merge a closed/draft PR"
   echo "SKIP #${PR_NUMBER} (state=${STATE},draft=${IS_DRAFT})"
+  exit 0
+fi
+
+# Author allowlist (hardening): the sweep must only ever re-drive trusted
+# automation PRs. The label alone is insufficient — anyone with triage on a repo
+# can apply merge/approved; they cannot forge the PR author. This closes the
+# "triager labels an arbitrary PR into a live merge" vector on repos without
+# required status checks.
+author_ok=false
+for a in $AUTHOR_ALLOWLIST; do
+  [ "$AUTHOR" = "$a" ] && { author_ok=true; break; }
+done
+if [ "$author_ok" != "true" ]; then
+  log "SKIP #${PR_NUMBER} (author '${AUTHOR}' not in allowlist) — never sweep a non-automation PR"
+  echo "SKIP #${PR_NUMBER} (author-not-allowlisted)"
+  exit 0
+fi
+
+# Review-decision gate. reviewDecision is null when the repo requires no reviews
+# (the common wedged-PR case — allowed), APPROVED when a required review is
+# satisfied (allowed). REVIEW_REQUIRED means a required review is unmet — GitHub
+# would block the merge server-side anyway, so skip to avoid a noisy failed
+# merge; CHANGES_REQUESTED is an explicit block. Never merge over either.
+if [ "$REVIEW" = "REVIEW_REQUIRED" ] || [ "$REVIEW" = "CHANGES_REQUESTED" ]; then
+  log "SKIP #${PR_NUMBER} (reviewDecision=${REVIEW}) — review unmet/blocked, not sweep-eligible"
+  echo "SKIP #${PR_NUMBER} (review-${REVIEW})"
   exit 0
 fi
 

--- a/tests/reconcile-sweeper.test.sh
+++ b/tests/reconcile-sweeper.test.sh
@@ -29,6 +29,16 @@ cat > "$BIN/gh" <<'MOCK'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$GH_TRACE"
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  # Optional transient-failure simulation: fail the FIRST pr-view call, then
+  # succeed — exercises gh_read's retry path end-to-end (F2 regression).
+  if [ "${MOCK_FAIL_ALL:-0}" = "1" ]; then
+    echo "gh: API rate limit exceeded (mock persistent)" >&2; exit 1
+  fi
+  if [ "${MOCK_FAIL_FIRST:-0}" = "1" ]; then
+    n=0; [ -f "$MOCK_VIEW_COUNT" ] && n="$(cat "$MOCK_VIEW_COUNT")"
+    n=$((n + 1)); printf '%s' "$n" > "$MOCK_VIEW_COUNT"
+    if [ "$n" -eq 1 ]; then echo "gh: API rate limit exceeded (mock transient)" >&2; exit 1; fi
+  fi
   cat "$MOCK_PR_JSON"; exit 0
 fi
 # Any write verb (merge/review/edit/close/comment/ready/...):
@@ -45,15 +55,17 @@ chmod +x "$BIN/gh"
 
 WRITE_VERBS_RE='pr (merge|review|edit|close|comment|ready)'
 
-# run_helper <json> <dry_run> <reject_writes> -> sets globals OUT, LAST_RC, TRACE.
-# NOT run under command substitution (that would subshell away LAST_RC/TRACE).
+# run_helper <json> <dry_run> <reject_writes> [fail_first] -> sets globals
+# OUT, LAST_RC, TRACE. NOT run under command substitution (that would subshell
+# away LAST_RC/TRACE). RETRY_MAX=2 keeps the one retry-path case fast (~1s sleep).
 OUT=""; LAST_RC=0; TRACE=""
 run_helper() {
-  local json="$1" dry="$2" reject="$3"
+  local json="$1" dry="$2" reject="$3" fail_first="${4:-0}" fail_all="${5:-0}"
+  : "$fail_all"  # consumed via ${5:-0} in the env line below
   printf '%s' "$json" > "$WORK/pr.json"
-  : > "$WORK/trace"
+  : > "$WORK/trace"; : > "$WORK/viewcount"
   PATH="$BIN:$PATH" GH_TRACE="$WORK/trace" MOCK_PR_JSON="$WORK/pr.json" \
-    MOCK_REJECT_WRITES="$reject" \
+      MOCK_REJECT_WRITES="$reject" MOCK_FAIL_FIRST="$fail_first" MOCK_FAIL_ALL="${5:-0}" MOCK_VIEW_COUNT="$WORK/viewcount" \
     PR_NUMBER=123 REPO="Coalfire-CF/some-repo" MERGE_METHOD=squash DRY_RUN="$dry" RETRY_MAX=2 \
     bash "$HELPER" > "$WORK/out" 2>/dev/null
   LAST_RC=$?
@@ -61,12 +73,18 @@ run_helper() {
   TRACE="$(cat "$WORK/trace")"
 }
 
-GREEN='{"state":"OPEN","isDraft":false,"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
-NOCHECKS='{"state":"OPEN","isDraft":false,"statusCheckRollup":[]}'
-REDJSON='{"state":"OPEN","isDraft":false,"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}'
-PENDJSON='{"state":"OPEN","isDraft":false,"statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":null}]}'
-DRAFTJSON='{"state":"OPEN","isDraft":true,"statusCheckRollup":[]}'
-CLOSEDJSON='{"state":"MERGED","isDraft":false,"statusCheckRollup":[]}'
+# Scenarios carry author (gh --json reports Dependabot as app/dependabot) and
+# reviewDecision (null = repo requires no reviews = the wedged case).
+AUTH='"author":{"login":"app/dependabot"},"reviewDecision":null'
+GREEN="{\"state\":\"OPEN\",\"isDraft\":false,${AUTH},\"statusCheckRollup\":[{\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}]}"
+NOCHECKS="{\"state\":\"OPEN\",\"isDraft\":false,${AUTH},\"statusCheckRollup\":[]}"
+REDJSON="{\"state\":\"OPEN\",\"isDraft\":false,${AUTH},\"statusCheckRollup\":[{\"status\":\"COMPLETED\",\"conclusion\":\"FAILURE\"}]}"
+PENDJSON="{\"state\":\"OPEN\",\"isDraft\":false,${AUTH},\"statusCheckRollup\":[{\"status\":\"IN_PROGRESS\",\"conclusion\":null}]}"
+DRAFTJSON="{\"state\":\"OPEN\",\"isDraft\":true,${AUTH},\"statusCheckRollup\":[]}"
+CLOSEDJSON="{\"state\":\"MERGED\",\"isDraft\":false,${AUTH},\"statusCheckRollup\":[]}"
+# F3 hardening scenarios: non-automation author, and an unmet required review.
+HUMANJSON='{"state":"OPEN","isDraft":false,"author":{"login":"mallory"},"reviewDecision":null,"statusCheckRollup":[]}'
+REVREQJSON='{"state":"OPEN","isDraft":false,"author":{"login":"app/dependabot"},"reviewDecision":"REVIEW_REQUIRED","statusCheckRollup":[]}'
 
 # ---- Case 1 (the AC expected-FAIL guard): GREEN + dry-run → WOULD-MERGE, and
 #      the recorded trace contains ZERO write verbs (mock also set to reject). ----
@@ -98,5 +116,36 @@ for scn in "RED:$REDJSON:checks-FAIL" "PENDING:$PENDJSON:checks-PENDING" \
   echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "$name issued a WRITE verb but must never merge"
   echo "OK: ${name} → SKIP (no merge)  [${want}]"
 done
+
+# ---- Case 5 (F2 regression): a transient pr-view failure on attempt 1 then a
+#      success on attempt 2 must still reach WOULD-MERGE — proves the retry log
+#      goes to stderr (not into the captured JSON) and gh_read really retries. ----
+run_helper "$GREEN" true 0 1
+[ "$LAST_RC" -eq 0 ] || fail "retry path should exit 0 (got $LAST_RC)"
+echo "$OUT" | grep -q "WOULD-MERGE #123" || fail "retry path should still WOULD-MERGE (got: $OUT)"
+[ "$(echo "$TRACE" | grep -cE 'pr view')" -eq 2 ] || fail "retry path should issue exactly two 'gh pr view' calls"
+echo "OK: transient-then-success retry → WOULD-MERGE (log on stderr, JSON uncontaminated)"
+
+# ---- Case 6 (F3): a non-automation author is NEVER swept (even green + live). ----
+run_helper "$HUMANJSON" false 0
+[ "$LAST_RC" -eq 0 ] || fail "human-authored should exit 0 (skip, got $LAST_RC)"
+echo "$OUT" | grep -q "SKIP #123 (author-not-allowlisted)" || fail "human-authored should SKIP author-not-allowlisted (got: $OUT)"
+echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "human-authored issued a WRITE verb but must never merge"
+echo "OK: non-automation author → SKIP (author-not-allowlisted)"
+
+# ---- Case 7 (F3): an unmet required review is NEVER swept. ----
+run_helper "$REVREQJSON" false 0
+[ "$LAST_RC" -eq 0 ] || fail "review-required should exit 0 (skip, got $LAST_RC)"
+echo "$OUT" | grep -q "SKIP #123 (review-REVIEW_REQUIRED)" || fail "review-required should SKIP (got: $OUT)"
+echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "review-required issued a WRITE verb but must never merge"
+echo "OK: reviewDecision=REVIEW_REQUIRED → SKIP (no merge)"
+
+# ---- Case 8 (F1 regression): pr-view fails on EVERY attempt → gh_read must
+#      return non-zero so the caller reaches the pr-view-unavailable fail-closed
+#      SKIP (before the fix gh_read returned 0 and that branch was dead code). ----
+run_helper "$GREEN" false 0 0 1
+echo "$OUT" | grep -q "SKIP #123 (pr-view-unavailable)" || fail "persistent read failure should hit pr-view-unavailable SKIP (got: $OUT)"
+echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "persistent read failure issued a WRITE verb but must never merge"
+echo "OK: persistent pr-view failure → SKIP (pr-view-unavailable), fail-closed branch reachable"
 
 echo "ALL TESTS PASSED"

--- a/tests/reconcile-sweeper.test.sh
+++ b/tests/reconcile-sweeper.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Meta-test for the reconcile sweeper's per-PR green-gate/merge helper
+# scripts/pr-green-merge.sh (grade-A plan #14).
+#
+# The sweep workflow (.github/workflows/org-dependabot-reconcile.yml) is a thin
+# loop over `gh search` that delegates every merge decision to this helper, so
+# the helper IS the testable safety surface. We drive it through a MOCK `gh`
+# shim placed first on PATH that (a) records every invocation and (b) can REJECT
+# any write verb — proving the dry-run path issues ZERO mutating calls, and that
+# red / pending / draft / closed PRs are never merged.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HELPER="${REPO_ROOT}/scripts/pr-green-merge.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$HELPER" ] || fail "helper not found at $HELPER"
+[ -x "$HELPER" ] || chmod +x "$HELPER"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+# ---- Mock gh: records argv to $GH_TRACE; serves pr view JSON from $MOCK_PR_JSON;
+#      rejects write verbs (pr merge/review/...) when $MOCK_REJECT_WRITES=1. ----
+cat > "$BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_TRACE"
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  cat "$MOCK_PR_JSON"; exit 0
+fi
+# Any write verb (merge/review/edit/close/comment/ready/...):
+if [ "$1" = "pr" ] && printf '%s' " merge review edit close comment ready " | grep -q " $2 "; then
+  if [ "${MOCK_REJECT_WRITES:-0}" = "1" ]; then
+    echo "MOCK: write verb 'gh pr $2' rejected (dry-run must not mutate)" >&2
+    exit 1
+  fi
+  exit 0
+fi
+exit 0
+MOCK
+chmod +x "$BIN/gh"
+
+WRITE_VERBS_RE='pr (merge|review|edit|close|comment|ready)'
+
+# run_helper <json> <dry_run> <reject_writes> -> sets globals OUT, LAST_RC, TRACE.
+# NOT run under command substitution (that would subshell away LAST_RC/TRACE).
+OUT=""; LAST_RC=0; TRACE=""
+run_helper() {
+  local json="$1" dry="$2" reject="$3"
+  printf '%s' "$json" > "$WORK/pr.json"
+  : > "$WORK/trace"
+  PATH="$BIN:$PATH" GH_TRACE="$WORK/trace" MOCK_PR_JSON="$WORK/pr.json" \
+    MOCK_REJECT_WRITES="$reject" \
+    PR_NUMBER=123 REPO="Coalfire-CF/some-repo" MERGE_METHOD=squash DRY_RUN="$dry" RETRY_MAX=2 \
+    bash "$HELPER" > "$WORK/out" 2>/dev/null
+  LAST_RC=$?
+  OUT="$(cat "$WORK/out")"
+  TRACE="$(cat "$WORK/trace")"
+}
+
+GREEN='{"state":"OPEN","isDraft":false,"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
+NOCHECKS='{"state":"OPEN","isDraft":false,"statusCheckRollup":[]}'
+REDJSON='{"state":"OPEN","isDraft":false,"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}'
+PENDJSON='{"state":"OPEN","isDraft":false,"statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":null}]}'
+DRAFTJSON='{"state":"OPEN","isDraft":true,"statusCheckRollup":[]}'
+CLOSEDJSON='{"state":"MERGED","isDraft":false,"statusCheckRollup":[]}'
+
+# ---- Case 1 (the AC expected-FAIL guard): GREEN + dry-run → WOULD-MERGE, and
+#      the recorded trace contains ZERO write verbs (mock also set to reject). ----
+run_helper "$GREEN" true 1
+[ "$LAST_RC" -eq 0 ] || fail "dry-run GREEN should exit 0 (got $LAST_RC)"
+echo "$OUT" | grep -q "WOULD-MERGE #123" || fail "dry-run GREEN should say WOULD-MERGE (got: $OUT)"
+echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "dry-run issued a WRITE verb: $(echo "$TRACE" | grep -E "$WRITE_VERBS_RE")"
+echo "OK: dry-run GREEN → WOULD-MERGE, zero mutating calls (trace clean)"
+
+# ---- Case 2: GREEN + live → MERGED, and exactly one `gh pr merge` recorded. ----
+run_helper "$GREEN" false 0
+[ "$LAST_RC" -eq 0 ] || fail "live GREEN should exit 0 (got $LAST_RC)"
+echo "$OUT" | grep -q "MERGED #123" || fail "live GREEN should MERGE (got: $OUT)"
+[ "$(echo "$TRACE" | grep -cE 'pr merge')" -eq 1 ] || fail "live GREEN must issue exactly one 'gh pr merge'"
+echo "OK: live GREEN → MERGED, exactly one merge call"
+
+# ---- Case 3: no-checks (wedged clean PR) + live → MERGED. ----
+run_helper "$NOCHECKS" false 0
+echo "$OUT" | grep -q "MERGED #123" || fail "live no-checks (wedged) should MERGE (got: $OUT)"
+echo "OK: live no-checks (wedged) → MERGED"
+
+# ---- Case 4: red / pending / draft / closed are NEVER merged (even live). ----
+for scn in "RED:$REDJSON:checks-FAIL" "PENDING:$PENDJSON:checks-PENDING" \
+           "DRAFT:$DRAFTJSON:draft=true" "CLOSED:$CLOSEDJSON:state=MERGED"; do
+  name="${scn%%:*}"; rest="${scn#*:}"; json="${rest%:*}"; want="${rest##*:}"
+  run_helper "$json" false 0
+  [ "$LAST_RC" -eq 0 ] || fail "$name should exit 0 (skip, got $LAST_RC)"
+  echo "$OUT" | grep -q "SKIP #123" || fail "$name should SKIP (got: $OUT)"
+  echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "$name issued a WRITE verb but must never merge"
+  echo "OK: ${name} → SKIP (no merge)  [${want}]"
+done
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Item #14 — Reconciliation sweeper for wedged PRs

Grade-A plan **item #14**. A scheduled safety net that converges Dependabot PRs which go green *after* their triggering auto-merge run (auto-merge un-latched on repos without required status checks) and sit `merge/approved` but unmerged — the ~60% first-party stall the direct-merge fallback exists for, and the 20+ live `merge/approved` PRs observed 2026-07-06.

Built as **option B** (approved by lead): the shared green-gate/merge logic ships as a **net-new** `scripts/pr-green-merge.sh` + the sweeper; **this PR does not touch `org-dependabot-auto-merge.yml`**. The auto-merge fallback's adoption of the shared helper is owned by the **#9/#12/#13 follow-up chain** on that file — flagged so it is tracked, not orphaned.

### What's added
- **`scripts/pr-green-merge.sh`** — shared per-PR green-gate + direct-merge. Re-applies the auto-merge fallback's `FAIL > PENDING > GREEN` gate, computed from the PR's `statusCheckRollup` (structured JSON) so a transient API error can never masquerade as GREEN. Empty rollup (no required checks) → GREEN = the wedged-PR case. **Never merges a closed/draft PR.** `DRY_RUN=true` (default) logs the decision and performs **zero mutating calls**. Bounded retry on transient `gh` reads (minimal guard per lead; converges onto #13's shared retry helper). shellcheck-clean; documented input contract.
- **`.github/workflows/org-dependabot-reconcile.yml`** — `on: schedule` (every 6h at :17) + `workflow_dispatch` (`dry_run` input **default true**). Enumerates open org PRs labeled `merge/approved` via `gh search` (**capped at `MAX_PRS=200`, warns on cap — no silent truncation**), uses an org-wide GitHub App token for cross-repo merges, **least-privilege `permissions: contents: read`**, `timeout-minutes: 30`, sweep-level `concurrency`. Never merges red/pending/draft/unlabeled PRs.
- **`tests/reconcile-sweeper.test.sh`** — mock `gh` shim recording every invocation.

### Safety posture
`dry_run` defaults to **true everywhere** (scheduled runs included): the shipped sweeper is observational until an operator dispatches with `dry_run=false` (validate first) or flips the schedule default after the dry-run window. Nothing auto-merges across the fleet the moment this lands.

**Concurrency note:** a batch scheduled workflow has no single PR in context, so the corrected #11 `repo+PR-number` key isn't expressible at the workflow level. The sweep uses a single group (`dependabot-reconcile-${{ github.repository }}`, `cancel-in-progress: false`) to serialize sweeps; per-PR race safety comes from idempotent merges (a merged/closed PR re-reads as non-OPEN → SKIP) + the auto-merge workflow's own per-PR concurrency.

### Acceptance criteria
- [x] **AC-1** New scheduled workflow (`on: schedule` + `workflow_dispatch`) enumerates every open org PR labeled `merge/approved`.
- [x] **AC-2** Re-applies the SAME green gate as the auto-merge fallback, re-checking freshness live (not trusting the label), and direct-merges the green ones.
- [x] **AC-3** `dry_run` input defaulting to `true` → logs would-merge, ZERO mutating calls.
- [x] **AC-4** Red / pending / draft / missing-`merge/approved` PRs are never merged.
- [x] **AC-5** Reused merge logic is a shared script (`scripts/pr-green-merge.sh`), not a copy-pasted heredoc, covered by fixtures/mock.
- [x] **AC-6** `concurrency:` group declared (batch-level; per-PR keying rationale documented above).
- [x] Lead additions: bounded retry on transient `gh` calls; capped sweep (`--limit` + `MAX_PRS` guard, warns on cap).

### Validated testing (local)
```
$ bash tests/*.test.sh          # all PASS (incl. reconcile-sweeper)
$ shellcheck scripts/pr-green-merge.sh          # CLEAN (exit 0)
$ SHELLCHECK_OPTS="-S warning" actionlint       # CLEAN (exit 0)
```
Mock-gh test output (expected-PASS):
```
OK: dry-run GREEN → WOULD-MERGE, zero mutating calls (trace clean)
OK: live GREEN → MERGED, exactly one merge call
OK: live no-checks (wedged) → MERGED
OK: RED → SKIP (no merge)  [checks-FAIL]
OK: PENDING → SKIP (no merge)  [checks-PENDING]
OK: DRAFT → SKIP (no merge)  [draft=true]
OK: CLOSED → SKIP (no merge)  [state=MERGED]
ALL TESTS PASSED
```
**Expected-FAIL demonstrated** (not committed): forcing the helper to merge in dry-run → the mock rejects the write and the trace guard fires → `NOT OK: dry-run GREEN should exit 0 (got 1)`.

Note: `scripts/pr-green-merge.sh` is shellcheck-clean; the `test-scripts.yml` full-shellcheck job that will also cover it arrives with #10 (PR #171). Based on latest main `6f8a99b` (zero file overlap with #171). **Do not merge — lead merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S
