### PR TITLE
feat(reconcile): scheduled sweeps merge for real (tail-catcher goes live)

### DIFF
--- a/.github/workflows/org-dependabot-reconcile.yml
+++ b/.github/workflows/org-dependabot-reconcile.yml
@@ -17,10 +17,13 @@ name: Dependabot Reconcile Sweeper
 # REST endpoint (which honors the App's bypass) past reviewDecision=REVIEW_REQUIRED.
 # An explicit human block (CHANGES_REQUESTED) is still never overridden.
 #
-# SAFETY: dry_run defaults to TRUE everywhere (scheduled runs included) — the
-# sweep logs would-merge decisions and performs ZERO mutating calls. To enable
-# live healing, dispatch manually with dry_run=false (validate first), or flip
-# the schedule default once the dry-run window looks correct.
+# SAFETY MODEL (2026-07-15): scheduled runs merge FOR REAL — this sweep is the
+# tail-catcher for PRs whose CI outlasts the PR-time merge (check_suite events
+# never fire for Actions-created suites, so no event-driven path exists for
+# Actions-gated repos). Every merge is still gated per-PR by pr-green-merge.sh:
+# green CI, dependabot author, merge/approved label, never over CHANGES_REQUESTED.
+# Manual dispatch stays dry-run by DEFAULT (safe canaries; scope with the `repo`
+# input) — pass dry_run=false explicitly to make a dispatched run merge.
 #
 # The auto-merge fallback's own adoption of scripts/pr-green-merge.sh is owned by
 # the #9/#12/#13 follow-up chain on org-dependabot-auto-merge.yml (option B) —
@@ -80,9 +83,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
-          # dry_run defaults to true; only a manual dispatch with dry_run=false
-          # (unchecked) performs merges. Scheduled runs are always dry-run.
-          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) && 'false' || 'true' }}
+          # Scheduled runs are LIVE (the tail-catcher — see header). Manual
+          # dispatch stays dry-run unless dry_run=false is passed explicitly.
+          DRY_RUN: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)) && 'false' || 'true' }}
           MERGE_METHOD: ${{ inputs.merge_method || 'squash' }}
           REPO_SCOPE: ${{ inputs.repo || '' }}
           MAX_PRS: '200'

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -74,9 +74,13 @@ code-owner-required ruleset it would sit `BLOCKED` forever. Plain `gh pr merge`
 (GraphQL) likewise refuses a blocked PR. The merge is gated on the head commit's
 check runs being green (`scripts/pr-green-merge.sh`, which ignores the auto-merge
 workflow's own in-flight jobs so it doesn't self-block); a PR still building is left
-for the reconcile sweeper to converge. (A `check_suite` re-merge job also exists, but
-GitHub suppresses `check_suite` events for Actions-created suites, so it only helps
-repos gated by *external* CI apps — not the GitHub-Actions-only common case.)
+for the **reconcile sweeper** (`org-dependabot-reconcile.yml`) to converge — its
+scheduled runs (every 6h) merge for real and are the tail-catcher for PRs whose CI
+outlasts the PR-time merge. Manual dispatch of the sweeper stays dry-run by default
+(scope a canary with its `repo` input; pass `dry_run=false` to merge). (A
+`check_suite` re-merge job also exists, but GitHub suppresses `check_suite` events
+for Actions-created suites, so it only helps repos gated by *external* CI apps —
+not the GitHub-Actions-only common case.)
 
 ### 2. AWS OIDC Role (required)
 

--- a/docs/superpowers/specs/2026-07-15-automerge-bypass-direct-merge.md
+++ b/docs/superpowers/specs/2026-07-15-automerge-bypass-direct-merge.md
@@ -48,8 +48,10 @@ The pipeline never did that. Three mechanics, each verified live:
   evaluation pipeline or checks out PR-branch code.
 
 **`org-dependabot-reconcile.yml`** — passes `BYPASS_REVIEW=true`; gained a `repo`
-input for scoped canary / targeted sweeps. Stays `dry_run` on schedule (a manual
-safety net, not the primary path).
+input for scoped canary / targeted sweeps. **Scheduled runs (every 6h) are LIVE**
+(flipped 2026-07-15, after `check_suite` proved a dead end — see gotchas): the sweep
+is the tail-catcher for PRs whose CI outlasts the PR-time merge. Manual dispatch
+stays dry-run by default.
 
 **Prerequisite:** `ci-automerge-app` granted `Checks: Read-only`
 (perms now: contents:write, pull_requests:write, metadata:read, checks:read).
@@ -83,4 +85,5 @@ safety net, not the primary path).
   events for suites created by GitHub Actions (recursion guard), so the `remerge`
   job never fires for Actions-gated repos. Those rely on the (fixed) PR-time merge
   or the reconcile sweep. Slow-CI repos whose checks outlast the decide job still
-  need the sweep to converge.
+  need the sweep to converge — which is why the scheduled sweep runs live: it is
+  the only reliable automated catcher for that tail.


### PR DESCRIPTION
## Why
Final gap from the auto-merge audit: a PR whose repo checks finish **after** the decide job has no automated catcher —
- `check_suite` re-merge never fires for Actions-created suites (GitHub recursion guard; fleet is Actions-gated), and
- the scheduled reconcile cron ran **dry-run**, merging nothing.

So late-green PRs wedged until the next Dependabot event or a manual sweep. PR-time merge itself is proven working post-#241 (`terraform-aws-ec2#213` merged by `app/ci-automerge-app` at PR-event time).

## Change
- Scheduled reconcile runs (cron, every 6h) now set `DRY_RUN=false` — the sweep is the live tail-catcher.
- Manual dispatch keeps its dry-run-by-default (canaries via the `repo` input; `dry_run=false` to merge).
- Header SAFETY comment + docs updated to match.

Every merge is still gated per-PR by `pr-green-merge.sh`: green CI (excluding auto-merge's own jobs), dependabot author allowlist, `merge/approved` label, never over `CHANGES_REQUESTED`.

## Testing
- `actionlint` (warning+) clean; markdownlint clean; `tests/reconcile-sweeper.test.sh` passes untouched (no script changes).
- Post-merge: one live dispatch drains the 14 pre-#241 wedged PRs; next scheduled run confirms unattended live operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)