### PR TITLE
refactor(auto-merge): adopt shared pr-green-merge.sh in the direct-merge fallback (grade-A chain closer)

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -636,17 +636,15 @@ jobs:
           PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')
           AUTO_ON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json autoMergeRequest --jq '.autoMergeRequest != null')
           if [ "$PR_STATE" = "OPEN" ] && [ "$AUTO_ON" != "true" ]; then
-            # Neither merged nor armed: safe to merge directly only if no check
-            # is failing or still pending (mirrors the auto-merge green gate).
-            CHECK_STATE=$(gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" 2>&1 | awk -F'\t' '
-              $2=="fail"{f=1} $2=="pending"{p=1}
-              END{ if(f) print "FAIL"; else if(p) print "PENDING"; else print "GREEN" }')
-            if [ "$CHECK_STATE" = "GREEN" ]; then
-              gh pr merge "$PR_NUMBER" "--${MERGE_METHOD}" --repo "$GITHUB_REPOSITORY"
-              echo "Merged PR #${PR_NUMBER} directly (auto-merge could not latch on clean PR)"
-            else
-              echo "PR #${PR_NUMBER} checks ${CHECK_STATE} — leaving for auto-merge/next event"
-            fi
+            # Neither merged nor armed: delegate the green-gate + direct-merge to
+            # the shared helper (grade-A #14 adoption) instead of an inline
+            # gh-pr-checks|awk gate. Same decision — merge iff the PR is a clean,
+            # green, non-draft trusted-author PR — via the canonical
+            # scripts/pr-green-merge.sh (statusCheckRollup gate; a transient
+            # checks-API error can no longer read as GREEN; a review-blocked PR is
+            # skipped cleanly rather than crashing on a rejected merge).
+            PR_NUMBER="$PR_NUMBER" REPO="$GITHUB_REPOSITORY" MERGE_METHOD="$MERGE_METHOD" DRY_RUN=false \
+              bash "${GITHUB_WORKSPACE}/actions-tools/scripts/pr-green-merge.sh"
           else
             echo "Auto-merge armed (or PR already merged) for PR #${PR_NUMBER}"
           fi

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -226,7 +226,9 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
         -H "Authorization: token ${GH_TOKEN}" \
         -H "Accept: application/vnd.github+json" \
         "https://api.github.com/repos/${UPSTREAM_REPO}/releases/tags/${TAG_FMT}"); then
-        NOTES=$(printf '%s' "$BODY" | jq -r '.body // ""')
+        # `|| echo ""` guards a 2xx-but-non-JSON body: jq would exit non-zero and,
+        # under set -e, crash the run (near-unreachable, but degrade gracefully).
+        NOTES=$(printf '%s' "$BODY" | jq -r '.body // ""' 2>/dev/null || echo "")
       else
         NOTES=""
       fi

--- a/tests/stagger-slot.test.sh
+++ b/tests/stagger-slot.test.sh
@@ -36,4 +36,13 @@ echo "OK: spread — 100 names → ${distinct_slots} distinct slots across ${dis
 [ "$("$S" org/alpha)" != "$("$S" org/omega)" ] || fail "two very different names collided (suspicious hash)"
 echo "OK: distinct names map to distinct slots (org/alpha != org/omega)"
 
+# ---- drift guard: org-dependabot.yml inlines this same algorithm (the generator
+#      runs in the consumer checkout, so it can't source this script). Pin the two
+#      load-bearing lines so the inline copy can't silently diverge. ----
+GEN="${REPO_ROOT}/.github/workflows/org-dependabot.yml"
+[ -f "$GEN" ] || fail "generator workflow not found at $GEN"
+grep -q 'sha256sum | cut -c1-8' "$GEN" || fail "generator drift: missing 'sha256sum | cut -c1-8' (must match ${S})"
+grep -q '% 1440' "$GEN"                || fail "generator drift: missing '% 1440' (must match ${S})"
+echo "OK: org-dependabot.yml inline stagger algorithm matches the canonical script (drift-guarded)"
+
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Adoption PR (chain 4/4, final) — fallback → shared `pr-green-merge.sh`

Grade-A chain closer (#14 option-B follow-up). The "Approve and auto-merge" step's inline green-gate + direct-merge is refactored onto the canonical `scripts/pr-green-merge.sh` (the same helper the reconcile sweeper uses) — **one green-gate/merge implementation, not two.** Plus the two non-blocking fold-ins from the #176 review.

### Before → after (decision path)
The approve + `gh pr merge --auto` arming and the outer `OPEN && !auto-armed` guard are **unchanged**. Only the inner direct-merge block changes:

| Step | Before (inline) | After (pr-green-merge.sh) |
|------|-----------------|---------------------------|
| gate to run at all | `PR_STATE==OPEN && AUTO_ON!=true` | same (outer guard kept) |
| still-open re-check | — | `state==OPEN` (re-read) |
| draft | not checked | never merge a draft |
| author | not checked | must be `app/dependabot`/`dependabot[bot]` (always true here) |
| review | not checked | skip if `REVIEW_REQUIRED`/`CHANGES_REQUESTED` |
| green gate | `gh pr checks 2>&1 \| awk` → FAIL>PENDING>GREEN | `statusCheckRollup` → **same** FAIL>PENDING>GREEN precedence |
| merge action | `gh pr merge --$METHOD` iff GREEN | `gh pr merge --$METHOD` iff GREEN |
| outcome | merged / left-for-next-event | MERGED / SKIP `#n (reason)` |

**Honest scope — this is decision-equivalent, not byte-identical.** In the normal path (a just-approved, clean, green Dependabot PR) the outcome is the same: merge. The deltas are all in the **safe** direction and I'm calling them out rather than hiding them behind a "pure refactor" label:

1. **Green gate impl differs** (`statusCheckRollup` vs `gh pr checks 2>&1 | awk`). Same classification, but the old inline gate piped stderr into awk — a **transient checks-API error produced no fail/pending lines → GREEN → merge** (fail-open). The shared helper reads structured `statusCheckRollup` via a retried `gh pr view`; a transient error → SKIP (fail-closed). Strictly safer.
2. **Adds draft/author/review guards.** For the fallback's own context (author is Dependabot, PR just approved) these pass or are moot. The one behavioral change: a repo whose branch protection is *not* satisfied by the app approval (`reviewDecision=REVIEW_REQUIRED`) — the **old** code ran `gh pr merge`, GitHub rejected it, and under `set -euo pipefail` the **job failed** (false-alarm failure notification); the **new** code SKIPs cleanly. Both leave the PR unmerged; new is quieter and correct.

If you'd rather keep it *literally* byte-identical (extract only the `gh pr checks|awk` gate into a shared fn and forgo the statusCheckRollup/guard improvements), say the word — but I believe adopting the hardened helper is the intent of the convergence and the safer result.

### Fold-ins (from #176 review)
1. `breaking-change-check.sh`: restored `|| echo ""` on the `NOTES` jq parse — a 2xx-but-non-JSON release body can't `set -e`-crash the run.
2. `tests/stagger-slot.test.sh`: **drift guard** — greps `org-dependabot.yml` for the two load-bearing inline lines (`sha256sum | cut -c1-8`, `% 1440`) so the generator's inlined stagger algorithm can't silently diverge from the canonical `scripts/stagger-slot.sh`.

### Validated testing (local)
```
$ bash tests/*.test.sh          # all 10 PASS (incl. stagger-slot drift guard)
$ shellcheck scripts/*.sh       # CLEAN
$ SHELLCHECK_OPTS="-S warning" actionlint   # CLEAN
```
`pr-green-merge.sh` resolves via the decide job's existing `actions-tools` self-checkout (added in #10). Based on main `b726d61`.

Chain: **#9 ✅ #12 ✅ #13 ✅ → adoption (this)**. After merge the chain closes → release + AC audit. **Do not merge — lead merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S
