### PR TITLE
feat: org-caliper.yml — CR2026/Rev5 scan + advisory Bedrock triage (reusable)

### DIFF
--- a/.github/workflows/org-caliper.yml
+++ b/.github/workflows/org-caliper.yml
@@ -7,9 +7,11 @@ name: Caliper Scan
 # zero). Triage is a Bedrock call whose output is DRAFTS ONLY — the model
 # never gates, never commits (structural guard inside caliper itself).
 #
-# Caller requirements:
-#   - org secret CALIPER_READ_TOKEN (read access to Coalfire-CF/caliper)
-#   - for triage: org secret CALIPER_ROLE_ARN (OIDC role with Bedrock Converse
+# Caller requirements (use `secrets: inherit`):
+#   - the org App cf-gha-tf-pull-from-private-repo credentials
+#     (CF_TF_PULL_PRIVATE_APP_CLIENTID / _PRIVATE_KEY) — already org secrets;
+#     each job mints a ~1h token scoped to Coalfire-CF/caliper only. No PAT.
+#   - for triage: org secret CALIPER_ROLE_ARN (OIDC role with Bedrock invoke
 #     + the caliper S3 cache prefix) and the aws_region input. Absent role =
 #     triage skips with a notice; the scan still runs.
 #
@@ -70,8 +72,11 @@ on:
         type: string
         default: ''
     secrets:
-      CALIPER_READ_TOKEN:
-        description: 'Token with read access to Coalfire-CF/caliper (private)'
+      CF_TF_PULL_PRIVATE_APP_CLIENTID:
+        description: 'Client id of the org cf-gha-tf-pull-from-private-repo App (reads private Coalfire-CF/caliper). Pass via secrets: inherit.'
+        required: true
+      CF_TF_PULL_PRIVATE_APP_PRIVATE_KEY:
+        description: 'Private key of the cf-gha-tf-pull-from-private-repo App.'
         required: true
       CALIPER_ROLE_ARN:
         description: 'OIDC role for Bedrock triage (optional; triage skips without it)'
@@ -91,9 +96,9 @@ concurrency:
 
 jobs:
   scan:
-    # dependabot-triggered runs receive Dependabot secrets only — org secrets
-    # (CALIPER_READ_TOKEN) resolve empty and the install would fail loud.
-    # Skip entirely; dependabot bumps are covered by their own pipeline.
+    # dependabot-triggered runs receive Dependabot secrets only — the App
+    # secrets resolve empty and the token mint would fail. Skip entirely;
+    # dependabot bumps are covered by their own pipeline.
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
@@ -114,16 +119,24 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Mint caliper read token (org App, scoped to caliper only)
+        id: caliper_token
+        # cf-gha-tf-pull-from-private-repo App (contents:read) → a ~1h token
+        # scoped to just Coalfire-CF/caliper. No PAT; nothing personal; the
+        # token dies with the job. Mirrors org-terraform-validate's pattern.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CF_TF_PULL_PRIVATE_APP_CLIENTID }}
+          private-key: ${{ secrets.CF_TF_PULL_PRIVATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: caliper
+
       - name: Install caliper (pinned ref)
         env:
-          READ_TOKEN: ${{ secrets.CALIPER_READ_TOKEN }}
+          READ_TOKEN: ${{ steps.caliper_token.outputs.token }}
           CALIPER_REF: ${{ inputs.caliper_ref }}
         run: |
           set -euo pipefail
-          if [ -z "$READ_TOKEN" ]; then
-            echo "::error::CALIPER_READ_TOKEN is not configured — cannot install caliper. Refusing a silent skip."
-            exit 2
-          fi
           git clone --quiet "https://x-access-token:${READ_TOKEN}@github.com/Coalfire-CF/caliper.git" caliper-src
           git -C caliper-src checkout --quiet "$CALIPER_REF"
           git -C caliper-src submodule update --init --quiet rules
@@ -283,10 +296,20 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Mint caliper read token (org App, scoped to caliper only)
+        id: caliper_token
+        if: steps.provisioned.outputs.ready == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CF_TF_PULL_PRIVATE_APP_CLIENTID }}
+          private-key: ${{ secrets.CF_TF_PULL_PRIVATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: caliper
+
       - name: Install caliper[triage] (pinned ref)
         if: steps.provisioned.outputs.ready == 'true'
         env:
-          READ_TOKEN: ${{ secrets.CALIPER_READ_TOKEN }}
+          READ_TOKEN: ${{ steps.caliper_token.outputs.token }}
           CALIPER_REF: ${{ inputs.caliper_ref }}
         run: |
           set -euo pipefail

--- a/.github/workflows/org-caliper.yml
+++ b/.github/workflows/org-caliper.yml
@@ -1,0 +1,316 @@
+name: Caliper Scan
+
+# CR2026/Rev5 alignment scan + advisory AI triage for Terraform module repos.
+# Governed by MTCS ADR-0032 (caliper productization) — advisory-first delivery:
+# the scan comments on the PR; the gate blocks ONLY when the caller opts in
+# via gate_enforce (per-repo ratchet flip, after the repo is dispositioned to
+# zero). Triage is a Bedrock call whose output is DRAFTS ONLY — the model
+# never gates, never commits (structural guard inside caliper itself).
+#
+# Caller requirements:
+#   - org secret CALIPER_READ_TOKEN (read access to Coalfire-CF/caliper)
+#   - for triage: org secret CALIPER_ROLE_ARN (OIDC role with Bedrock Converse
+#     + the caliper S3 cache prefix) and the aws_region input. Absent role =
+#     triage skips with a notice; the scan still runs.
+#
+# v1 coverage note: remote module sources are NOT expanded (no terraform init
+# at scan time — the engine does not consume .terraform yet); every artifact
+# carries modules_resolved:false and the report says so. Do not add an init
+# step here without engine support — it would be dead weight.
+
+on:
+  workflow_call:
+    inputs:
+      caliper_ref:
+        description: 'Coalfire-CF/caliper ref to install (pin a release SHA; update deliberately)'
+        required: false
+        type: string
+        default: 'b08f66017477298c99daf95ef321aca4fc281e38' # main @ P4 merge, pre-v1 (2026-07-23)
+      baseline:
+        description: 'Rev5 baseline for the crosswalk projection'
+        required: false
+        type: string
+        default: 'fedramp-moderate'
+      gate_enforce:
+        description: 'Ratchet gate blocks the PR on NEW undispositioned NOT_ALIGNED findings'
+        required: false
+        type: boolean
+        default: false
+      triage:
+        description: 'Run advisory Bedrock triage (needs CALIPER_ROLE_ARN + aws_region)'
+        required: false
+        type: boolean
+        default: true
+      aws_region:
+        description: 'AWS region for OIDC + Bedrock + S3 cache (required if triage runs)'
+        required: false
+        type: string
+        default: ''
+      triage_cache_bucket:
+        description: 'S3 bucket for the triage result cache (optional but strongly recommended)'
+        required: false
+        type: string
+        default: ''
+      slack_channel_id:
+        description: 'Slack channel ID for failure notifications (optional)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      CALIPER_READ_TOKEN:
+        description: 'Token with read access to Coalfire-CF/caliper (private)'
+        required: true
+      CALIPER_ROLE_ARN:
+        description: 'OIDC role for Bedrock triage (optional; triage skips without it)'
+        required: false
+      SLACK_BOT_TOKEN:
+        description: 'Slack bot token (required if slack_channel_id is set)'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    outputs:
+      gate_ok: ${{ steps.gate.outputs.gate_ok }}
+      not_aligned: ${{ steps.head_scan.outputs.not_aligned }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          path: repo
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install caliper (pinned ref)
+        env:
+          READ_TOKEN: ${{ secrets.CALIPER_READ_TOKEN }}
+          CALIPER_REF: ${{ inputs.caliper_ref }}
+        run: |
+          set -euo pipefail
+          if [ -z "$READ_TOKEN" ]; then
+            echo "::error::CALIPER_READ_TOKEN is not configured — cannot install caliper. Refusing a silent skip."
+            exit 2
+          fi
+          git clone --quiet "https://x-access-token:${READ_TOKEN}@github.com/Coalfire-CF/caliper.git" caliper-src
+          git -C caliper-src checkout --quiet "$CALIPER_REF"
+          git -C caliper-src submodule update --init --quiet rules
+          pip install --quiet ./caliper-src
+          echo "CALIPER_RULES_PATH=${GITHUB_WORKSPACE}/caliper-src/rules/fedramp-consolidated-rules.json" >> "$GITHUB_ENV"
+
+      - name: Scan PR head
+        id: head_scan
+        env:
+          BASELINE: ${{ inputs.baseline }}
+        run: |
+          set -euo pipefail
+          caliper scan --repo repo --baseline "$BASELINE" --out out/head
+          caliper report --artifact out/head/scan.json --out out/head/report.md
+          python -c "
+          import json
+          art = json.load(open('out/head/scan.json'))
+          na = sum(1 for f in art['findings'] if f['fedramp'] == 'NOT_ALIGNED')
+          print(f'not_aligned={na}')
+          " >> "$GITHUB_OUTPUT"
+
+      - name: Scan base ref (stateless ratchet baseline)
+        if: github.event_name == 'pull_request'
+        env:
+          BASELINE: ${{ inputs.baseline }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git -C repo worktree add ../base-repo "$BASE_SHA"
+          caliper scan --repo base-repo --baseline "$BASELINE" --out out/base
+
+      - name: Gate (ratchet)
+        id: gate
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          DISPO_ARGS=""
+          if [ -f repo/.caliper/dispositions.yaml ]; then
+            DISPO_ARGS="--dispositions repo/.caliper/dispositions.yaml"
+          fi
+          set +e
+          caliper gate --artifact out/head/scan.json --baseline-artifact out/base/scan.json $DISPO_ARGS | tee out/gate.txt
+          RC=$?
+          set -e
+          echo "gate_ok=$([ $RC -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: caliper-scan
+          path: out/
+
+      - name: Comment scan results (upsert)
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- org-caliper-scan -->';
+            const art = JSON.parse(fs.readFileSync('out/head/scan.json', 'utf8'));
+            const counts = {NOT_ALIGNED: 0, ALIGNED: 0, NOT_FOUND: 0};
+            for (const f of art.findings) counts[f.fedramp]++;
+            let gate = '';
+            try { gate = fs.readFileSync('out/gate.txt', 'utf8'); } catch (e) {}
+            const gateOk = '${{ steps.gate.outputs.gate_ok }}' !== 'false';
+            const enforce = ${{ inputs.gate_enforce }};
+
+            let body = `${marker}\n#### Caliper CR2026/Rev5 scan 📐\n\n` +
+              `| Not aligned | Aligned | Pattern absent / indeterminate |\n` +
+              `| --- | --- | --- |\n` +
+              `| ${counts.NOT_ALIGNED} | ${counts.ALIGNED} | ${counts.NOT_FOUND} |\n\n` +
+              `**Gate (ratchet):** ${gateOk ? '✅ no new undispositioned findings' : '❌ NEW undispositioned NOT_ALIGNED findings'}` +
+              `${enforce ? ' — *enforcing*' : ' — *advisory (gate_enforce: false)*'}\n\n`;
+            if (gate.trim()) body += `\`\`\`\n${gate.trim().slice(0, 2500)}\n\`\`\`\n\n`;
+            const na = art.findings.filter(f => f.fedramp === 'NOT_ALIGNED');
+            if (na.length) {
+              body += `<details>\n<summary>NOT_ALIGNED findings (${na.length})</summary>\n\n` +
+                `| Check | Where | Evidence |\n| --- | --- | --- |\n`;
+              for (const f of na) {
+                body += `| ${f.check} | \`${f.address || 'repo-scoped'}\` | \`${f.evidence || '—'}\` |\n`;
+              }
+              body += `\n</details>\n\n`;
+            }
+            body += `<sub>ruleset ${art.ruleset_version} · ${art.scanner_version} · ` +
+              `modules not expanded (delegated hardening checked in dependency repos) · ` +
+              `full report in the workflow artifacts</sub>`;
+
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number, per_page: 100});
+            const mine = comments.find(c => c.body && c.body.startsWith(marker));
+            if (mine && mine.body === body) return;  // fingerprint dedup: unchanged
+            if (mine) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: mine.id, body});
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body});
+            }
+
+      - name: Dependabot notice (read-only token cannot comment)
+        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+        run: echo "::notice::dependabot PR — GITHUB_TOKEN is read-only; scan ran, comment skipped (see artifacts)."
+
+      - name: Enforce gate
+        if: inputs.gate_enforce && steps.gate.outputs.gate_ok == 'false'
+        run: |
+          echo "::error::caliper gate: new undispositioned NOT_ALIGNED findings (ratchet only tightens — disposition or fix them)"
+          exit 1
+
+  triage:
+    needs: scan
+    if: inputs.triage && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check triage provisioning
+        id: provisioned
+        env:
+          ROLE: ${{ secrets.CALIPER_ROLE_ARN }}
+          REGION: ${{ inputs.aws_region }}
+        run: |
+          if [ -z "$ROLE" ] || [ -z "$REGION" ]; then
+            echo "::notice::triage skipped — CALIPER_ROLE_ARN / aws_region not provisioned (scan is unaffected)."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.provisioned.outputs.ready == 'true'
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ secrets.CALIPER_ROLE_ARN }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Set up Python
+        if: steps.provisioned.outputs.ready == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install caliper[triage] (pinned ref)
+        if: steps.provisioned.outputs.ready == 'true'
+        env:
+          READ_TOKEN: ${{ secrets.CALIPER_READ_TOKEN }}
+          CALIPER_REF: ${{ inputs.caliper_ref }}
+        run: |
+          set -euo pipefail
+          git clone --quiet "https://x-access-token:${READ_TOKEN}@github.com/Coalfire-CF/caliper.git" caliper-src
+          git -C caliper-src checkout --quiet "$CALIPER_REF"
+          git -C caliper-src submodule update --init --quiet rules
+          pip install --quiet './caliper-src[triage]'
+          echo "CALIPER_RULES_PATH=${GITHUB_WORKSPACE}/caliper-src/rules/fedramp-consolidated-rules.json" >> "$GITHUB_ENV"
+
+      - name: Download scan artifact
+        if: steps.provisioned.outputs.ready == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: caliper-scan
+          path: out
+
+      - name: Run triage (advisory — model never gates)
+        if: steps.provisioned.outputs.ready == 'true'
+        env:
+          CALIPER_TRIAGE_BUCKET: ${{ inputs.triage_cache_bucket }}
+        run: |
+          set -euo pipefail
+          caliper triage --artifact out/head/scan.json --out out/triage
+
+      - name: Comment triage results (upsert)
+        if: steps.provisioned.outputs.ready == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- org-caliper-triage -->';
+            let md = '';
+            try { md = fs.readFileSync('out/triage/triage.md', 'utf8'); } catch (e) { return; }
+            let draft = '';
+            try { draft = fs.readFileSync('out/triage/dispositions-draft.yaml', 'utf8'); } catch (e) {}
+            let body = `${marker}\n${md}`;
+            if (draft.trim()) {
+              body += `\n<details>\n<summary>📋 Draft .caliper/dispositions.yaml (review, edit, commit — ` +
+                `a human owns every disposition)</summary>\n\n\`\`\`yaml\n${draft}\`\`\`\n\n</details>`;
+            }
+            body = body.slice(0, 60000);
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number, per_page: 100});
+            const mine = comments.find(c => c.body && c.body.startsWith(marker));
+            if (mine && mine.body === body) return;
+            if (mine) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: mine.id, body});
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body});
+            }
+
+  notify-failure:
+    needs: [scan, triage]
+    if: failure() && inputs.slack_channel_id != ''
+    uses: ./.github/workflows/org-slack-notify.yml
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    with:
+      notification-type: failure
+      channel-id: ${{ inputs.slack_channel_id }}

--- a/.github/workflows/org-caliper.yml
+++ b/.github/workflows/org-caliper.yml
@@ -50,10 +50,15 @@ on:
         type: boolean
         default: true
       aws_region:
-        description: 'AWS region for OIDC + Bedrock + S3 cache (required if triage runs)'
+        description: 'AWS region for OIDC + Bedrock + S3 cache'
         required: false
         type: string
-        default: ''
+        default: 'us-gov-east-1'
+      triage_model_id:
+        description: 'Bedrock model/inference-profile id (GovCloud has no Haiku 4.5; default is gov Sonnet 4.5)'
+        required: false
+        type: string
+        default: 'us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0'
       triage_cache_bucket:
         description: 'S3 bucket for the triage result cache (optional but strongly recommended)'
         required: false
@@ -303,6 +308,7 @@ jobs:
         if: steps.provisioned.outputs.ready == 'true'
         env:
           CALIPER_TRIAGE_BUCKET: ${{ inputs.triage_cache_bucket }}
+          CALIPER_TRIAGE_MODEL_ID: ${{ inputs.triage_model_id }}
         run: |
           set -euo pipefail
           caliper triage --artifact out/head/scan.json --out out/triage

--- a/.github/workflows/org-caliper.yml
+++ b/.github/workflows/org-caliper.yml
@@ -13,6 +13,14 @@ name: Caliper Scan
 #     + the caliper S3 cache prefix) and the aws_region input. Absent role =
 #     triage skips with a notice; the scan still runs.
 #
+# Q8 delivery deviation (recorded): the plan called for AI drafts as
+# suggested-changes reviews on .caliper/dispositions.yaml; GitHub suggestions
+# can only anchor to lines already in the PR diff, which that file usually
+# isn't. v1 therefore ships the draft as fenced YAML in the triage comment —
+# the human-commits contract is preserved, the click-to-commit mechanic is
+# not. Follow-up (diff-anchored suggestions when the file IS in the diff):
+# Coalfire-CF/caliper#13.
+#
 # v1 coverage note: remote module sources are NOT expanded (no terraform init
 # at scan time — the engine does not consume .terraform yet); every artifact
 # carries modules_resolved:false and the report says so. Do not add an init
@@ -25,7 +33,7 @@ on:
         description: 'Coalfire-CF/caliper ref to install (pin a release SHA; update deliberately)'
         required: false
         type: string
-        default: 'b08f66017477298c99daf95ef321aca4fc281e38' # main @ P4 merge, pre-v1 (2026-07-23)
+        default: 'b08f66017477298c99daf95ef321aca4fc281e38' # main @ P4 merge, pre-v1 — replace with the v0.1.0 release SHA when release-please cuts it (RFC-0008)
       baseline:
         description: 'Rev5 baseline for the crosswalk projection'
         required: false
@@ -72,14 +80,25 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: org-caliper-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
+    # dependabot-triggered runs receive Dependabot secrets only — org secrets
+    # (CALIPER_READ_TOKEN) resolve empty and the install would fail loud.
+    # Skip entirely; dependabot bumps are covered by their own pipeline.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       gate_ok: ${{ steps.gate.outputs.gate_ok }}
       not_aligned: ${{ steps.head_scan.outputs.not_aligned }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout PR merge ref
+        # default pull_request checkout = the MERGE commit; paired with the
+        # base.sha baseline below, the ratchet delta is the PR's effective
+        # contribution (deliberate design choice, not an accident)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -104,6 +123,7 @@ jobs:
           git -C caliper-src checkout --quiet "$CALIPER_REF"
           git -C caliper-src submodule update --init --quiet rules
           pip install --quiet ./caliper-src
+          rm -rf caliper-src/.git  # token-bearing remote config; checked-out files remain
           echo "CALIPER_RULES_PATH=${GITHUB_WORKSPACE}/caliper-src/rules/fedramp-consolidated-rules.json" >> "$GITHUB_ENV"
 
       - name: Scan PR head
@@ -146,14 +166,31 @@ jobs:
           set -e
           echo "gate_ok=$([ $RC -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
+      - name: Lint dispositions (expiry + validity)
+        id: lint
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          if [ ! -f repo/.caliper/dispositions.yaml ]; then
+            echo "lint_ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          set +e
+          caliper lint --artifact out/head/scan.json \
+            --dispositions repo/.caliper/dispositions.yaml | tee out/lint.txt
+          RC=$?
+          set -e
+          echo "lint_ok=$([ $RC -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: caliper-scan
           path: out/
+          overwrite: true  # re-runs reuse the run's artifact namespace
 
       - name: Comment scan results (upsert)
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -179,8 +216,9 @@ jobs:
             if (na.length) {
               body += `<details>\n<summary>NOT_ALIGNED findings (${na.length})</summary>\n\n` +
                 `| Check | Where | Evidence |\n| --- | --- | --- |\n`;
+              const esc = (v) => String(v).replace(/\|/g, '\\|');
               for (const f of na) {
-                body += `| ${f.check} | \`${f.address || 'repo-scoped'}\` | \`${f.evidence || '—'}\` |\n`;
+                body += `| ${f.check} | \`${esc(f.address || 'repo-scoped')}\` | \`${esc(f.evidence || '—')}\` |\n`;
               }
               body += `\n</details>\n\n`;
             }
@@ -188,7 +226,7 @@ jobs:
               `modules not expanded (delegated hardening checked in dependency repos) · ` +
               `full report in the workflow artifacts</sub>`;
 
-            const {data: comments} = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: context.issue.number, per_page: 100});
             const mine = comments.find(c => c.body && c.body.startsWith(marker));
@@ -203,14 +241,10 @@ jobs:
                 issue_number: context.issue.number, body});
             }
 
-      - name: Dependabot notice (read-only token cannot comment)
-        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-        run: echo "::notice::dependabot PR — GITHUB_TOKEN is read-only; scan ran, comment skipped (see artifacts)."
-
-      - name: Enforce gate
-        if: inputs.gate_enforce && steps.gate.outputs.gate_ok == 'false'
+      - name: Enforce gate + lint
+        if: inputs.gate_enforce && (steps.gate.outputs.gate_ok == 'false' || steps.lint.outputs.lint_ok == 'false')
         run: |
-          echo "::error::caliper gate: new undispositioned NOT_ALIGNED findings (ratchet only tightens — disposition or fix them)"
+          echo "::error::caliper: gate_ok=${{ steps.gate.outputs.gate_ok }} lint_ok=${{ steps.lint.outputs.lint_ok }} (new undispositioned findings and/or invalid/expired dispositions)"
           exit 1
 
   triage:
@@ -255,6 +289,7 @@ jobs:
           git -C caliper-src checkout --quiet "$CALIPER_REF"
           git -C caliper-src submodule update --init --quiet rules
           pip install --quiet './caliper-src[triage]'
+          rm -rf caliper-src/.git  # token-bearing remote config; checked-out files remain
           echo "CALIPER_RULES_PATH=${GITHUB_WORKSPACE}/caliper-src/rules/fedramp-consolidated-rules.json" >> "$GITHUB_ENV"
 
       - name: Download scan artifact
@@ -290,7 +325,7 @@ jobs:
                 `a human owns every disposition)</summary>\n\n\`\`\`yaml\n${draft}\`\`\`\n\n</details>`;
             }
             body = body.slice(0, 60000);
-            const {data: comments} = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: context.issue.number, per_page: 100});
             const mine = comments.find(c => c.body && c.body.startsWith(marker));

--- a/.github/workflows/org-caliper.yml
+++ b/.github/workflows/org-caliper.yml
@@ -55,12 +55,12 @@ on:
         description: 'AWS region for OIDC + Bedrock + S3 cache'
         required: false
         type: string
-        default: 'us-gov-east-1'
+        default: 'us-east-1'
       triage_model_id:
-        description: 'Bedrock model/inference-profile id (GovCloud has no Haiku 4.5; default is gov Sonnet 4.5)'
+        description: 'Bedrock model/inference-profile id (default: commercial Sonnet 4.5; triage runs in occ-com, ADR-0032)'
         required: false
         type: string
-        default: 'us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0'
+        default: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
       triage_cache_bucket:
         description: 'S3 bucket for the triage result cache (optional but strongly recommended)'
         required: false


### PR DESCRIPTION
## What

The reusable caliper workflow (MTCS ADR-0032, P5 of the caliper productization plan): advisory scan comment on every PR + stateless ratchet gate (per-repo `gate_enforce` opt-in) + OIDC Bedrock triage with draft dispositions — model never gates.

## Design notes

- Caliper installs from the private repo at a **SHA-pinned ref** via `CALIPER_READ_TOKEN` (org read-token install decision); bumping the default ref is a deliberate PR to this file.
- Base-ref scan in the same run = the ratchet baseline — no committed scan state in caller repos.
- Triage degrades gracefully at every layer: unprovisioned role → notice; model/cache failure → "AI triage unavailable" comment section; nothing ever blocks on AI.
- Injection review: all event-derived values via `env:`; default merge-ref checkout; scanned-repo strings reach comment bodies only (API, not shell).
- Deliberately no `terraform init`: the engine doesn't consume `.terraform` yet — an init step would be dead weight (artifacts carry `modules_resolved: false`).

## Operator prerequisites (before first caller onboards)

`CALIPER_READ_TOKEN` + `CALIPER_ROLE_ARN` org secrets, the S3 cache bucket, and the OIDC role — full runbook: `docs/OPERATOR.md` in Coalfire-CF/caliper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)