### PR TITLE
fix(auto-merge): fail-safe S3 cache reads + schema/producer validation (grade-A #9)

### DIFF
--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -123,6 +123,36 @@ Create an S3 bucket for cross-repo analysis caching:
 - **Encryption**: SSE-S3
 - **Access**: Private (no public access)
 - **Lifecycle**: Expire objects after 90 days
+- **Write scoping (required)**: `s3:PutObject` on `analyses/*` MUST be restricted to
+  the single CI OIDC role (`AUTOMERGE_DEPENDABOT_ROLE_ARN`). The cache key
+  `analyses/shared/{dep}/{version}.json` is a shared namespace: any other principal
+  with write access could poison it to suppress an OSV / scorecard / breaking-change
+  block for the whole TTL window. Attach a bucket policy such as:
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AutomergeCacheWriteOnlyFromCIRole",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:PutObject",
+        "Resource": "arn:aws:s3:::<your-cache-bucket>/analyses/*",
+        "Condition": {
+          "StringNotEquals": {
+            "aws:PrincipalArn": "<AUTOMERGE_DEPENDABOT_ROLE_ARN>"
+          }
+        }
+      }
+    ]
+  }
+  ```
+
+  Defence-in-depth pairs with the read-side `schema_version`/`producer` validation
+  (grade-A #9): an object of an unrecognized shape or origin is re-analyzed rather
+  than trusted, and missing gate fields fail closed (block/manual-review), never
+  approve.
 
 The cache uses a two-tier layout to share universal data across repos while keeping
 repo-specific analysis scoped:

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -39,6 +39,11 @@
 #
 set -euo pipefail
 
+# Shared cache read/validate helpers (grade-A #9): fail-safe field reads +
+# schema_version/producer validation.
+# shellcheck source=scripts/cache-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cache-lib.sh"
+
 # Grouped-PR support: each dependency is analyzed individually and
 # folded into aggregates (semver = max, breaking = OR). Bedrock/API
 # errors increment CHECK_ERRORS -> decide fails CLOSED to manual
@@ -84,12 +89,18 @@ if [ "$CACHED" = "ok" ]; then
       NOW_EPOCH=$(date +%s)
       AGE_DAYS=$(( (NOW_EPOCH - ANALYZED_EPOCH) / 86400 ))
       if [ "$AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
-        SHARED_CACHE_HIT="true"
-        SEMVER_TYPE=$(jq -r '.semver.type // "unknown"' /tmp/cached_analysis.json)
-        HAS_BREAKING=$(jq -r '.changelog.breaking // "false"' /tmp/cached_analysis.json)
-        CONFIDENCE=$(jq -r '.changelog.confidence // "0"' /tmp/cached_analysis.json)
-        RISK_SUMMARY=$(jq -r '.changelog.summary // ""' /tmp/cached_analysis.json)
-        echo "Shared cache hit for changelog analysis of ${DEP_NAME}@${TO_VERSION}"
+        if cache_schema_ok /tmp/cached_analysis.json; then
+          SHARED_CACHE_HIT="true"
+          SEMVER_TYPE=$(jq -r '.semver.type // "unknown"' /tmp/cached_analysis.json)
+          # Fail-SAFE (grade-A #9): a missing/non-boolean changelog.breaking
+          # resolves to true (breaking) so a degraded cache blocks, not approves.
+          HAS_BREAKING=$(cache_read_bool /tmp/cached_analysis.json '.changelog.breaking' true)
+          CONFIDENCE=$(jq -r '.changelog.confidence // "0"' /tmp/cached_analysis.json)
+          RISK_SUMMARY=$(jq -r '.changelog.summary // ""' /tmp/cached_analysis.json)
+          echo "Shared cache hit for changelog analysis of ${DEP_NAME}@${TO_VERSION}"
+        else
+          echo "::warning::Shared cache object for ${DEP_NAME}@${TO_VERSION} failed schema/producer validation — re-analyzing (treated as miss)"
+        fi
       fi
     fi
   fi
@@ -104,10 +115,16 @@ if [ "$REPO_CACHED" = "ok" ]; then
     NOW_EPOCH=$(date +%s)
     REPO_AGE_DAYS=$(( (NOW_EPOCH - REPO_EPOCH) / 86400 ))
     if [ "$REPO_AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
-      REPO_CACHE_HIT="true"
-      APPLIES_TO_REPO=$(jq -r '.applies_to_repo // "true"' /tmp/cached_repo_analysis.json)
-      RISK_SUMMARY=$(jq -r '.risk_summary // "'"$RISK_SUMMARY"'"' /tmp/cached_repo_analysis.json)
-      echo "Repo cache hit for applicability of ${DEP_NAME}@${TO_VERSION} in ${GITHUB_REPOSITORY}"
+      if cache_schema_ok /tmp/cached_repo_analysis.json; then
+        REPO_CACHE_HIT="true"
+        # applies_to_repo is non-gating (decide never blocks on it); keep its
+        # conservative "assume applies" default, but validate presence/type.
+        APPLIES_TO_REPO=$(cache_read_bool /tmp/cached_repo_analysis.json '.applies_to_repo' true)
+        RISK_SUMMARY=$(jq -r '.risk_summary // "'"$RISK_SUMMARY"'"' /tmp/cached_repo_analysis.json)
+        echo "Repo cache hit for applicability of ${DEP_NAME}@${TO_VERSION} in ${GITHUB_REPOSITORY}"
+      else
+        echo "::warning::Repo cache object for ${DEP_NAME}@${TO_VERSION} failed schema/producer validation — re-analyzing (treated as miss)"
+      fi
     fi
   fi
 fi
@@ -277,6 +294,8 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
   fi
 
   echo "$EXISTING" | jq \
+    --arg schema "$CACHE_SCHEMA_VERSION" \
+    --arg producer "$CACHE_PRODUCER" \
     --arg dep "$DEP_NAME" \
     --arg ver "$TO_VERSION" \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -288,6 +307,8 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
     --arg summary "$RISK_SUMMARY" \
     --argjson risks "$AI_RISKS" \
     '. + {
+      schema_version: $schema,
+      producer: $producer,
       dependency: $dep,
       version: $ver,
       analyzed_at: $ts,
@@ -358,6 +379,8 @@ fi
 # ---------------------------------------------------------
 if [ "$REPO_CACHE_HIT" = "false" ]; then
   jq -n \
+    --arg schema "$CACHE_SCHEMA_VERSION" \
+    --arg producer "$CACHE_PRODUCER" \
     --arg dep "$DEP_NAME" \
     --arg ver "$TO_VERSION" \
     --arg repo "$GITHUB_REPOSITORY" \
@@ -365,6 +388,8 @@ if [ "$REPO_CACHE_HIT" = "false" ]; then
     --argjson applies "$([ "$APPLIES_TO_REPO" = "true" ] && echo true || echo false)" \
     --arg summary "$RISK_SUMMARY" \
     '{
+      schema_version: $schema,
+      producer: $producer,
       dependency: $dep,
       version: $ver,
       repository: $repo,

--- a/scripts/cache-lib.sh
+++ b/scripts/cache-lib.sh
@@ -42,11 +42,14 @@ cache_schema_ok() {
 # never approves it (osv.clear→false, scorecard.pass→false, changelog.breaking→true).
 cache_read_bool() {
   local f="$1" path="$2" safe="$3" v
-  # NOTE: do NOT use jq's `// default` here — `//` fires on both null AND false,
-  # so a legitimate `false` would be mistaken for missing. Read the raw value and
-  # accept it only if it is a genuine boolean; anything else (null/missing/string/
-  # unreadable) → the SAFE value.
-  v="$(jq -r "${path}" "$f" 2>/dev/null)" || v="__MISSING__"
+  # Accept the cached value ONLY if it is a genuine JSON boolean. Two traps:
+  #   1. jq's `// default` fires on both null AND false, so `.breaking // true`
+  #      would coerce a real `false` to `true` — never use `//` here.
+  #   2. `jq -r` renders the string "true" and the boolean true identically, so a
+  #      type check is required or a poisoned {"clear":"true"} string reads as
+  #      clear. We emit the value only when (path|type)=="boolean".
+  # Anything else — missing / null / string / number / unreadable — → SAFE value.
+  v="$(jq -r "if ((${path}) | type) == \"boolean\" then (${path} | tostring) else \"__INVALID__\" end" "$f" 2>/dev/null)" || v="__INVALID__"
   case "$v" in
     true | false) printf '%s' "$v" ;;
     *)            printf '%s' "$safe" ;;

--- a/scripts/cache-lib.sh
+++ b/scripts/cache-lib.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# cache-lib.sh — shared S3 analysis-cache read/validate helpers for the
+# Dependabot auto-merge workflow (grade-A plan #9). Sourced by
+# scripts/supply-chain-check.sh and scripts/breaking-change-check.sh.
+#
+# Why: the cached supply-chain/breaking-change objects gate the merge decision.
+# The pre-#9 reads defaulted missing fields to the PERMISSIVE value
+# (`.osv.clear // "true"`, `.scorecard.pass // "true"`, `.changelog.breaking //
+# "false"`), so a partial/corrupt/poisoned cache object could silently suppress
+# an OSV / scorecard / breaking-change block for the whole TTL window. These
+# helpers make reads fail-SAFE and add a schema_version + producer stamp so an
+# object of an unrecognized shape or origin is re-analyzed instead of trusted.
+#
+# Pure bash + jq — no aws / network — so it is unit-tested offline by
+# tests/cache-read.test.sh.
+#
+# This file is sourced (not executed); it defines constants + functions only.
+
+# Bumped whenever the cached object schema changes. A read whose schema_version
+# does not match is treated as a cache MISS (re-analyze) — which also means every
+# pre-#9 object (no schema_version) is transparently re-analyzed on rollout.
+CACHE_SCHEMA_VERSION="1"
+# Identity every writer stamps; a read from any other producer is not trusted.
+CACHE_PRODUCER="coalfire-org-dependabot-auto-merge"
+
+# cache_schema_ok <file> : exit 0 iff the object carries the expected
+# schema_version AND producer. Any mismatch / missing field / unreadable file
+# → non-zero (caller treats it as a cache miss and re-analyzes).
+cache_schema_ok() {
+  local f="$1" sv prod
+  [ -f "$f" ] || return 1
+  sv="$(jq -r '.schema_version // ""' "$f" 2>/dev/null)" || return 1
+  prod="$(jq -r '.producer // ""' "$f" 2>/dev/null)" || return 1
+  [ "$sv" = "$CACHE_SCHEMA_VERSION" ] && [ "$prod" = "$CACHE_PRODUCER" ]
+}
+
+# cache_read_bool <file> <jq_path> <safe_value> : echo the cached value at
+# jq_path ONLY if it is a genuine boolean (true/false); otherwise echo the
+# SAFE value. Missing, null, non-boolean, or unreadable → safe (fail closed).
+# The safe value is chosen by the caller so a degraded cache blocks/holds a PR,
+# never approves it (osv.clear→false, scorecard.pass→false, changelog.breaking→true).
+cache_read_bool() {
+  local f="$1" path="$2" safe="$3" v
+  # NOTE: do NOT use jq's `// default` here — `//` fires on both null AND false,
+  # so a legitimate `false` would be mistaken for missing. Read the raw value and
+  # accept it only if it is a genuine boolean; anything else (null/missing/string/
+  # unreadable) → the SAFE value.
+  v="$(jq -r "${path}" "$f" 2>/dev/null)" || v="__MISSING__"
+  case "$v" in
+    true | false) printf '%s' "$v" ;;
+    *)            printf '%s' "$safe" ;;
+  esac
+}

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -35,6 +35,11 @@
 #
 set -euo pipefail
 
+# Shared cache read/validate helpers (grade-A #9): fail-safe field reads +
+# schema_version/producer validation.
+# shellcheck source=scripts/cache-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cache-lib.sh"
+
 # Grouped-PR support: every dependency in the PR is checked
 # individually and folded into AND/OR aggregates. Any per-dep
 # query ERROR (as opposed to a clean result) increments
@@ -71,11 +76,17 @@ if [ "$CACHED" = "ok" ]; then
     NOW_EPOCH=$(date +%s)
     AGE_DAYS=$(( (NOW_EPOCH - ANALYZED_EPOCH) / 86400 ))
     if [ "$AGE_DAYS" -lt "$CACHE_TTL_DAYS" ]; then
-      CACHE_HIT="true"
-      OSV_CLEAR=$(jq -r '.osv.clear // "true"' /tmp/cached_analysis.json)
-      SCORECARD_PASS=$(jq -r '.scorecard.pass // "true"' /tmp/cached_analysis.json)
-      SCORECARD_SCORE=$(jq -r '.scorecard.score // "0"' /tmp/cached_analysis.json)
-      echo "Cache hit for ${DEP_NAME}@${TO_VERSION} (age: ${AGE_DAYS}d)"
+      if cache_schema_ok /tmp/cached_analysis.json; then
+        CACHE_HIT="true"
+        # Fail-SAFE reads (grade-A #9): a missing/non-boolean field resolves to
+        # the blocking value (not-clear / not-pass), never permissive.
+        OSV_CLEAR=$(cache_read_bool /tmp/cached_analysis.json '.osv.clear' false)
+        SCORECARD_PASS=$(cache_read_bool /tmp/cached_analysis.json '.scorecard.pass' false)
+        SCORECARD_SCORE=$(jq -r '.scorecard.score // "0"' /tmp/cached_analysis.json)
+        echo "Cache hit for ${DEP_NAME}@${TO_VERSION} (age: ${AGE_DAYS}d)"
+      else
+        echo "::warning::Cached object for ${DEP_NAME}@${TO_VERSION} failed schema/producer validation — re-analyzing (treated as miss)"
+      fi
     fi
   fi
 fi
@@ -167,6 +178,8 @@ if [ "$CACHE_HIT" = "false" ]; then
   # Breaking change check will merge its fields in separately
   # ---------------------------------------------------------
   jq -n \
+    --arg schema "$CACHE_SCHEMA_VERSION" \
+    --arg producer "$CACHE_PRODUCER" \
     --arg dep "$DEP_NAME" \
     --arg ver "$TO_VERSION" \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -175,6 +188,8 @@ if [ "$CACHE_HIT" = "false" ]; then
     --arg sc_score "$SCORECARD_SCORE" \
     --argjson sc_pass "$([ "$SCORECARD_PASS" = "true" ] && echo true || echo false)" \
     '{
+      schema_version: $schema,
+      producer: $producer,
       dependency: $dep,
       version: $ver,
       analyzed_at: $ts,

--- a/tests/cache-read.test.sh
+++ b/tests/cache-read.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Meta-test for scripts/cache-lib.sh (grade-A plan #9): fail-SAFE cache field
+# reads + schema_version/producer validation.
+#
+# Pins the hardened behavior:
+#   - a valid object (schema_version + producer match) is accepted; a genuine
+#     boolean field reads through as-is;
+#   - a MISSING / non-boolean field reads as the caller's SAFE value (osv.clear
+#     and scorecard.pass → false = not-clear/not-pass; changelog.breaking → true
+#     = breaking), so a partial/corrupt cache blocks or holds a PR, never approves;
+#   - an object with the wrong producer, an unknown schema_version, or NO schema
+#     stamp at all (every pre-#9 object) fails cache_schema_ok → the caller treats
+#     it as a miss and re-analyzes.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${REPO_ROOT}/scripts/cache-lib.sh"
+FIX="${SCRIPT_DIR}/fixtures/cache-read"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$LIB" ] || fail "cache-lib.sh not found at $LIB"
+# shellcheck source=scripts/cache-lib.sh
+. "$LIB"
+
+eq() { # <desc> <got> <want>
+  [ "$2" = "$3" ] || fail "$1: got '$2' want '$3'"
+  echo "OK: $1 -> $2"
+}
+
+# ---- schema/producer validation (cache_schema_ok) ----
+cache_schema_ok "$FIX/complete_clean.json"  || fail "complete_clean should pass schema_ok"
+echo "OK: complete_clean passes schema_ok"
+cache_schema_ok "$FIX/missing_fields.json"  || fail "missing_fields (valid stamp) should pass schema_ok"
+echo "OK: missing_fields (valid stamp, no data fields) passes schema_ok"
+cache_schema_ok "$FIX/vuln.json"            || fail "vuln (valid stamp) should pass schema_ok"
+echo "OK: vuln (valid stamp) passes schema_ok"
+! cache_schema_ok "$FIX/wrong_producer.json"  || fail "wrong_producer must FAIL schema_ok"
+echo "OK: wrong_producer fails schema_ok (rejected → re-analyze)"
+! cache_schema_ok "$FIX/unknown_schema.json"  || fail "unknown_schema must FAIL schema_ok"
+echo "OK: unknown_schema fails schema_ok (rejected → re-analyze)"
+! cache_schema_ok "$FIX/legacy_no_schema.json" || fail "legacy (no stamp) must FAIL schema_ok"
+echo "OK: legacy pre-#9 object (no stamp) fails schema_ok (transparently re-analyzed)"
+! cache_schema_ok "$FIX/does-not-exist.json"   || fail "missing file must FAIL schema_ok"
+echo "OK: missing file fails schema_ok"
+
+# ---- fail-SAFE field reads (cache_read_bool <file> <path> <safe>) ----
+# Present, genuine booleans read through as-is.
+eq "clean osv.clear=true"        "$(cache_read_bool "$FIX/complete_clean.json" '.osv.clear' false)"       "true"
+eq "clean scorecard.pass=true"   "$(cache_read_bool "$FIX/complete_clean.json" '.scorecard.pass' false)"  "true"
+eq "clean changelog.breaking=false" "$(cache_read_bool "$FIX/complete_clean.json" '.changelog.breaking' true)" "false"
+# Legitimate not-clear / not-pass / breaking read through.
+eq "vuln osv.clear=false"        "$(cache_read_bool "$FIX/vuln.json" '.osv.clear' false)"                  "false"
+eq "vuln changelog.breaking=true" "$(cache_read_bool "$FIX/vuln.json" '.changelog.breaking' true)"         "true"
+# MISSING fields resolve to the SAFE value — the live bug #9 fixes (pre-#9 these
+# defaulted PERMISSIVE: osv.clear→"true", scorecard.pass→"true", breaking→"false").
+eq "missing osv.clear -> SAFE false"        "$(cache_read_bool "$FIX/missing_fields.json" '.osv.clear' false)"       "false"
+eq "missing scorecard.pass -> SAFE false"   "$(cache_read_bool "$FIX/missing_fields.json" '.scorecard.pass' false)"  "false"
+eq "missing changelog.breaking -> SAFE true" "$(cache_read_bool "$FIX/missing_fields.json" '.changelog.breaking' true)" "true"
+
+echo "ALL TESTS PASSED"

--- a/tests/cache-read.test.sh
+++ b/tests/cache-read.test.sh
@@ -59,5 +59,11 @@ eq "vuln changelog.breaking=true" "$(cache_read_bool "$FIX/vuln.json" '.changelo
 eq "missing osv.clear -> SAFE false"        "$(cache_read_bool "$FIX/missing_fields.json" '.osv.clear' false)"       "false"
 eq "missing scorecard.pass -> SAFE false"   "$(cache_read_bool "$FIX/missing_fields.json" '.scorecard.pass' false)"  "false"
 eq "missing changelog.breaking -> SAFE true" "$(cache_read_bool "$FIX/missing_fields.json" '.changelog.breaking' true)" "true"
+# TYPE STRICTNESS: a quoted "true"/"false" STRING is NOT a boolean → SAFE. `jq -r`
+# renders string "true" and boolean true identically, so without a type check a
+# poisoned {"clear":"true"} string would read as clear. Must route to SAFE.
+eq "string osv.clear='true' -> SAFE false"       "$(cache_read_bool "$FIX/string_booleans.json" '.osv.clear' false)"       "false"
+eq "string scorecard.pass='false' -> SAFE false" "$(cache_read_bool "$FIX/string_booleans.json" '.scorecard.pass' false)"  "false"
+eq "string changelog.breaking='false' -> SAFE true" "$(cache_read_bool "$FIX/string_booleans.json" '.changelog.breaking' true)" "true"
 
 echo "ALL TESTS PASSED"

--- a/tests/fixtures/cache-read/complete_clean.json
+++ b/tests/fixtures/cache-read/complete_clean.json
@@ -1,0 +1,1 @@
+{"schema_version":"1","producer":"coalfire-org-dependabot-auto-merge","dependency":"actions/checkout","version":"4.2.0","analyzed_at":"2026-07-06T00:00:00Z","osv":{"clear":true,"vulns":[]},"scorecard":{"score":"9","pass":true},"changelog":{"breaking":false,"confidence":0.9,"summary":"no breaking changes"},"applies_to_repo":true}

--- a/tests/fixtures/cache-read/legacy_no_schema.json
+++ b/tests/fixtures/cache-read/legacy_no_schema.json
@@ -1,0 +1,1 @@
+{"dependency":"actions/checkout","version":"4.2.0","analyzed_at":"2026-07-06T00:00:00Z","osv":{"clear":true},"scorecard":{"pass":true},"changelog":{"breaking":false}}

--- a/tests/fixtures/cache-read/missing_fields.json
+++ b/tests/fixtures/cache-read/missing_fields.json
@@ -1,0 +1,1 @@
+{"schema_version":"1","producer":"coalfire-org-dependabot-auto-merge","dependency":"actions/checkout","version":"4.2.0","analyzed_at":"2026-07-06T00:00:00Z"}

--- a/tests/fixtures/cache-read/string_booleans.json
+++ b/tests/fixtures/cache-read/string_booleans.json
@@ -1,0 +1,1 @@
+{"schema_version":"1","producer":"coalfire-org-dependabot-auto-merge","osv":{"clear":"true"},"scorecard":{"pass":"false"},"changelog":{"breaking":"false"}}

--- a/tests/fixtures/cache-read/unknown_schema.json
+++ b/tests/fixtures/cache-read/unknown_schema.json
@@ -1,0 +1,1 @@
+{"schema_version":"999","producer":"coalfire-org-dependabot-auto-merge","osv":{"clear":true},"scorecard":{"pass":true},"changelog":{"breaking":false}}

--- a/tests/fixtures/cache-read/vuln.json
+++ b/tests/fixtures/cache-read/vuln.json
@@ -1,0 +1,1 @@
+{"schema_version":"1","producer":"coalfire-org-dependabot-auto-merge","osv":{"clear":false,"vulns":["CVE-x"]},"scorecard":{"score":"3","pass":false},"changelog":{"breaking":true}}

--- a/tests/fixtures/cache-read/wrong_producer.json
+++ b/tests/fixtures/cache-read/wrong_producer.json
@@ -1,0 +1,1 @@
+{"schema_version":"1","producer":"attacker-poisoned","osv":{"clear":true},"scorecard":{"pass":true},"changelog":{"breaking":false}}


### PR DESCRIPTION
## Item #9 — Harden the S3 cache (fail-safe reads + schema/producer validation)

Grade-A plan **item #9** (TOP priority). The cached supply-chain / breaking-change objects gate the merge decision, but the reads defaulted missing fields to the **permissive** value, so a partial / corrupt / poisoned object on the shared key namespace could silently suppress an OSV, scorecard, or breaking-change block for the whole TTL window. #10 moved these reads/writers into `scripts/*.sh`, so this hardening is now unit-tested.

### What changed
- **`scripts/cache-lib.sh`** (new, sourced — pure bash+jq, no aws/network):
  - `cache_schema_ok <file>` — accept only an object whose `schema_version` **and** `producer` match the constants.
  - `cache_read_bool <file> <path> <safe>` — return the cached value only if it is a **genuine boolean**, else the caller's SAFE value. (Deliberately avoids jq's `// default`, which fires on `false` as well as `null` — a real bug I hit and pinned in tests.)
- **`supply-chain-check.sh` / `breaking-change-check.sh`** — on a TTL-valid hit, `cache_schema_ok` is checked **first** (mismatch / unknown schema / legacy-unstamped → treated as a **miss** → re-analyze, AC-3), then the gate fields read **fail-safe**: `osv.clear`→`false` (not-clear), `scorecard.pass`→`false` (not-pass), `changelog.breaking`→`true` (breaking) — so a degraded cache routes to block/manual-review, **never approve** (AC-1). `applies_to_repo` stays non-gating but is validated. All **3 writers** stamp `schema_version` + `producer` (AC-2).
- **docs** — required least-privilege bucket policy: `s3:PutObject` on `analyses/*` restricted to the CI OIDC role (AC-4 evidence, below).

### Acceptance criteria
- [x] **AC-1** Missing/non-boolean `osv.clear`/`scorecard.pass`/`changelog.breaking` → SAFE (block/manual), never approve; `applies_to_repo` non-gating default validated.
- [x] **AC-2** Every cache write (`supply-chain-check.sh`, `breaking-change-check.sh` shared + repo) emits `schema_version` + `producer`.
- [x] **AC-3** Unrecognized `schema_version` **or** unexpected `producer` → rejected (cache miss → re-analyze). Every pre-#9 object (no stamp) is transparently re-analyzed on rollout.
- [x] **AC-4** Write access restricted to the CI OIDC role — bucket-side IAM, not CI-testable. Evidence below + documented in `docs/ORG_DEPENDABOT_AUTO_MERGE.md`.

### AC-4 — required bucket policy (out-of-band IAM evidence)
```json
{
  "Version": "2012-10-17",
  "Statement": [{
    "Sid": "AutomergeCacheWriteOnlyFromCIRole",
    "Effect": "Deny", "Principal": "*", "Action": "s3:PutObject",
    "Resource": "arn:aws:s3:::<cache-bucket>/analyses/*",
    "Condition": { "StringNotEquals": { "aws:PrincipalArn": "<AUTOMERGE_DEPENDABOT_ROLE_ARN>" } }
  }]
}
```
This is a bucket-side control the workflow YAML cannot enforce or test; applying it is an ops action. The read-side `schema_version`/`producer` validation is the CI-enforceable defence-in-depth.

### Validated testing (local)
```
$ bash tests/*.test.sh          # all PASS incl. cache-read (and #10's auto-merge-decide unchanged)
$ shellcheck scripts/*.sh       # CLEAN (exit 0)
$ SHELLCHECK_OPTS="-S warning" actionlint   # CLEAN
```
Expected-PASS / Expected-FAIL (permissive path):
```
missing osv.clear:          OLD `// "true"` → true (fail-OPEN)   NEW → false (fail-SAFE)
missing changelog.breaking: OLD `// "false"`→ false (fail-OPEN)  NEW → true  (fail-SAFE)
wrong_producer / unknown_schema / legacy_no_schema → REJECTED (re-analyze)
legit osv.clear=false / changelog.breaking=true → read through unchanged
```

Serial chain **#9 → #12 → #13** (then the `pr-green-merge.sh` fallback adoption). Based on main `7096d01`. **Do not merge — lead merges;** I rebase + ship #12 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S

---
### Review riders addressed (from #173 review)
1. **jq type strictness (baked in):** `cache_read_bool` never uses jq `//` (fires on `false`) **and** type-checks `(path|type)=="boolean"` — a quoted `"true"`/`"false"` **string** is not a boolean → SAFE. New `string_booleans.json` fixture + assertions pin this (a poisoned `{"clear":"true"}` string reads as not-clear, not clear).
2. **One-time cache stampede (expected, not a regression):** every pre-#9 object lacks `schema_version`, so the **first** post-merge run treats the entire cache as a MISS and re-analyzes every dependency once (live OSV + Scorecard + Bedrock calls). Expect a slower first cycle / elevated API rate for that run only; writers repopulate with the new schema and steady-state resumes next cycle. This is correct behavior — do not misread the first slow sweep as a regression. (#13's retry/jitter further smooths this burst.)
3. **AC-4 bucket policy — Status: PENDING, owner: ops.** The policy JSON above is the *required* control; it is **not yet applied** and CI cannot apply it (no bucket-side access). Tracked in [#174](https://github.com/Coalfire-CF/Actions/issues/174) — apply before any `strict`/live-critical reliance. The read-side schema/producer validation shipped here is the CI-enforceable defence-in-depth that stands regardless.
