### PR TITLE
docs(auto-merge): link AC-4 bucket-policy tracking issue (#174), mark PENDING/owner

### DIFF
--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -154,6 +154,11 @@ Create an S3 bucket for cross-repo analysis caching:
   than trusted, and missing gate fields fail closed (block/manual-review), never
   approve.
 
+  > **Status: PENDING — owner: ops.** This bucket policy is the required control
+  > but is applied out-of-band (CI has no bucket-side access). Tracked in
+  > [Coalfire-CF/Actions#174](https://github.com/Coalfire-CF/Actions/issues/174);
+  > apply before any `strict`/live-critical reliance on the cache.
+
 The cache uses a two-tier layout to share universal data across repos while keeping
 repo-specific analysis scoped:
 


### PR DESCRIPTION
Recovers the 5-line doc callout from 406c19f (AC-4 status PENDING / owner / #174 link), which raced the #173 squash-merge by 19s and never landed on main. Clean cherry-pick onto current main; supersedes the conflicting #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S