### PR TITLE
fix(mdlint): relax cosmetic rules — enforce well-formed markdown, not perfection

### DIFF
--- a/.github/workflows/org-markdown-lint.yml
+++ b/.github/workflows/org-markdown-lint.yml
@@ -61,17 +61,38 @@ jobs:
         {
           "ignores": ["CHANGELOG.md", "**/CHANGELOG.md"],
           "config": {
+            // Policy: enforce well-formed markdown that renders correctly;
+            // do NOT enforce cosmetic perfection. Rules that catch real
+            // rendering/structural breakage (malformed heading syntax, broken
+            // list nesting, spaces inside emphasis/code/links, empty links)
+            // stay on via "default": true. Everything below is a deliberate
+            // relaxation for authored + machine-generated docs.
             "default": true,
-            "MD013": false,
-            "MD024": false,
-            "MD033": false,
-            "MD041": false,
-            "MD034": false,
-            "MD060": false,
+            // -- style pins (single style where consistency matters) --
             "MD029": { "style": "one" },
             "MD035": { "style": "---" },
             "MD046": { "style": "fenced" },
-            "MD048": { "style": "backtick" }
+            "MD048": { "style": "backtick" },
+            // -- cosmetic rules relaxed: formatted well, not perfect --
+            "MD001": false,                    // heading levels may skip; renders fine
+            "MD004": false,                    // mixed -/* bullets across generated+authored sections
+            "MD007": false,                    // list indent width varies by generator
+            "MD009": false,                    // trailing spaces are invisible and harmless
+            "MD010": { "code_blocks": false }, // tabs inside code fences are legitimate (Go/Makefile/TF)
+            "MD012": false,                    // multiple blank lines (release-please, authored docs)
+            "MD013": false,                    // line length
+            "MD024": false,                    // duplicate headings (changelogs, per-env sections)
+            "MD025": false,                    // multiple H1 (terraform-docs merged READMEs)
+            "MD026": false,                    // trailing punctuation in headings
+            "MD033": false,                    // inline HTML
+            "MD034": false,                    // bare URLs
+            "MD036": false,                    // bold-line-as-heading (common authored pattern)
+            "MD040": false,                    // fence language tag optional
+            "MD041": false,                    // first line need not be a heading
+            "MD049": false,                    // _em_ vs *em* style
+            "MD050": false,                    // __strong__ vs **strong** style
+            "MD051": false,                    // anchor fragments — lychee owns link checking
+            "MD060": false
           }
         }
         JSONC


### PR DESCRIPTION
Per Doug: the markdown linter is too strict on auto-generated and Claude-authored docs (example: terraform-aws-airlock#87, release-please CHANGELOG tripping MD012).

**Policy:** keep every rule that catches real rendering/structural breakage; relax cosmetic perfection.

| Kept (via `default: true`) | Relaxed |
|---|---|
| heading syntax (MD018–MD023), list nesting (MD005), spaces in emphasis/code/links (MD037–MD039), reversed/empty links (MD011/MD042), blanks around fences/lists (MD031/MD032), style pins (MD029/MD035/MD046/MD048) | line length, blank-line counts, bullet/indent styles, trailing spaces, tabs **inside code fences**, dup headings, multiple H1, heading punctuation/level-skips, bold-as-heading, bare URLs, inline HTML, fence language tags, em/strong style, anchor fragments (lychee owns links) |

**Validated:** fixture with all relaxed offenses → 0 errors; fixture with reversed link + empty link + space-in-emphasis → still fails.

Notes: CHANGELOG.md remains fully ignored (already on main, unreleased). Repos with their own `.markdownlint*` config still override this fallback. Fleet gets this at the v0.11 re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S