### PR TITLE
feat(ci): dogfood org reusable workflows (auto-merge, label-sync, tree-readme)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot Auto-Merge
+
+# Self-caller: evaluates this repo's own Dependabot PRs for auto-merge
+# (classify -> supply-chain + breaking-change + Bedrock changelog checks ->
+# approve+merge or label for review). Fixes the gap where PR #192 got no
+# evaluation. pull_request_target is required so the reusable has write
+# access + org secrets on Dependabot PRs (it only reads PR metadata, never
+# executes PR-branch code). Terraform bumps are always labeled blocked/*.
+# Reusable definition: ./.github/workflows/org-dependabot-auto-merge.yml
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: ./.github/workflows/org-dependabot-auto-merge.yml
+    secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,19 @@
+name: Sync Auto-Merge Labels
+
+# Self-caller: runs the org label-sync reusable on this repo so the
+# merge/*, dep/*, check/*, ai/*, risk/*, blocked/* label taxonomy that
+# org-dependabot-auto-merge.yml writes to always exists here.
+# Reusable definition: ./.github/workflows/org-label-sync.yml
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync-labels:
+    uses: ./.github/workflows/org-label-sync.yml
+    secrets: inherit

--- a/.github/workflows/tree-readme.yml
+++ b/.github/workflows/tree-readme.yml
@@ -1,0 +1,19 @@
+name: README Tree
+
+# Self-caller: regenerates the README `## Tree` section on this repo's PRs
+# using the on-repo .github/readmetreerc.yml config, so the repo dogfoods
+# the tree generator it publishes. No-op commit when the tree is unchanged.
+# Reusable definition: ./.github/workflows/org-tree-readme.yml
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  tree-readme:
+    uses: ./.github/workflows/org-tree-readme.yml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Called on merge to main.
 | Workflow | File | Description |
 |----------|------|-------------|
 | Local Release | `release.yml` | Release workflow for the Actions repo itself |
+| Sync Auto-Merge Labels | `label-sync.yml` | Self-caller: syncs the auto-merge label taxonomy on this repo (weekly + manual) |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -170,3 +170,96 @@ Issue labels:
 - Enhancement
 - Documentation
 - Code
+
+## Tree
+
+```text
+.
+|-- CHANGELOG.md
+|-- README.md
+|-- actions
+|   |-- gitleaks
+|       |-- action.yml
+|-- docs
+|   |-- GATE_CONFIG.md
+|   |-- GATE_PROMOTION.md
+|   |-- ORG_DEPENDABOT_AUTO_MERGE.md
+|   |-- ORG_JIRA_SYNC_SETUP.md
+|   |-- ORG_LABEL_TAXONOMY.md
+|   |-- ORG_OPA.md
+|   |-- ORG_RELEASE_AUTO_PATCH.md
+|   |-- ORG_RELEASE_CLEAN.md
+|   |-- ORG_SLACK_NOTIFY.md
+|   |-- ORG_SOURCE_PIN.md
+|   |-- ORG_TERRATEST.md
+|   |-- ORG_VERSION_BAND.md
+|   |-- superpowers
+|       |-- specs
+|           |-- 2026-07-14-self-dogfood-reusable-workflows-design.md
+|-- gate-config.yml
+|-- package-lock.json
+|-- package.json
+|-- release-please-config.json
+|-- renovate
+|   |-- terraform-ref-pins.json5
+|-- scripts
+|   |-- auto-merge-decide.sh
+|   |-- breaking-change-check.sh
+|   |-- cache-lib.sh
+|   |-- gate-config-resolve.sh
+|   |-- pr-green-merge.sh
+|   |-- prompt-lib.sh
+|   |-- release-patch-merge.sh
+|   |-- retry-lib.sh
+|   |-- source-pin-check.sh
+|   |-- stagger-slot.sh
+|   |-- supply-chain-check.sh
+|   |-- uses-pin-check.sh
+|   |-- version-band-check.sh
+|-- tests
+    |-- auto-merge-decide.test.sh
+    |-- cache-read.test.sh
+    |-- fixtures
+    |   |-- auto-merge-decide
+    |   |   |-- first_party_waiver.env
+    |   |   |-- major_blocked.env
+    |   |   |-- osv_blocked.env
+    |   |   |-- parse_error_manual.env
+    |   |-- cache-read
+    |   |   |-- complete_clean.json
+    |   |   |-- legacy_no_schema.json
+    |   |   |-- missing_fields.json
+    |   |   |-- string_booleans.json
+    |   |   |-- unknown_schema.json
+    |   |   |-- vuln.json
+    |   |   |-- wrong_producer.json
+    |   |-- release-patch
+    |   |   |-- changelog.base.md
+    |   |   |-- changelog.patch.md
+    |   |   |-- manifest.base.json
+    |   |   |-- manifest.patch.json
+    |   |   |-- snapshot.happy.json
+    |   |-- source-pin
+    |   |   |-- fail_branch.tf
+    |   |   |-- fail_floating.tf
+    |   |   |-- fail_sha.tf
+    |   |   |-- pass.tf
+    |   |   |-- pass_renovate.tf
+    |   |   |-- warn_tag.tf
+    |   |-- uses-pin
+    |       |-- fail_main.yml
+    |       |-- fail_sha_nocomment.yml
+    |       |-- pass_local.yml
+    |       |-- pass_sha.yml
+    |       |-- warn_tag.yml
+    |-- gate-config-resolve.test.sh
+    |-- prompt-build.test.sh
+    |-- reconcile-sweeper.test.sh
+    |-- release-patch-merge.test.sh
+    |-- retry-lib.test.sh
+    |-- source-pin-check.test.sh
+    |-- stagger-slot.test.sh
+    |-- tree-readme-section.test.sh
+    |-- uses-pin-check.test.sh
+    |-- version-band-check.test.sh
+```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Called on merge to main.
 |----------|------|-------------|
 | Local Release | `release.yml` | Release workflow for the Actions repo itself |
 | Sync Auto-Merge Labels | `label-sync.yml` | Self-caller: syncs the auto-merge label taxonomy on this repo (weekly + manual) |
+| README Tree | `tree-readme.yml` | Self-caller: regenerates the README `## Tree` section on this repo's PRs |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Called on merge to main.
 | Local Release | `release.yml` | Release workflow for the Actions repo itself |
 | Sync Auto-Merge Labels | `label-sync.yml` | Self-caller: syncs the auto-merge label taxonomy on this repo (weekly + manual) |
 | README Tree | `tree-readme.yml` | Self-caller: regenerates the README `## Tree` section on this repo's PRs |
+| Dependabot Auto-Merge (self) | `dependabot-auto-merge.yml` | Self-caller: runs auto-merge evaluation on this repo's own Dependabot PRs |
 
 ## Usage
 

--- a/docs/superpowers/specs/2026-07-14-self-dogfood-reusable-workflows-design.md
+++ b/docs/superpowers/specs/2026-07-14-self-dogfood-reusable-workflows-design.md
@@ -78,6 +78,7 @@ a regression. The full accounting is in the Gap Analysis below.
 ## The three new files
 
 ### `.github/workflows/dependabot-auto-merge.yml`
+
 ```yaml
 name: Dependabot Auto-Merge
 on:
@@ -89,6 +90,7 @@ jobs:
     uses: ./.github/workflows/org-dependabot-auto-merge.yml
     secrets: inherit
 ```
+
 `pull_request_target` (per the reusable workflow's header) so it gets write access
 plus the org secrets on Dependabot PRs. The reusable workflow owns its own per-PR
 `concurrency` group and re-applies the `dependabot[bot]` guard internally, so the
@@ -96,6 +98,7 @@ caller stays minimal. All reusable-workflow inputs are optional; defaults are
 correct for this repo.
 
 ### `.github/workflows/label-sync.yml`
+
 ```yaml
 name: Sync Auto-Merge Labels
 on:
@@ -107,10 +110,12 @@ jobs:
     uses: ./.github/workflows/org-label-sync.yml
     secrets: inherit
 ```
+
 No required inputs/secrets. Run once via `workflow_dispatch` at rollout so the
 label taxonomy exists before the first auto-merge evaluation.
 
 ### `.github/workflows/tree-readme.yml`
+
 ```yaml
 name: README Tree
 on:
@@ -121,6 +126,7 @@ jobs:
     uses: ./.github/workflows/org-tree-readme.yml
     secrets: inherit
 ```
+
 Idempotent: no-op commit when the tree is unchanged. On Dependabot PRs it is
 push-suppressed by design (read-only token → warn only), so it does not collide
 with the auto-merge caller.
@@ -161,8 +167,8 @@ with the auto-merge caller.
 1. A new Dependabot PR receives the `Dependabot Auto-Merge` check and (for an
    eligible non-Terraform bump) the classification labels + Bedrock changelog
    evaluation, and either auto-merges or is labeled for review.
-2. `label-sync` `workflow_dispatch` run creates/updates the full label taxonomy.
-3. A PR that changes the repo tree gets a `## Tree` README update committed by
+1. `label-sync` `workflow_dispatch` run creates/updates the full label taxonomy.
+1. A PR that changes the repo tree gets a `## Tree` README update committed by
    `tree-readme` (or a clean no-op when unchanged).
-4. All three new workflow files pass the repo's own `test-scripts.yml` lint
+1. All three new workflow files pass the repo's own `test-scripts.yml` lint
    (actionlint + N2 no-mutable-main-refs guard).

--- a/docs/superpowers/specs/2026-07-14-self-dogfood-reusable-workflows-design.md
+++ b/docs/superpowers/specs/2026-07-14-self-dogfood-reusable-workflows-design.md
@@ -1,0 +1,168 @@
+# Design: Dogfood the org reusable workflows on the Actions repo itself
+
+**Date:** 2026-07-14
+**Status:** Approved (design), pending implementation plan
+**Author:** Douglas Francis (with Claude Code)
+
+## Problem
+
+`Coalfire-CF/Actions` publishes ~24 reusable (`workflow_call`) workflows that the
+rest of the fleet consumes, but it does not run all of the applicable ones on
+**itself**. This surfaced when Dependabot PR
+[#192](https://github.com/Coalfire-CF/Actions/pull/192) received no auto-merge
+evaluation and no Bedrock changelog comment: the `org-dependabot-auto-merge.yml`
+reusable workflow has no self-caller in this repo, so the per-PR half of the
+Dependabot pipeline never runs here — even though the scheduled
+`org-dependabot-reconcile.yml` sweeper (which assumes that per-PR workflow ran)
+runs on cron.
+
+The goal: the Actions repo should exercise the same tooling it ships, wherever
+that tooling genuinely applies to a composite-actions + reusable-workflows +
+scripts repo (i.e. one with **no production Terraform**).
+
+## Scope decision
+
+"Everything applicable" — wire up every reusable workflow that has real work to
+do on this repo, and explicitly exclude the ones that would be no-ops, noise, or
+a regression. The full accounting is in the Gap Analysis below.
+
+## Gap analysis (all published reusable workflows)
+
+### Already dogfooding — no work
+
+| Workflow | How it self-triggers |
+|---|---|
+| `test-scripts.yml` | `pull_request` |
+| `org-markdown-lint.yml` | baked-in `pull_request` (paths `**.md`) |
+| `org-terraform-fmt.yml` | baked-in `pull_request` |
+| `org-terraform-source-pin.yml` | baked-in `pull_request` (incl. the `uses:` pin job, highly relevant here) |
+| `org-terraform-version-check.yml` | `schedule` |
+| `org-dependabot-reconcile.yml` | `schedule` (every 6h) + `workflow_dispatch` |
+| `release.yml` (Local Release) | `pull_request` closed→main; gates on gitleaks(full-history) + trivy(fs) + actionlint + release-please |
+
+### ADD a self-caller (applicable, currently dormant)
+
+| # | New caller file | Trigger | Calls | Rationale |
+|---|---|---|---|---|
+| 1 | `dependabot-auto-merge.yml` | `pull_request_target` [opened, synchronize, reopened], `if dependabot[bot]` | `./.github/workflows/org-dependabot-auto-merge.yml` | The #192 gap. Completes the per-PR producer the reconcile sweeper already assumes. |
+| 2 | `label-sync.yml` | `schedule` weekly + `workflow_dispatch` | `./.github/workflows/org-label-sync.yml` | Prerequisite for #1 — creates the `merge/*`, `dep/*`, `check/*`, `ai/*`, `risk/*`, `blocked/*` label taxonomy auto-merge writes. |
+| 3 | `tree-readme.yml` | `pull_request` branches [main] | `./.github/workflows/org-tree-readme.yml` | `.github/readmetreerc.yml` already present; workflow under active development yet never exercised on the repo's own PRs. |
+
+### Deferred (applicable but low-value / higher-friction)
+
+- **`dependabot-config-refresh.yml`** (`org-dependabot.yml`) — regenerates
+  `.github/dependabot.yml`. Deferred: this repo's ecosystem set changes rarely,
+  and a `pull_request`-triggered commit would race `tree-readme`'s commits on the
+  same human PRs. Revisit later, path-scoped, if desired.
+
+### Skip — not applicable / would be a regression
+
+| Workflow | Reason to skip |
+|---|---|
+| `org-trivy-pr.yml` | Scans changed `*.tf` only; repo has none but source-pin test fixtures → no-op. `self-scan-trivy` in `release.yml` already covers fs+vuln+secret as a **blocking** gate. |
+| `org-trivy-exception-review.yml` | No `.trivyignore.yaml` exists → pure no-op. |
+| `org-terraform-docs.yml` | No real modules with a README to inject → no-op / churn. |
+| `org-terraform-version-band.yml` | No real `required_version` constraints → no-op or fixture noise. |
+| `org-opa.yml` | No `.rego` policies; `org-opa-policies` not landed; no production Terraform → self-skips. |
+| `org-release.yml` (migration) | Keep `release.yml`. It runs scans as **blocking pre-gates**; `org-release.yml` runs them post-release/report-only and adds cosign tarballs a SHA-consumed repo does not need. Migrating would be a **security downgrade**. |
+
+### Borderline — creds exist, deliberately not wired (opt-in later)
+
+- **`org-gitleaks-pr.yml`** — would add earlier secret-scan feedback on *open* PRs,
+  but is PR-diff-only vs the stronger full-history blocking gate already in
+  `release.yml`. Complementary, mildly redundant. Not added.
+- **`org-jira-sync.yml`** — `JIRA_*` secrets exist org-wide, so it *could* mirror
+  this repo's issues into the org Jira project, but that pushes Actions-repo
+  issues into a shared tracker. Judgment call; not added.
+
+## The three new files
+
+### `.github/workflows/dependabot-auto-merge.yml`
+```yaml
+name: Dependabot Auto-Merge
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: ./.github/workflows/org-dependabot-auto-merge.yml
+    secrets: inherit
+```
+`pull_request_target` (per the reusable workflow's header) so it gets write access
+plus the org secrets on Dependabot PRs. The reusable workflow owns its own per-PR
+`concurrency` group and re-applies the `dependabot[bot]` guard internally, so the
+caller stays minimal. All reusable-workflow inputs are optional; defaults are
+correct for this repo.
+
+### `.github/workflows/label-sync.yml`
+```yaml
+name: Sync Auto-Merge Labels
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+jobs:
+  sync-labels:
+    uses: ./.github/workflows/org-label-sync.yml
+    secrets: inherit
+```
+No required inputs/secrets. Run once via `workflow_dispatch` at rollout so the
+label taxonomy exists before the first auto-merge evaluation.
+
+### `.github/workflows/tree-readme.yml`
+```yaml
+name: README Tree
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  tree-readme:
+    uses: ./.github/workflows/org-tree-readme.yml
+    secrets: inherit
+```
+Idempotent: no-op commit when the tree is unchanged. On Dependabot PRs it is
+push-suppressed by design (read-only token → warn only), so it does not collide
+with the auto-merge caller.
+
+## Conventions & constraints
+
+- **Local `./` path form, not `@main`.** `test-scripts.yml` (the N2 regression
+  lint) fails any internal sibling call that uses `@main`; self-callers must use
+  `uses: ./.github/workflows/<name>.yml`. Consumer-repo callers (in docs) keep the
+  pinned `@<sha>` form — that rule is for external consumers, not in-repo callers.
+- **`secrets: inherit`** on every caller so org-level `AUTOMERGE_*` and
+  `SLACK_BOT_TOKEN` (all `ALL` visibility) forward into the reusable workflow.
+
+## Prerequisites (status: all met)
+
+- `AUTOMERGE_CLIENT_ID`, `AUTOMERGE_APP_PRIVATE_KEY`,
+  `AUTOMERGE_DEPENDABOT_ROLE_ARN` — present as org secrets (`ALL` visibility);
+  the reconcile sweeper already uses the App successfully every 6h, so the
+  GitHub App + OIDC/S3/Bedrock role are proven working.
+- Labels — created by the new `label-sync` job (dispatch once at rollout).
+- `.github/readmetreerc.yml` — already present.
+
+## Risks & interactions
+
+- **auto-merge × tree-readme on Dependabot PRs:** auto-merge runs via
+  `pull_request_target`; tree-readme runs via `pull_request` but is push-suppressed
+  for the `dependabot[bot]` actor → no commit, no collision.
+- **auto-merge does not run on human PRs** (guarded to `dependabot[bot]`), so it
+  never competes with tree-readme's commits there.
+- **reconcile sweeper** is unchanged and now has the per-PR producer it assumed;
+  no behavioral change to it.
+- **Terraform module/provider bumps** are still labeled `blocked/*` for manual
+  review by the reusable auto-merge logic (no unit-test infra), so no Terraform
+  change auto-merges unexpectedly.
+
+## Success criteria
+
+1. A new Dependabot PR receives the `Dependabot Auto-Merge` check and (for an
+   eligible non-Terraform bump) the classification labels + Bedrock changelog
+   evaluation, and either auto-merges or is labeled for review.
+2. `label-sync` `workflow_dispatch` run creates/updates the full label taxonomy.
+3. A PR that changes the repo tree gets a `## Tree` README update committed by
+   `tree-readme` (or a clean no-op when unchanged).
+4. All three new workflow files pass the repo's own `test-scripts.yml` lint
+   (actionlint + N2 no-mutable-main-refs guard).


### PR DESCRIPTION
## What

Adds three thin **self-caller** workflows so the Actions repo runs the same tooling it publishes to the fleet, wherever it applies to a workflows/actions/scripts repo (no production Terraform):

| New file | Trigger | Wraps |
|---|---|---|
| `dependabot-auto-merge.yml` | `pull_request_target` (dependabot only) | `org-dependabot-auto-merge.yml` |
| `label-sync.yml` | weekly cron + manual | `org-label-sync.yml` |
| `tree-readme.yml` | `pull_request` | `org-tree-readme.yml` |

## Why

Surfaced by #192: a Dependabot PR got **no auto-merge evaluation and no Bedrock changelog comment** because `org-dependabot-auto-merge.yml` had no self-caller here — even though the scheduled `org-dependabot-reconcile.yml` sweeper (which assumes the per-PR workflow ran) runs every 6h. This wires the missing per-PR producer, plus the label taxonomy it depends on, plus the README-tree generator that was never exercised on the repo's own PRs.

## Notes

- Callers use the local `./` path form (N2 lint) and `secrets: inherit`; the auto-merge caller grants `id-token: write` for the reusable's OIDC/Bedrock step (a caller only sets the ceiling).
- All prerequisites already exist at org scope — `AUTOMERGE_*` secrets are `ALL`-visibility and the reconcile sweeper proves the GitHub App + OIDC role work.
- Deliberately **not** wired (no-ops or regressions here): trivy-pr, trivy-exception-review, terraform-docs, version-band, opa, the `org-release.yml` migration, and borderline gitleaks-pr / jira-sync. Rationale in `docs/superpowers/specs/2026-07-14-self-dogfood-reusable-workflows-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)