### PR TITLE
fix(ci): actor-gate push-back workflows for read-only Dependabot token (#149)

### DIFF
--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -389,8 +389,12 @@ jobs:
           echo "---- changed files ----"
           git diff --name-only -- . ':!**/.git/**' || true
 
+      # ACTOR-gate the push (issue #149): a Dependabot-actor run gets a read-only
+      # GITHUB_TOKEN and would false-red on push. Gated on github.actor (token
+      # capability), not pull_request.user.login — a human push to a Dependabot
+      # branch gets a write token and should push.
       - name: Commit & push (if changed)
-        if: ${{ steps.run.outputs.exit_code == '10' }}
+        if: ${{ steps.run.outputs.exit_code == '10' && github.actor != 'dependabot[bot]' }}
         env:
           HEAD_BRANCH: ${{ inputs.head_branch }}
           COMMIT_MESSAGE: ${{ inputs.commit_message }}
@@ -401,6 +405,18 @@ jobs:
           git add -A
           git commit -m "${COMMIT_MESSAGE}"
           git push origin "HEAD:${HEAD_BRANCH}"
+
+      # Keep the drift visible on Dependabot runs (can't push; read-only token
+      # also can't comment) — annotation + step summary.
+      - name: Report dependabot.yml drift (Dependabot read-only token)
+        if: ${{ steps.run.outputs.exit_code == '10' && github.actor == 'dependabot[bot]' }}
+        run: |
+          echo "::warning::.github/dependabot.yml is out of date on this Dependabot PR and could not be auto-pushed (read-only Dependabot token). A maintainer push — or @dependabot rebase after a human commit — will refresh it (issue #149)."
+          {
+            echo "### dependabot.yml drift (not auto-pushed)"
+            echo ""
+            echo "This PR runs under the read-only Dependabot token; the regenerated dependabot.yml could not be committed. Push as a maintainer to refresh it."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   notify-failure:
     needs: sync

--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -180,6 +180,13 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Kill the closed-unmerged false-red fleet-wide (issue #149): release-please
+    # has nothing to do on a PR that closed without merging. Non-PR events
+    # (push/schedule/dispatch) and merged PRs still run; downstream jobs already
+    # chain off release_created, so no consumer edit is needed.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.merged == true
 
     permissions:
       contents: write

--- a/.github/workflows/org-terraform-docs.yml
+++ b/.github/workflows/org-terraform-docs.yml
@@ -32,24 +32,56 @@ on:
 permissions:
   contents: write
 
+# Serialize per PR (or per ref for a post-merge regen); cancel superseded PR runs.
+concurrency:
+  group: terraform-docs-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
     docs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
-            ref: ${{ github.event.pull_request.head.ref }}
+            # `|| github.ref_name` lets this also run in a post-merge push:main
+            # regen mode (issue #149 re-pin-wave opt-in), not only on PR events.
+            ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
         - name: Render terraform docs inside the README.md and push changes back to PR branch
           uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
           with:
             find-dir: ${{ inputs.find-dir }}
-            git-push: "true"
+            # ACTOR-gate the push (issue #149): a Dependabot-actor run gets a
+            # read-only GITHUB_TOKEN, so git-push would false-red. Render still
+            # runs; only the push is suppressed. String ternary — the action
+            # input is a string. Gated on github.actor (token capability), NOT
+            # pull_request.user.login: a human push to a Dependabot branch gets a
+            # write token and SHOULD push.
+            git-push: ${{ github.actor != 'dependabot[bot]' && 'true' || 'false' }}
             output-file: README.md
             output-method: inject
             recursive: ${{ inputs.recursive }}
             recursive-path: ${{ inputs.recursive-path }}
             working-dir: ${{ inputs.working-dir }}
+
+        # Drift-critical: README version tables DO change on provider bumps, so a
+        # Dependabot run that can't push must still surface the drift. The
+        # read-only token can't comment, so warn + summarize the diffstat.
+        - name: Report terraform-docs drift (Dependabot read-only token)
+          if: ${{ github.actor == 'dependabot[bot]' }}
+          run: |
+            if git diff --quiet; then
+              echo "terraform-docs: no README drift."
+            else
+              echo "::warning::terraform-docs README is out of date on this Dependabot PR and could not be auto-pushed (read-only Dependabot token). A maintainer push — or @dependabot rebase after a human commit — will refresh it (issue #149)."
+              {
+                echo "### terraform-docs README drift (not auto-pushed)"
+                echo ""
+                echo '```'
+                git diff --stat || true
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
 
     notify-failure:
       needs: docs

--- a/.github/workflows/org-tree-readme.yml
+++ b/.github/workflows/org-tree-readme.yml
@@ -26,6 +26,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize per PR (or per ref for non-PR events); cancel superseded PR runs.
+concurrency:
+  group: tree-readme-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-readme-on-pr:
     runs-on: ubuntu-latest
@@ -158,8 +163,14 @@ jobs:
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit 0
 
+      # ACTOR-gate the push (issue #149): a Dependabot-actor run gets a READ-ONLY
+      # GITHUB_TOKEN and cannot see the App secrets, so the push is structurally
+      # impossible and would false-red. We gate on github.actor (token capability),
+      # NOT pull_request.user.login — a human pushing to a Dependabot branch gets a
+      # WRITE token and SHOULD push. This is a deliberate divergence from the
+      # auto-merge login gate, whose job is authorship trust, not token capability.
       - name: Commit & push if changed
-        if: ${{ steps.run.outputs.exit_code == '10' }}
+        if: ${{ steps.run.outputs.exit_code == '10' && github.actor != 'dependabot[bot]' }}
         env:
           COMMIT_MSG: ${{ inputs.commit_message }}
         run: |
@@ -170,6 +181,18 @@ jobs:
           fi
           git commit -m "$COMMIT_MSG"
           git push origin HEAD
+
+      # Keep the drift VISIBLE on Dependabot runs (can't push). The read-only token
+      # can't post a PR comment, so an annotation + step summary is the only channel.
+      - name: Report README-tree drift (Dependabot read-only token)
+        if: ${{ steps.run.outputs.exit_code == '10' && github.actor == 'dependabot[bot]' }}
+        run: |
+          echo "::warning::README tree is out of date on this Dependabot PR and could not be auto-pushed (read-only Dependabot token). A maintainer commit/push — or @dependabot rebase after one — will refresh it."
+          {
+            echo "### README tree drift (not auto-pushed)"
+            echo ""
+            echo "This PR runs under the read-only Dependabot token, so the tree README update could not be committed. Push a commit as a maintainer to refresh it (issue #149)."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   notify-failure:
     needs: update-readme-on-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
     name: Self-scan — gitleaks (full history)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Merged-gate (issue #149): a closed-unmerged PR has nothing to release —
+    # skip all jobs so a superseded close stops burning 3 self-scan runners.
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     permissions:
       contents: read
     steps:
@@ -56,6 +59,7 @@ jobs:
     name: Self-scan — trivy (secret/misconfig/vuln)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     permissions:
       contents: read
     steps:
@@ -79,6 +83,7 @@ jobs:
     name: Self-scan — actionlint
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     permissions:
       contents: read
     steps:
@@ -106,6 +111,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [self-scan-gitleaks, self-scan-trivy, self-scan-actionlint]
+    # Merged-gate + actor-gate (issue #149): a Dependabot-actor run cannot see the
+    # RELEASE_APP secrets (Actions-store only) and its read-only token can't push,
+    # so release-please would 403. A skipped release self-heals — release-please
+    # scans ALL commits since the last tag on the next human/App-actor run, so no
+    # release is lost by skipping here.
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.merged == true) &&
+      github.actor != 'dependabot[bot]'
 
     permissions:
       contents: write
@@ -113,5 +126,30 @@ jobs:
       issues: write
 
     steps:
+      # App-token wiring mirrored verbatim from org-release.yml: falls back to
+      # github.token when RELEASE_APP_* is absent. Bonus — App-created release PRs
+      # get CI runs (a GITHUB_TOKEN-created PR does not).
+      - name: Check for GitHub App credentials
+        id: check-app
+        env:
+          APP_ID: ${{ secrets.RELEASE_APP_ID }}
+        run: |
+          if [[ -n "${APP_ID}" ]]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::GitHub App credentials not found — falling back to github.token"
+          fi
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.check-app.outputs.available == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Run Release Please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Called by downstream repos on pull requests.
 | Gitleaks | `org-gitleaks-pr.yml` | Secret detection on PR commits |
 | Terraform Validate | `org-terraform-validate.yml` | `terraform init` + `terraform validate` with PR comment |
 | Terraform fmt | `org-terraform-fmt.yml` | Format check and auto-fix for Terraform files |
-| Terraform Docs | `org-terraform-docs.yml` | Auto-generate and commit terraform-docs output |
+| Terraform Docs | `org-terraform-docs.yml` | Auto-generate and commit terraform-docs output (check-only on Dependabot PRs — read-only token can't push; drift surfaced as a warning, [#149](https://github.com/Coalfire-CF/Actions/issues/149)) |
 | Terraform Plan | `org-terraform-plan.yml` | Terraform plan with PR comment |
 | Terraform Apply | `org-terraform-apply.yml` | Terraform apply (manual trigger or post-merge) |
 | Markdown Lint | `org-markdown-lint.yml` | Lint changed markdown files with markdownlint-cli2 |
-| Tree README | `org-tree-readme.yml` | Auto-generate and commit directory tree in README |
+| Tree README | `org-tree-readme.yml` | Auto-generate and commit directory tree in README (check-only on Dependabot PRs — read-only token can't push; drift surfaced as a warning, [#149](https://github.com/Coalfire-CF/Actions/issues/149)) |
 | Dependabot Refresh | `org-dependabot.yml` | Auto-detect ecosystems and regenerate dependabot.yml |
 | Dependabot Auto-Merge | `org-dependabot-auto-merge.yml` | Evaluate and auto-merge non-terraform Dependabot PRs ([docs](docs/ORG_DEPENDABOT_AUTO_MERGE.md)) |
 | Label Sync | `org-label-sync.yml` | Sync Dependabot auto-merge label taxonomy to downstream repos ([taxonomy](docs/ORG_LABEL_TAXONOMY.md)) |


### PR DESCRIPTION
## Issue #149 — push-back workflows false-red on Dependabot PRs

**Root mechanism:** a Dependabot-actor run gets a **read-only** `GITHUB_TOKEN` and sees only *Dependabot* org secrets (`RELEASE_APP_*` are Actions-store only). So every App-token/App-push path is structurally dead for this class — the push-back steps 403 and false-red. Fix: **actor-gate the writes, keep drift visible, stop closed-unmerged runs.** YAML-only (four one-line gates + report steps; no decision logic worth a script).

Gated on **`github.actor`** (token capability), **not** `pull_request.user.login`: a human pushing to a Dependabot branch gets a *write* token and SHOULD push — a deliberate divergence from the auto-merge login gate (whose job is authorship trust). **No `pull_request_target`** anywhere (these execute PR content).

### Changes
1. **`org-tree-readme.yml`** — actor-gate `Commit & push`; drift `::warning::` + step summary on Dependabot runs; workflow `concurrency` (cancel-in-progress).
2. **`org-terraform-docs.yml`** — checkout `ref: …head.ref || github.ref_name` (post-merge regen mode); `git-push: ${{ github.actor != 'dependabot[bot]' && 'true' || 'false' }}` (string ternary); drift **diffstat** warning (README version tables change on provider bumps — drift-critical); concurrency.
3. **`org-dependabot.yml`** — actor-gate `Commit & push (if changed)` + drift warning.
4. **`org-release.yml`** — release job `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true` — kills closed-unmerged false-red fleet-wide, **zero consumer edits** (downstream jobs already chain off `release_created`).
5. **`release.yml` (local)** — merged-gate ALL jobs (stop burning 3 self-scan runners per superseded close) + actor-gate the release job (Dependabot can't see `RELEASE_APP_*` → release-please would 403; a skipped release **self-heals** — release-please scans all commits since the last tag on the next human/App run) + wired the check-app/app-token/fallback block verbatim (bonus: App-created release PRs get CI runs).
6. **README** — tree/docs rows note the Dependabot check-only behavior + #149 crossref.

`org-terraform-version-check.yml` left **untouched** (schedule/dispatch only — Dependabot can't initiate; a gate would be dead code).

### Failure-mode table

| Scenario | Behavior |
|---|---|
| **Dependabot PR** (read-only token) | Push steps **skip**; drift surfaced as `::warning::` + step summary (annotation is the only channel — read-only token can't comment). Green, not red. |
| **Human PR** | Push runs **unchanged** (write token). |
| **Human push to a Dependabot branch** | `github.actor` = the human → push **runs** (write token; actor-gate matches capability exactly). |
| **Closed-unmerged PR** | release job + local self-scans **all skip** (merged-gate) — no false-red, no wasted runners. |
| **Merged / push / schedule / dispatch** | Runs normally. |

Loop safety of the post-merge `org-terraform-docs` leg is inherent: `GITHUB_TOKEN` pushes don't retrigger, consumer path filters (`**.tf`) exclude a README-only commit, and no-diff = no commit.

### Validated testing (local, exact CI invocations)
```
$ SHELLCHECK_OPTS="-S warning" actionlint      # CLEAN (all workflows)
$ shellcheck scripts/*.sh                       # CLEAN
$ bash tests/*.test.sh                           # all 11 PASS (unchanged; this PR is YAML-only)
$ markdownlint-cli2 README.md                    # 0 errors (repo config)
```

### NOT in this PR — re-pin-wave items (recorded per plan)
- Consumer trigger fixes (delete `types: [opened]` from validate callers — guardduty).
- Job rename `create-release` → `terraform-validate` (verify required-check names first).
- CS-SIEM-Tooling legacy `shirakiya` workflow replacement.
- Docs-caller `push: branches: [main]` + tf-paths leg (post-merge regen opt-in).
- `@dependabot rebase` to flush frozen reds.
- **Deferred:** registering `RELEASE_APP_*` as Dependabot org secrets (security-surface expansion; unneeded once merges are App-authored).

Based on main `6c93507` (v0.11.0). **Do not merge — lead merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S
