### PR TITLE
feat(org-terratest): add timeout_minutes input (default 60) for large modules

### DIFF
--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -44,6 +44,11 @@ on:
         required: false
         default: '30m'
         type: string
+      timeout_minutes:
+        description: 'Job timeout in minutes. Default 60; raise for large modules whose full create+destroy exceeds an hour (e.g. a full EKS + Splunk Operator deploy).'
+        required: false
+        default: 60
+        type: number
       working_directory:
         description: 'Working directory (repo root by default)'
         required: false
@@ -162,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     # Cap the job so a hung 'terraform apply' cannot burn the 6-hour default while
     # holding cloud resources (the header's 'prevent runaway resource creation' claim).
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Issue labels:
 |       |-- specs
 |           |-- 2026-07-14-self-dogfood-reusable-workflows-design.md
 |           |-- 2026-07-15-automerge-bypass-direct-merge.md
+|           |-- 2026-07-15-org-repo-bootstrap-design.md
 |-- gate-config.yml
 |-- package-lock.json
 |-- package.json


### PR DESCRIPTION
## Why

A full EKS + Splunk Operator terratest (`terraform-aws-splunk/modules/eks`) does a complete cluster **create + destroy**. The deploy is fast (~22 min, reaches formation + HEC round-trip), but **teardown** of EKS node groups + the ingestion NLB Service + VPC runs ~38 min, so the run blows the hardcoded `timeout-minutes: 60` job cap mid-teardown and is cancelled — despite the module code being correct.

## What

- Add a `timeout_minutes` `workflow_call` input, **default `60`** (fully backward-compatible — existing callers are unchanged).
- Wire the job to `timeout-minutes: ${{ inputs.timeout_minutes || 60 }}` (the `|| 60` also covers the `workflow_dispatch` path).

Large modules can now set e.g. `timeout_minutes: 120`; the runaway-resource guard still applies to everyone else at 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)