### PR TITLE
fix(automerge): green gate ignores auto-merge's own in-flight checks

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -693,7 +693,11 @@ jobs:
   # (if eligible + all gates passed) labeled it merge/approved. A PR that was
   # still building at decide-time was left PENDING and NOT merged. This job
   # re-drives the bypass merge the instant a check suite completes, so such PRs
-  # merge promptly instead of waiting for the reconcile sweep. It is cheap and
+  # merge promptly instead of waiting for the reconcile sweep.
+  # CAVEAT: GitHub does NOT emit check_suite events for suites created by GitHub
+  # Actions (recursion guard), so this only fires for EXTERNAL CI apps. Repos
+  # gated purely by GitHub Actions rely on the PR-time merge (now that the green
+  # gate ignores auto-merge's own in-flight jobs) or the reconcile sweep. It is cheap and
   # tightly filtered: it acts ONLY on an OPEN, dependabot-authored, merge/approved
   # PR associated with the completed suite, and delegates the green-gate + bypass
   # merge to the same scripts/pr-green-merge.sh (so a not-yet-green PR is still

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Issue labels:
 |   |-- superpowers
 |       |-- specs
 |           |-- 2026-07-14-self-dogfood-reusable-workflows-design.md
+|           |-- 2026-07-15-automerge-bypass-direct-merge.md
 |-- gate-config.yml
 |-- package-lock.json
 |-- package.json

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -72,8 +72,11 @@ native auto-merge (`gh pr merge --auto`): native auto-merge waits for every rule
 requirement to be literally met and never consults bypass, so on a
 code-owner-required ruleset it would sit `BLOCKED` forever. Plain `gh pr merge`
 (GraphQL) likewise refuses a blocked PR. The merge is gated on the head commit's
-check runs being green (`scripts/pr-green-merge.sh`); a PR still building is left
-for the event-driven re-merge / the reconcile sweeper to converge.
+check runs being green (`scripts/pr-green-merge.sh`, which ignores the auto-merge
+workflow's own in-flight jobs so it doesn't self-block); a PR still building is left
+for the reconcile sweeper to converge. (A `check_suite` re-merge job also exists, but
+GitHub suppresses `check_suite` events for Actions-created suites, so it only helps
+repos gated by *external* CI apps — not the GitHub-Actions-only common case.)
 
 ### 2. AWS OIDC Role (required)
 

--- a/docs/superpowers/specs/2026-07-15-automerge-bypass-direct-merge.md
+++ b/docs/superpowers/specs/2026-07-15-automerge-bypass-direct-merge.md
@@ -73,3 +73,14 @@ safety net, not the primary path).
   custom `with:` inputs is skipped (none existed at rollout).
 - Reconcile returns non-zero if any single PR errors (e.g. a merge conflict → 405,
   or a mergeability-recompute race → 409); that is expected, not a fix failure.
+- **Green-gate self-skip (fixed):** the `decide` job merges inline, so its own
+  check run (`auto-merge / decide`) is IN_PROGRESS and `notify_failure`/`remerge`
+  are QUEUED while `pr-green-merge.sh` reads check runs — making the PR-time merge
+  self-classify PENDING forever. Fixed via `IGNORE_CHECK_PREFIX` (default
+  `"auto-merge / "`), which excludes the auto-merge workflow's own jobs from the
+  gate. Repo CI checks still gate.
+- **`check_suite` re-merge is external-CI-only:** GitHub does not emit `check_suite`
+  events for suites created by GitHub Actions (recursion guard), so the `remerge`
+  job never fires for Actions-gated repos. Those rely on the (fixed) PR-time merge
+  or the reconcile sweep. Slow-CI repos whose checks outlast the decide job still
+  need the sweep to converge.

--- a/scripts/pr-green-merge.sh
+++ b/scripts/pr-green-merge.sh
@@ -53,6 +53,9 @@
 #   RETRY_MAX        optional — max attempts for a transient gh read (default: 3)
 #   AUTHOR_ALLOWLIST optional — space-separated trusted author logins
 #                    (default: "app/dependabot dependabot[bot]")
+#   IGNORE_CHECK_PREFIX optional — exclude check runs whose name starts with this
+#                    from the green gate (default "auto-merge / " — the auto-merge
+#                    workflow's own jobs, which are in-flight while it merges). "" disables.
 #
 # Output: a single decision line on stdout, one of:
 #   MERGED #<n>        (DRY_RUN=false, was GREEN)
@@ -74,6 +77,14 @@ MERGE_METHOD="${MERGE_METHOD:-squash}"
 DRY_RUN="${DRY_RUN:-true}"
 BYPASS_REVIEW="${BYPASS_REVIEW:-false}"
 RETRY_MAX="${RETRY_MAX:-3}"
+# Check runs whose name starts with this prefix are EXCLUDED from the green gate.
+# Default excludes the auto-merge workflow's own jobs ("auto-merge / classify",
+# "auto-merge / decide", …): when the decide job runs the merge inline, its own
+# check run is IN_PROGRESS and notify_failure/remerge are QUEUED, so counting them
+# would make the PR-time merge forever self-classify PENDING and never fire. Those
+# jobs gate the auto-merge DECISION (upstream), not code correctness, so excluding
+# them is safe; the repo's real CI checks still gate. Set to "" to disable.
+IGNORE_CHECK_PREFIX="${IGNORE_CHECK_PREFIX:-auto-merge / }"
 # Space-separated allowlist of trusted PR-author logins. NOTE: `gh --json author`
 # reports Dependabot as `app/dependabot` (the GitHub App identity); the webhook
 # `pull_request.user.login` form is `dependabot[bot]`. Both are accepted so the
@@ -170,7 +181,10 @@ if [ "$REVIEW" = "REVIEW_REQUIRED" ] && [ "$BYPASS_REVIEW" != "true" ]; then
 fi
 
 # Green gate: read the head commit's check runs via REST (checks:read) and
-# classify FAIL > PENDING > GREEN. No check runs (empty) classifies GREEN — the
+# classify FAIL > PENDING > GREEN, EXCLUDING check runs named with
+# IGNORE_CHECK_PREFIX (the auto-merge workflow's own jobs — see var comment; when
+# the decide job merges inline, its own check is IN_PROGRESS and would otherwise
+# wedge the gate PENDING forever). No (remaining) check runs classifies GREEN — the
 # wedged-PR case (a clean PR on a repo with no gating checks). We read check RUNS
 # only (GitHub Actions checks — what the fleet gates on); legacy commit statuses
 # are not consulted, since the ruleset requires no status checks and reading them
@@ -186,8 +200,10 @@ if ! CHECKS_JSON="$(gh_read api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?pe
   echo "SKIP #${PR_NUMBER} (check-runs-unavailable)"
   exit 0
 fi
-CHECK_STATE="$(printf '%s' "$CHECKS_JSON" | jq -r '
-  [ .check_runs[]? | ((.conclusion // .status // "") | ascii_upcase) ] as $c
+CHECK_STATE="$(printf '%s' "$CHECKS_JSON" | jq -r --arg ign "$IGNORE_CHECK_PREFIX" '
+  [ .check_runs[]?
+    | select(($ign == "") or ((.name // "") | startswith($ign) | not))
+    | ((.conclusion // .status // "") | ascii_upcase) ] as $c
   | if   ($c | map(select(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE")) | length) > 0 then "FAIL"
     elif ($c | map(select(. == "QUEUED" or . == "IN_PROGRESS" or . == "PENDING" or . == "WAITING" or . == "REQUESTED" or . == "")) | length) > 0 then "PENDING"
     else "GREEN" end')"

--- a/tests/reconcile-sweeper.test.sh
+++ b/tests/reconcile-sweeper.test.sh
@@ -116,6 +116,19 @@ CK_GREEN='{"check_runs":[{"status":"completed","conclusion":"success"}]}'
 CK_EMPTY='{"check_runs":[]}'
 CK_RED='{"check_runs":[{"status":"completed","conclusion":"failure"}]}'
 CK_PEND='{"check_runs":[{"status":"in_progress","conclusion":null}]}'
+# Self-referential: the auto-merge workflow's own jobs are in-flight (decide
+# running the merge, notify_failure/remerge queued) while a real repo check is
+# green. The green gate must EXCLUDE the "auto-merge / *" runs and see GREEN.
+CK_SELF='{"check_runs":[
+  {"name":"gitleaks / scan","status":"completed","conclusion":"success"},
+  {"name":"auto-merge / decide","status":"in_progress","conclusion":null},
+  {"name":"auto-merge / notify_failure","status":"queued","conclusion":null},
+  {"name":"auto-merge / remerge","status":"queued","conclusion":null}]}'
+# Same, but a NON-excluded repo check (terraform) is still running -> PENDING.
+CK_SELF_PEND='{"check_runs":[
+  {"name":"gitleaks / scan","status":"completed","conclusion":"success"},
+  {"name":"auto-merge / decide","status":"in_progress","conclusion":null},
+  {"name":"terraform / plan","status":"in_progress","conclusion":null}]}'
 
 # ---- Case 1 (the AC expected-FAIL guard): GREEN + dry-run → WOULD-MERGE, and
 #      the recorded trace contains ZERO write verbs (mock also set to reject). ----
@@ -210,5 +223,20 @@ BR=true CF=1 run_helper "$PV_REVREQ" "$CK_GREEN" false 0
 echo "$OUT" | grep -q "SKIP #123 (check-runs-unavailable)" || fail "unreadable check-runs should fail closed (got: $OUT)"
 echo "$TRACE" | grep -qE 'pulls/[0-9]+/merge' && fail "unreadable check-runs must never merge"
 echo "OK: bypass + unreadable check-runs → SKIP (fail closed, no merge)"
+
+# ---- Case 12 (self-skip fix): auto-merge's OWN jobs in-flight + green repo check
+#      -> GREEN via IGNORE_CHECK_PREFIX exclusion -> MERGED. Without the exclusion
+#      this PR would wedge PENDING forever at PR-merge time. ----
+BR=true run_helper "$PV_REVREQ" "$CK_SELF" false 0
+echo "$OUT" | grep -q "MERGED #123" || fail "self-jobs-in-flight + green should MERGE (got: $OUT)"
+[ "$(echo "$TRACE" | grep -cE 'pulls/[0-9]+/merge')" -eq 1 ] || fail "should issue exactly one REST merge"
+echo "OK: own auto-merge jobs in-flight ignored → MERGED (self-skip fixed)"
+
+# ---- Case 13 (exclusion is scoped): a NON-excluded repo check still running
+#      -> PENDING -> SKIP (we don't merge over a real in-flight check). ----
+BR=true run_helper "$PV_REVREQ" "$CK_SELF_PEND" false 0
+echo "$OUT" | grep -q "SKIP #123 (checks-PENDING)" || fail "real pending check must still block (got: $OUT)"
+echo "$TRACE" | grep -qE "$WRITE_VERBS_RE" && fail "must not merge while a real check is pending"
+echo "OK: real repo check pending (terraform) → SKIP (exclusion is scoped to auto-merge/*)"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Problem
Approved Dependabot PRs kept wedging at PR-merge time (e.g. terraform-google-private-service-access#45): `pr-green-merge.sh` classified them PENDING and skipped, so they only merged via a later reconcile sweep.

## Root cause
The `decide` job runs the merge **inline**, so at merge time the head SHA's check runs include `auto-merge / decide` (IN_PROGRESS — itself) and `auto-merge / notify_failure` / `auto-merge / remerge` (QUEUED). The green gate counted those → PENDING → SKIP, forever. The `check_suite` re-merge (Layer 3) doesn't rescue it either: GitHub suppresses `check_suite` events for Actions-created check suites (recursion guard).

## Fix
`IGNORE_CHECK_PREFIX` (default `"auto-merge / "`) excludes the auto-merge workflow's own jobs from the green gate — they gate the *decision*, not code correctness. The repo's real CI checks still gate. Propagates fleet-wide immediately via `actions_ref=main` (no re-release/re-sweep).

Also corrects the overstated `check_suite` claim in the workflow comment + docs (it only helps external-CI repos).

## Tests
`tests/reconcile-sweeper.test.sh`: +2 cases (own jobs in-flight + green repo check → MERGED; a non-excluded repo check still running → SKIP). All pass; shellcheck + actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)