### PR TITLE
fix(auto-merge): shared retry-lib (jitter+backoff) across external calls + staggered schedule (grade-A #13)

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -87,6 +87,15 @@ on:
         required: false
         type: number
         default: 30
+      jitter_max_seconds:
+        description: >-
+          Max seconds for a random pre-call delay before the first external API
+          call in each check job (grade-A #13). De-syncs the fleet-wide daily
+          Dependabot burst so OSV/Scorecard/Bedrock/GitHub see a spread-out load.
+          0 disables.
+        required: false
+        type: number
+        default: 30
       actions_ref:
         description: >-
           Git ref of Coalfire-CF/Actions to load the extracted decision scripts
@@ -327,6 +336,7 @@ jobs:
           S3_BUCKET: ${{ inputs.s3_cache_bucket }}
           CACHE_TTL_DAYS: ${{ inputs.cache_ttl_days }}
           SCORECARD_THRESHOLD: ${{ inputs.scorecard_threshold }}
+          JITTER_MAX_SECONDS: ${{ inputs.jitter_max_seconds }}
         run: |
           set -euo pipefail
           bash "${GITHUB_WORKSPACE}/actions-tools/scripts/supply-chain-check.sh"
@@ -451,6 +461,7 @@ jobs:
           CACHE_TTL_DAYS: ${{ inputs.cache_ttl_days }}
           BEDROCK_MODEL_ID: ${{ inputs.bedrock_model_id }}
           GH_TOKEN: ${{ github.token }}
+          JITTER_MAX_SECONDS: ${{ inputs.jitter_max_seconds }}
         run: |
           set -euo pipefail
           bash "${GITHUB_WORKSPACE}/actions-tools/scripts/breaking-change-check.sh"

--- a/.github/workflows/org-dependabot-reconcile.yml
+++ b/.github/workflows/org-dependabot-reconcile.yml
@@ -80,18 +80,21 @@ jobs:
           : "${GH_TOKEN:?missing app token}"
           echo "Reconcile sweep — owner=${OWNER} dry_run=${DRY_RUN} method=${MERGE_METHOD} cap=${MAX_PRS}"
 
-          # Enumerate open org PRs labeled merge/approved (capped). Bounded retry
-          # on a transient search blip (minimal guard, not #13's full backoff).
-          attempt=1
-          until PRS="$(gh search prs --owner "$OWNER" --state open --label 'merge/approved' --limit "$MAX_PRS" --json repository,number 2>/dev/null)"; do
-            if [ "$attempt" -ge 3 ]; then
-              echo "::error::gh search failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "transient gh search failure (attempt ${attempt}/3); retrying"
-            attempt=$((attempt + 1))
-            sleep "$attempt"
-          done
+          # Shared bounded-retry helper (grade-A #13) — one implementation, not three.
+          # shellcheck source=scripts/retry-lib.sh
+          . "${GITHUB_WORKSPACE}/scripts/retry-lib.sh"
+
+          # Enumerate open org PRs labeled merge/approved (capped). A gh-search
+          # blip is treated as transient (retry with backoff); persistent failure
+          # is a hard error (the sweep can't run blind).
+          _search_prs() {
+            gh search prs --owner "$OWNER" --state open --label 'merge/approved' \
+              --limit "$MAX_PRS" --json repository,number 2>/dev/null || return "$RETRY_TRANSIENT_RC"
+          }
+          if ! PRS="$(with_retry 3 2 20 -- _search_prs)"; then
+            echo "::error::gh search failed after retries"
+            exit 1
+          fi
 
           COUNT="$(printf '%s' "$PRS" | jq 'length')"
           echo "Found ${COUNT} open merge/approved PR(s)."

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -82,6 +82,17 @@ jobs:
           REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
           EXCLUDE_PATHS="${EXCLUDE_PATHS:-}"
 
+          # Deterministic per-repo schedule offset (grade-A #13): spread the
+          # fleet's daily Dependabot fanout across the day instead of a shared
+          # top-of-window herd. Same repo name -> same HH:MM slot (idempotent
+          # re-runs = zero diff; no runtime randomness). This is the identical
+          # algorithm as scripts/stagger-slot.sh — the canonical, unit-tested
+          # reference (tests/stagger-slot.test.sh); the generator runs in the
+          # consumer checkout so it inlines rather than self-checking-out Actions.
+          STAGGER_HEX="$(printf '%s' "${GITHUB_REPOSITORY:-unknown/unknown}" | sha256sum | cut -c1-8)"
+          STAGGER_MIN=$(( 16#$STAGGER_HEX % 1440 ))
+          STAGGER_TIME="$(printf '%02d:%02d' $(( STAGGER_MIN / 60 )) $(( STAGGER_MIN % 60 )))"
+
           log() { printf '%s\n' "$*" >&2; }
           die() { log "ERROR: $*"; exit 1; }
 
@@ -268,6 +279,7 @@ jobs:
               directory: "${d}"
               schedule:
                 interval: "${DEFAULT_INTERVAL}"
+                time: "${STAGGER_TIME}"
               commit-message:
                 prefix: "chore"
                 include: "scope"

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -46,6 +46,16 @@ set -euo pipefail
 # Prompt-injection-resistant Bedrock prompt builders (grade-A #12).
 # shellcheck source=scripts/prompt-lib.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/prompt-lib.sh"
+# Shared bounded-retry + jitter helper (grade-A #13).
+# shellcheck source=scripts/retry-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/retry-lib.sh"
+
+# Tunables for external-call retry (transient-only; fail closed on exhaustion).
+RETRY_MAX="${RETRY_MAX:-3}"
+RETRY_BASE="${RETRY_BASE:-2}"
+RETRY_CAP="${RETRY_CAP:-20}"
+# One-time pre-call jitter to de-sync the daily fleet burst (0 disables).
+jitter_delay "${JITTER_MAX_SECONDS:-0}"
 
 # Grouped-PR support: each dependency is analyzed individually and
 # folded into aggregates (semver = max, breaking = OR). Bedrock/API
@@ -209,11 +219,17 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
     fi
 
     for TAG_FMT in "${CANDIDATE_TAGS[@]}"; do
-      NOTES=$(curl -sf --max-time 15 \
+      # Transient (429/5xx/timeout) retries with backoff (grade-A #13); a 404 is
+      # the EXPECTED "tag not found" case (permanent, no spin) → try the next tag.
+      if BODY=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
+        http_retryable --max-time 15 \
         -H "Authorization: token ${GH_TOKEN}" \
         -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/${UPSTREAM_REPO}/releases/tags/${TAG_FMT}" \
-        2>/dev/null | jq -r '.body // ""' || echo "")
+        "https://api.github.com/repos/${UPSTREAM_REPO}/releases/tags/${TAG_FMT}"); then
+        NOTES=$(printf '%s' "$BODY" | jq -r '.body // ""')
+      else
+        NOTES=""
+      fi
       if [ -n "$NOTES" ]; then
         echo "Found release notes at tag: ${TAG_FMT}"
         RELEASE_NOTES="$NOTES"
@@ -253,13 +269,16 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
 
   echo '{"maxTokens":512}' > /tmp/bedrock_config.json
 
-  # Fail CLOSED on Bedrock error (the old fallback silently
-  # defaulted to breaking=false — an unanalyzed dep is NOT safe).
-  if ! AI_RESPONSE=$(aws bedrock-runtime converse \
+  # Fail CLOSED on Bedrock error (the old fallback silently defaulted to
+  # breaking=false — an unanalyzed dep is NOT safe). Throttling/5xx/timeout
+  # retries with backoff (grade-A #13); a terminal or non-throttle error still
+  # fails closed (CHECK_ERRORS -> decide manual review).
+  if ! AI_RESPONSE=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
+    bedrock_retryable converse \
     --model-id "$BEDROCK_MODEL_ID" \
     --messages file:///tmp/bedrock_messages.json \
     --inference-config file:///tmp/bedrock_config.json \
-    --output json 2>/tmp/bedrock_err.log); then
+    --output json); then
     echo "::warning::Bedrock analysis FAILED for ${DEP_NAME} — failing closed"
     CHECK_ERRORS=$((CHECK_ERRORS + 1))
     AI_RESPONSE='{"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":0,\"risks\":[\"API call failed\"],\"summary\":\"Analysis errored — routed to manual review\"}"}]}}}'
@@ -377,11 +396,14 @@ if [ "$SHARED_CACHE_HIT" = "true" ] && [ "$REPO_CACHE_HIT" = "false" ]; then
   # Applicability errors stay conservative (assume it applies) but
   # do NOT count as CHECK_ERRORS: applies_to_repo never gates the
   # decision, and defaulting to true is already the safe direction.
-  APPLY_RESPONSE=$(aws bedrock-runtime converse \
+  # Transient retries (grade-A #13); on terminal failure keep the conservative
+  # fallback (assume it applies — non-gating, already the safe direction).
+  APPLY_RESPONSE=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
+    bedrock_retryable converse \
     --model-id "$BEDROCK_MODEL_ID" \
     --messages file:///tmp/bedrock_apply_messages.json \
     --inference-config file:///tmp/bedrock_apply_config.json \
-    --output json 2>/tmp/bedrock_apply_err.log \
+    --output json \
     || echo '{"output":{"message":{"content":[{"text":"{\"applies_to_repo\":true,\"summary\":\"Unable to assess applicability — defaulting to assume it applies\"}"}]}}}')
 
   APPLY_TEXT=$(echo "$APPLY_RESPONSE" | jq -r '.output.message.content[0].text // "{}"')

--- a/scripts/pr-green-merge.sh
+++ b/scripts/pr-green-merge.sh
@@ -45,6 +45,11 @@
 #
 set -euo pipefail
 
+# Shared bounded-retry helper (grade-A #13): gh_read now delegates to with_retry
+# rather than carrying its own retry loop (one implementation, not three).
+# shellcheck source=scripts/retry-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/retry-lib.sh"
+
 PR_NUMBER="${PR_NUMBER:?PR_NUMBER required}"
 REPO="${REPO:?REPO required (owner/name)}"
 MERGE_METHOD="${MERGE_METHOD:-squash}"
@@ -59,30 +64,28 @@ AUTHOR_ALLOWLIST="${AUTHOR_ALLOWLIST:-app/dependabot dependabot[bot]}"
 # log to STDERR so a retry message never contaminates a $(gh_read ...) capture.
 log() { echo "[pr-green-merge] $*" >&2; }
 
-# Bounded-retry wrapper for a transient gh READ failure (rate blips / 5xx). Only
-# used for read calls; a merge is issued at most once. Prints command stdout on
-# success; returns the last non-zero code after RETRY_MAX attempts (surfacing the
-# last stderr line for diagnosability).
-gh_read() {
-  local out rc attempt=1 errf
+# _gh_read_once <gh-args...> : run one gh read. Prints stdout + returns 0 on
+# success; on any failure logs the last stderr line (STDERR only) and returns
+# $RETRY_TRANSIENT_RC so with_retry treats a gh blip as transient (matches the
+# prior retry-any-failure behavior).
+_gh_read_once() {
+  local out errf
   errf="$(mktemp)"
-  while :; do
-    if out="$(gh "$@" 2>"$errf")"; then
-      rm -f "$errf"
-      printf '%s' "$out"
-      return 0
-    else
-      rc=$?
-    fi
-    if [ "$attempt" -ge "$RETRY_MAX" ]; then
-      log "gh $* failed after ${attempt} attempt(s) (rc=${rc}): $(tail -n1 "$errf" 2>/dev/null)"
-      rm -f "$errf"
-      return "$rc"
-    fi
-    log "transient gh read failure (attempt ${attempt}/${RETRY_MAX}); retrying"
-    attempt=$((attempt + 1))
-    sleep "$attempt"
-  done
+  if out="$(gh "$@" 2>"$errf")"; then
+    rm -f "$errf"
+    printf '%s' "$out"
+    return 0
+  fi
+  log "gh $* failed: $(tail -n1 "$errf" 2>/dev/null)"
+  rm -f "$errf"
+  return "$RETRY_TRANSIENT_RC"
+}
+
+# gh_read <gh-args...> : bounded-retry gh READ via the shared helper. rc-on-
+# failure capture + stderr-only logging are guaranteed by with_retry (re-pinned
+# in tests/retry-lib.test.sh). A merge is still issued at most once (never via this).
+gh_read() {
+  with_retry "$RETRY_MAX" 1 8 -- _gh_read_once "$@"
 }
 
 # One combined read: PR state + draft + author + review decision + check rollup.

--- a/scripts/retry-lib.sh
+++ b/scripts/retry-lib.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# retry-lib.sh — the single shared bounded-retry + jitter helper for the
+# Dependabot auto-merge platform (grade-A plan #13). Converges the three ad-hoc
+# retry stubs that previously existed (the inline external-call error handling in
+# supply-chain-check.sh / breaking-change-check.sh, pr-green-merge.sh's gh_read,
+# and the reconcile sweeper's gh-search loop) onto ONE implementation.
+#
+# Model: transient-only retry. with_retry retries a command ONLY when it exits
+# with $RETRY_TRANSIENT_RC; exit 0 = success (stop), any other exit = permanent
+# failure (stop immediately). This forces every call site to classify its own
+# failures on EVIDENCE (HTTP status / CLI stderr) rather than blindly retrying —
+# and to default UNKNOWN failures to permanent (fail toward the caller's existing
+# fail-closed routing, never spin). Thin classifier wrappers (http_retryable,
+# bedrock_retryable) supply that evidence per call site.
+#
+# Sleeping goes through _retry_sleep so tests can substitute a mock clock (record
+# delays, never actually sleep). Pure bash + coreutils; unit-tested by
+# tests/retry-lib.test.sh.
+
+# Exit code a command uses to request a retry. 75 = EX_TEMPFAIL (sysexits.h).
+: "${RETRY_TRANSIENT_RC:=75}"
+
+# _retry_sleep <seconds> : real sleep. Tests override this to record instead.
+_retry_sleep() { sleep "$1"; }
+
+# _retry_log <msg> : logs go to STDERR only, so a $(with_retry ...) capture is
+# never contaminated (a lesson from #172/#173).
+_retry_log() { echo "[retry] $*" >&2; }
+
+# _backoff_delay <attempt> <base> <cap> : exponential backoff base*2^(attempt-1),
+# capped at <cap>, plus random jitter in [0, base). attempt is 1-based.
+_backoff_delay() {
+  local attempt="$1" base="$2" cap="$3" exp jitter span
+  exp=$(( base * (1 << (attempt - 1)) ))
+  [ "$exp" -gt "$cap" ] && exp="$cap"
+  span=$(( base > 0 ? base : 1 ))
+  jitter=$(( RANDOM % span ))
+  echo $(( exp + jitter ))
+}
+
+# jitter_delay <max_j> : sleep a random pre-delay in [0, max_j] to de-synchronise
+# a fleet-wide burst before the first external call of a run.
+jitter_delay() {
+  local max="$1" d
+  [ "${max:-0}" -gt 0 ] || return 0
+  d=$(( RANDOM % (max + 1) ))
+  _retry_log "pre-call jitter ${d}s"
+  _retry_sleep "$d"
+}
+
+# with_retry <max_attempts> <base_delay_s> <cap_delay_s> -- <cmd...>
+#   exit 0                    -> success; with_retry returns 0 (cmd's stdout flows through)
+#   exit $RETRY_TRANSIENT_RC  -> transient; retry with backoff+jitter up to max_attempts
+#   any other exit            -> permanent; return that code immediately (no retry)
+# After exhausting attempts on transient failures, returns $RETRY_TRANSIENT_RC.
+with_retry() {
+  local max="$1" base="$2" cap="$3"; shift 3
+  [ "${1:-}" = "--" ] && shift
+  local attempt=1 rc delay
+  while :; do
+    "$@"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      return 0
+    elif [ "$rc" -ne "$RETRY_TRANSIENT_RC" ]; then
+      return "$rc"                       # permanent — do not retry
+    elif [ "$attempt" -ge "$max" ]; then
+      _retry_log "transient failure persisted after ${attempt} attempt(s)"
+      return "$RETRY_TRANSIENT_RC"
+    fi
+    delay="$(_backoff_delay "$attempt" "$base" "$cap")"
+    _retry_log "transient (attempt ${attempt}/${max}); backing off ${delay}s"
+    _retry_sleep "$delay"
+    attempt=$(( attempt + 1 ))
+  done
+}
+
+# http_retryable <curl-args...> : run curl capturing the HTTP status code; print
+# the response body to stdout. Classification (EVIDENCE = captured http_code):
+#   2xx                         -> 0 (success)
+#   429 / 5xx / 000 (timeout/conn) / empty -> $RETRY_TRANSIENT_RC (retry)
+#   any other definitive code (4xx) -> 1 (permanent; do not spin on a 400/404)
+# Run under with_retry. Uses -sS (surface transport errors to stderr) not -f, so
+# the body is available for classification even on an error status.
+http_retryable() {
+  local resp code body
+  resp="$(curl -sS -w '\n%{http_code}' "$@" 2>/dev/null)" || resp="${resp:-}"$'\n'000
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  case "$code" in
+    2[0-9][0-9])                 printf '%s' "$body"; return 0 ;;
+    429|5[0-9][0-9]|000|"")      return "$RETRY_TRANSIENT_RC" ;;
+    *)                           return 1 ;;
+  esac
+}
+
+# bedrock_retryable <aws-bedrock-runtime-args...> : run the AWS CLI Bedrock call
+# (which yields no HTTP code) capturing stderr; print stdout on success.
+# Classification (EVIDENCE = exit code + stderr patterns):
+#   exit 0                                          -> 0 (success)
+#   stderr matches throttle/5xx/timeout signatures  -> $RETRY_TRANSIENT_RC (retry)
+#   any other failure (Validation/AccessDenied/UNKNOWN) -> 1 (permanent)
+# UNKNOWN defaults to permanent: fail toward the caller's manual-review routing,
+# never spin on an unclassifiable error.
+bedrock_retryable() {
+  local out errf rc
+  errf="$(mktemp)"
+  out="$(aws bedrock-runtime "$@" 2>"$errf")"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    rm -f "$errf"
+    printf '%s' "$out"
+    return 0
+  fi
+  if grep -qiE 'Throttl|TooManyRequests|ServiceUnavailable|InternalServerError|RequestTimeout|Timeout|ServiceQuota|(^|[^0-9])(429|500|502|503|504)([^0-9]|$)' "$errf"; then
+    _retry_log "bedrock transient: $(tail -n1 "$errf" 2>/dev/null)"
+    rm -f "$errf"
+    return "$RETRY_TRANSIENT_RC"
+  fi
+  _retry_log "bedrock permanent (not retrying): $(tail -n1 "$errf" 2>/dev/null)"
+  rm -f "$errf"
+  return 1
+}

--- a/scripts/stagger-slot.sh
+++ b/scripts/stagger-slot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# stagger-slot.sh <repo-name> — deterministic daily-schedule slot (HH:MM) derived
+# from a hash of the repo name (grade-A plan #13). Spreads the fleet's Dependabot
+# fanout across the 24h window instead of a shared top-of-window herd.
+#
+# DETERMINISTIC by design: the same repo name ALWAYS yields the same slot, so
+# regenerating a repo's dependabot.yml produces zero diff. No runtime randomness.
+set -euo pipefail
+
+name="${1:?repo name required}"
+# First 8 hex chars of the SHA-256 → a 32-bit int → minute-of-day in [0,1439].
+hex="$(printf '%s' "$name" | sha256sum | cut -c1-8)"
+minute=$(( 16#$hex % 1440 ))
+printf '%02d:%02d\n' $(( minute / 60 )) $(( minute % 60 ))

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -39,6 +39,17 @@ set -euo pipefail
 # schema_version/producer validation.
 # shellcheck source=scripts/cache-lib.sh
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cache-lib.sh"
+# Shared bounded-retry + jitter helper (grade-A #13).
+# shellcheck source=scripts/retry-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/retry-lib.sh"
+
+# Tunables for external-call retry (transient-only; fail closed on exhaustion).
+RETRY_MAX="${RETRY_MAX:-3}"
+RETRY_BASE="${RETRY_BASE:-2}"
+RETRY_CAP="${RETRY_CAP:-20}"
+# One-time pre-call jitter to de-sync the daily fleet burst (0 disables; the
+# workflow sets JITTER_MAX_SECONDS). Runs once per job, before the first call.
+jitter_delay "${JITTER_MAX_SECONDS:-0}"
 
 # Grouped-PR support: every dependency in the PR is checked
 # individually and folded into AND/OR aggregates. Any per-dep
@@ -111,17 +122,19 @@ if [ "$CACHE_HIT" = "false" ]; then
 
   OSV_VULNS="[]"
   if [ -n "$OSV_ECOSYSTEM" ]; then
-    # Fail CLOSED on query error: a failed OSV call is NOT a clean
-    # result (the old `|| echo` fail-open let vulns through silently).
-    if ! OSV_RESPONSE=$(curl -sf --max-time 30 \
+    # Fail CLOSED on query error: a failed OSV call is NOT a clean result.
+    # Transient (429/5xx/timeout) retries with backoff+jitter (grade-A #13); a
+    # terminal failure still fails closed (CHECK_ERRORS -> decide manual review).
+    OSV_PAYLOAD=$(jq -n \
+      --arg pkg "$DEP_NAME" \
+      --arg ver "$TO_VERSION" \
+      --arg eco "$OSV_ECOSYSTEM" \
+      '{package: {name: $pkg, ecosystem: $eco}, version: $ver}')
+    if ! OSV_RESPONSE=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
+      http_retryable --max-time 30 \
       -X POST "https://api.osv.dev/v1/query" \
       -H "Content-Type: application/json" \
-      -d "$(jq -n \
-        --arg pkg "$DEP_NAME" \
-        --arg ver "$TO_VERSION" \
-        --arg eco "$OSV_ECOSYSTEM" \
-        '{package: {name: $pkg, ecosystem: $eco}, version: $ver}')" \
-      2>/dev/null); then
+      -d "$OSV_PAYLOAD"); then
       echo "::warning::OSV query FAILED for ${DEP_NAME}@${TO_VERSION} — failing closed"
       CHECK_ERRORS=$((CHECK_ERRORS + 1))
       OSV_RESPONSE='{"vulns":[]}'
@@ -157,9 +170,13 @@ if [ "$CACHE_HIT" = "false" ]; then
   esac
 
   if [ -n "$SCORECARD_REPO" ]; then
-    SCORECARD_RESPONSE=$(curl -sf --max-time 30 \
+    # Transient retries (grade-A #13); on terminal failure preserve today's
+    # conservative fallback — empty object → score 0 → not-pass (blocks, unless
+    # first-party-waived). Not a CHECK_ERROR (matches prior behavior).
+    SCORECARD_RESPONSE=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
+      http_retryable --max-time 30 \
       "https://api.securityscorecards.dev/projects/${SCORECARD_REPO}" \
-      2>/dev/null || echo '{}')
+      || echo '{}')
     SCORECARD_SCORE=$(echo "$SCORECARD_RESPONSE" | jq -r '.score // 0')
 
     if [ "$(echo "$SCORECARD_SCORE < $SCORECARD_THRESHOLD" | bc -l)" -eq 1 ]; then

--- a/tests/retry-lib.test.sh
+++ b/tests/retry-lib.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Meta-test for scripts/retry-lib.sh (grade-A plan #13): the single shared
+# bounded-retry + jitter helper. Uses a MOCK CLOCK (_retry_sleep override) so no
+# test actually sleeps, and mock curl/aws shims to exercise the evidence-based
+# transient classification.
+#
+# Also re-pins the two hard-won gh_read properties (from #172/#173) at the
+# with_retry level so the convergence can't regress them:
+#   - a permanent failure's exit code is captured and returned (not masked to 0);
+#   - retry logging goes to STDERR only (never contaminates a $(...) capture).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${REPO_ROOT}/scripts/retry-lib.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$LIB" ] || fail "retry-lib.sh not found at $LIB"
+# shellcheck source=scripts/retry-lib.sh
+. "$LIB"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+DELAYS="$WORK/delays"; : > "$DELAYS"
+
+# Mock clock: record requested delays, never sleep.
+_retry_sleep() { echo "$1" >> "$DELAYS"; }
+
+# ---- with_retry: transient twice then success → 2 recorded backoffs, strictly
+#      increasing, each within cap. ----
+: > "$DELAYS"; N=0
+flaky() { N=$((N + 1)); [ "$N" -ge 3 ] && { echo "OK-BODY"; return 0; }; return "$RETRY_TRANSIENT_RC"; }
+out="$(with_retry 5 1 8 -- flaky)"; rc=$?
+[ "$rc" -eq 0 ] || fail "flaky-then-success should return 0 (got $rc)"
+[ "$out" = "OK-BODY" ] || fail "success body should flow through (got '$out')"
+nd="$(wc -l < "$DELAYS" | tr -d ' ')"
+[ "$nd" -eq 2 ] || fail "expected exactly 2 backoffs before success, got $nd"
+d1="$(sed -n 1p "$DELAYS")"; d2="$(sed -n 2p "$DELAYS")"
+[ "$d2" -gt "$d1" ] || fail "backoff not strictly increasing ($d1 then $d2)"
+[ "$d2" -le $((8 + 1)) ] || fail "backoff exceeded cap+jitter ($d2)"
+echo "OK: with_retry retries transient then succeeds — 2 increasing backoffs, body passthrough"
+
+# ---- with_retry: persistent transient → exhausts, returns RETRY_TRANSIENT_RC. ----
+: > "$DELAYS"
+always_transient() { return "$RETRY_TRANSIENT_RC"; }
+with_retry 3 1 8 -- always_transient; rc=$?
+[ "$rc" -eq "$RETRY_TRANSIENT_RC" ] || fail "persistent transient should return RETRY_TRANSIENT_RC (got $rc)"
+[ "$(wc -l < "$DELAYS" | tr -d ' ')" -eq 2 ] || fail "3 attempts should back off exactly twice"
+echo "OK: with_retry exhausts persistent transient and returns transient rc (caller fails closed)"
+
+# ---- with_retry: permanent failure → returned immediately, rc PRESERVED, no retry. ----
+: > "$DELAYS"
+permanent42() { return 42; }
+with_retry 5 1 8 -- permanent42; rc=$?
+[ "$rc" -eq 42 ] || fail "permanent rc must be captured & returned unchanged (got $rc, want 42)"
+[ "$(wc -l < "$DELAYS" | tr -d ' ')" -eq 0 ] || fail "permanent failure must not back off/retry"
+echo "OK: permanent failure returns its exact rc with zero retries (rc-capture property re-pinned)"
+
+# ---- stderr-only: retry logs must NOT appear on stdout (capture-safe). ----
+: > "$DELAYS"; N=0
+logout="$(with_retry 5 1 8 -- flaky 2>/dev/null)"
+[ "$logout" = "OK-BODY" ] || fail "captured stdout must be ONLY the body, no retry log lines (got '$logout')"
+echo "OK: retry logging is stderr-only (stdout capture uncontaminated)"
+
+# ---- jitter_delay: bounded pre-delay ∈ [0, J] over many samples; 0 → no sleep. ----
+: > "$DELAYS"
+for _ in $(seq 1 200); do jitter_delay 5 >/dev/null 2>&1; done
+awk 'NR{ if ($1<0 || $1>5) { print "OUT_OF_RANGE:"$1; exit 1 } } END{ if(NR<200) exit 1 }' "$DELAYS" \
+  || fail "jitter_delay produced an out-of-range or missing sample"
+[ "$(sort -u "$DELAYS" | wc -l | tr -d ' ')" -gt 1 ] || fail "jitter_delay is constant — not random"
+: > "$DELAYS"; jitter_delay 0; [ "$(wc -l < "$DELAYS" | tr -d ' ')" -eq 0 ] || fail "jitter_delay 0 must not sleep"
+echo "OK: jitter_delay bounded in [0,J], varies, and no-ops at 0"
+
+# ---- http_retryable: evidence-based classification via a mock curl shim. ----
+BIN="$WORK/bin"; mkdir -p "$BIN"
+cat > "$BIN/curl" <<'MOCK'
+#!/usr/bin/env bash
+[ "${MOCK_CURL_RC:-0}" != "0" ] && exit "$MOCK_CURL_RC"     # simulate transport failure (http_code 000)
+printf '%s\n%s' "${MOCK_BODY:-}" "${MOCK_CODE:-200}"
+MOCK
+chmod +x "$BIN/curl"
+export PATH="$BIN:$PATH"
+hget() { http_retryable https://example.test; }
+
+out="$(MOCK_CODE=200 MOCK_BODY='{"ok":true}' hget)"; rc=$?
+[ "$rc" -eq 0 ] && [ "$out" = '{"ok":true}' ] || fail "200 should succeed with body (rc=$rc out=$out)"
+( MOCK_CODE=503 hget ) >/dev/null 2>&1; [ $? -eq "$RETRY_TRANSIENT_RC" ] || fail "503 must be transient"
+( MOCK_CODE=429 hget ) >/dev/null 2>&1; [ $? -eq "$RETRY_TRANSIENT_RC" ] || fail "429 must be transient"
+( MOCK_CODE=404 hget ) >/dev/null 2>&1; [ $? -eq 1 ] || fail "404 must be permanent (no spin)"
+( MOCK_CURL_RC=28 hget ) >/dev/null 2>&1; [ $? -eq "$RETRY_TRANSIENT_RC" ] || fail "curl timeout (rc!=0 → code 000) must be transient"
+echo "OK: http_retryable — 2xx ok, 429/5xx/000 transient, 4xx permanent"
+
+# ---- bedrock_retryable: classification via a mock aws shim. ----
+cat > "$BIN/aws" <<'MOCK'
+#!/usr/bin/env bash
+if [ -n "${MOCK_AWS_ERR:-}" ]; then echo "$MOCK_AWS_ERR" >&2; exit 255; fi
+printf '%s' "${MOCK_AWS_OUT:-}"
+MOCK
+chmod +x "$BIN/aws"
+bget() { bedrock_retryable converse --model-id m; }
+
+out="$(MOCK_AWS_OUT='{"output":1}' bget)"; rc=$?
+[ "$rc" -eq 0 ] && [ "$out" = '{"output":1}' ] || fail "bedrock success should pass through (rc=$rc)"
+( MOCK_AWS_ERR='An error occurred (ThrottlingException) when calling Converse' bget ) >/dev/null 2>&1
+[ $? -eq "$RETRY_TRANSIENT_RC" ] || fail "ThrottlingException must be transient"
+( MOCK_AWS_ERR='An error occurred (ValidationException): bad input' bget ) >/dev/null 2>&1
+[ $? -eq 1 ] || fail "ValidationException must be permanent"
+( MOCK_AWS_ERR='some unclassifiable weirdness' bget ) >/dev/null 2>&1
+[ $? -eq 1 ] || fail "UNKNOWN error must default to permanent (never spin)"
+echo "OK: bedrock_retryable — success ok, throttle transient, validation/unknown permanent"
+
+echo "ALL TESTS PASSED"

--- a/tests/stagger-slot.test.sh
+++ b/tests/stagger-slot.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Meta-test for scripts/stagger-slot.sh (grade-A plan #13, rider 2): the per-repo
+# Dependabot schedule offset must be DETERMINISTIC (idempotent re-runs → zero
+# diff) and SPREAD across the day (no degenerate all-in-one-bin hash).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+S="${REPO_ROOT}/scripts/stagger-slot.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -x "$S" ] || chmod +x "$S"
+
+# ---- format: HH:MM, valid ranges ----
+slot="$("$S" Coalfire-CF/terraform-aws-rds)"
+echo "$slot" | grep -qE '^([01][0-9]|2[0-3]):[0-5][0-9]$' || fail "slot '$slot' is not valid HH:MM"
+echo "OK: slot format is valid HH:MM ($slot)"
+
+# ---- determinism: same name → same slot across repeated invocations ----
+a="$("$S" foo/bar)"; b="$("$S" foo/bar)"; c="$("$S" foo/bar)"
+[ "$a" = "$b" ] && [ "$b" = "$c" ] || fail "not deterministic: $a / $b / $c"
+echo "OK: deterministic — same repo name yields the same slot ($a) on every run"
+
+# ---- spread: 100 synthetic names must not all collapse into one bucket ----
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+for i in $(seq 1 100); do "$S" "Coalfire-CF/repo-${i}"; done > "$tmp"
+distinct_slots="$(sort -u "$tmp" | wc -l | tr -d ' ')"
+distinct_hours="$(cut -d: -f1 "$tmp" | sort -u | wc -l | tr -d ' ')"
+[ "$distinct_slots" -gt 1 ] || fail "degenerate: all 100 names mapped to ONE slot"
+[ "$distinct_hours" -gt 4 ] || fail "poor spread: only ${distinct_hours} distinct hours across 100 names"
+echo "OK: spread — 100 names → ${distinct_slots} distinct slots across ${distinct_hours} hours (not degenerate)"
+
+# ---- distinct names generally differ (sanity, not a hard uniqueness guarantee) ----
+[ "$("$S" org/alpha)" != "$("$S" org/omega)" ] || fail "two very different names collided (suspicious hash)"
+echo "OK: distinct names map to distinct slots (org/alpha != org/omega)"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Item #13 — Jitter + retry-with-backoff, converged onto one shared helper (grade-A #13)

Four external calls run with a timeout but no retry/jitter (a transient 429 turns an auto-mergeable PR into manual-review), and three separate ad-hoc retry stubs had accreted. This adds transient-only retry+backoff+jitter and **converges everything onto one tested helper**.

### Full step plan (as built)
1. **`scripts/retry-lib.sh`** (new, sourced, pure + mock-clockable):
   - `with_retry <max> <base> <cap> -- cmd…` — retries **only** on `$RETRY_TRANSIENT_RC` (75); exit 0 = success, **any other exit = permanent → no retry**. This forces each call site to classify its own failures on evidence and default UNKNOWN → permanent (fail toward existing fail-closed routing, never spin).
   - `jitter_delay <J>` — random pre-call delay ∈ [0,J] to de-sync the fleet burst.
   - `http_retryable` (curl) — captures `%{http_code}`: **2xx** ok / **429·5xx·000(timeout)** transient / **4xx** permanent.
   - `bedrock_retryable` (aws CLI, no http_code) — classifies on exit + stderr signatures (Throttling/5xx/Timeout → transient; Validation/AccessDenied/**UNKNOWN → permanent**).
   - Sleep via `_retry_sleep` (tests substitute a mock clock); logs **stderr-only**.
2. **Rewired the 4 calls** to `with_retry` + the right classifier: OSV + Scorecard (`supply-chain-check.sh`), GitHub release-notes + Bedrock (`breaking-change-check.sh`, both prompts). Terminal failure preserves today's fail-closed routing. The release-notes **404 stays permanent** so the candidate-tag iteration is unaffected (no spin on "tag not found").
3. **Converged the other two stubs:** `pr-green-merge.sh` `gh_read` now delegates to `with_retry` (a gh blip → transient); `org-dependabot-reconcile.yml` sources retry-lib and wraps `gh search` in `with_retry`. **One retry implementation, not three.**
4. **`scripts/stagger-slot.sh`** (new) + `org-dependabot.yml` generator emits a deterministic per-repo `schedule.time:` (`sha256(repo)→HH:MM`), spreading the daily fanout. New `jitter_max_seconds` workflow input (default 30) drives the pre-call jitter.
5. **Tests:** `tests/retry-lib.test.sh` + `tests/stagger-slot.test.sh`.

### Riders addressed
1. **Evidence-based classification (rider 1):** `http_retryable` keys off the captured `%{http_code}`; `bedrock_retryable` (no http_code) classifies on exit code + stderr patterns, documented per call site, **UNKNOWN → non-retryable** (fail toward manual review, never spin). Both proven in the test via mock curl/aws shims.
2. **Deterministic stagger, no runtime randomness (rider 2):** offset = hash of repo name. `tests/stagger-slot.test.sh` asserts **same name → same slot** (idempotent, zero-diff re-runs) and **spread** (100 synthetic names → 96 distinct slots across 23 hours; no degenerate all-in-one-bin).
3. **`gh_read` carry-forward:** the convergence preserves both hard-won properties — **rc captured on failure** (with_retry returns the permanent rc unchanged; transient-rc on exhaustion) and **stderr-only logging** — re-pinned directly in `tests/retry-lib.test.sh` (`permanent42` → rc 42 with zero retries; stdout-capture-uncontaminated case). `tests/reconcile-sweeper.test.sh` still passes unchanged, confirming behavior held.

### Validated testing (local)
```
$ bash tests/*.test.sh          # all 10 PASS (retry-lib, stagger-slot, + the 8 prior)
$ shellcheck scripts/*.sh       # CLEAN
$ SHELLCHECK_OPTS="-S warning" actionlint   # CLEAN
```
Key retry-lib assertions:
```
with_retry: transient×2 then success → 2 strictly-increasing backoffs, body passthrough
with_retry: persistent transient → exhausts, returns transient rc (caller fails closed)
with_retry: permanent → returns exact rc, ZERO retries (rc-capture re-pinned)
retry logging is stderr-only (capture uncontaminated)
jitter_delay bounded ∈ [0,J], varies, no-ops at 0
http_retryable: 2xx ok · 429/5xx/000 transient · 4xx permanent
bedrock_retryable: success ok · throttle transient · validation/unknown permanent
stagger-slot: deterministic + 96/100 distinct slots across 23 hours
```

Serial chain **#9 ✅ → #12 ✅ → #13 (this) → adoption PR (4th)**. Based on main `56120a7`. **Do not merge — lead merges;** the adoption PR (auto-merge fallback → `pr-green-merge.sh`) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S
