### PR TITLE
fix: correct two low-severity script bugs (#207 duplicate label, #209 ceiling-only band) 

### DIFF
--- a/scripts/auto-merge-decide.sh
+++ b/scripts/auto-merge-decide.sh
@@ -106,6 +106,21 @@ if [ "$MANUAL" = "true" ] && [ "$DECISION" = "approve" ]; then
   DECISION="manual"
 fi
 
+# Dedupe blocked labels while preserving order and the leading-space format.
+# The group-aware (UPDATE_TYPE_META) and aggregate (SEMVER_TYPE=major) gates both
+# append blocked/major-bump; a duplicate in this output would mislead any
+# consumer that splits/counts blocked_labels (issue #207).
+if [ -n "$BLOCKED_LABELS" ]; then
+  _seen=""
+  _dedup=""
+  for _label in $BLOCKED_LABELS; do
+    case " ${_seen} " in *" ${_label} "*) continue ;; esac
+    _seen="${_seen} ${_label}"
+    _dedup="${_dedup} ${_label}"
+  done
+  BLOCKED_LABELS="$_dedup"
+fi
+
 # Determine if medium risk (not blocked but warrants attention)
 if [ "$DECISION" = "approve" ] && [ "$SEMVER_TYPE" = "minor" ]; then
   RISK_LEVEL="medium"

--- a/scripts/version-band-check.sh
+++ b/scripts/version-band-check.sh
@@ -112,13 +112,19 @@ while IFS= read -r entry; do
     emit_fail "$file" "$lineno" "required_version '${constraint}' is open-ended (no upper bound); RFC-0004 requires a ceiling (< ${CEILING} or ~>)"
     continue
   fi
-  # The first concrete version in the constraint is the effective lower/anchor bound.
-  low="$(printf '%s' "$constraint" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
-  if [ -n "$low" ]; then
-    # Normalize to X.Y.Z for comparison.
-    [[ "$low" =~ ^[0-9]+\.[0-9]+$ ]] && low="${low}.0"
-    if ! in_band "$low"; then
-      emit_fail "$file" "$lineno" "required_version '${constraint}' anchors at ${low}, outside the band [>= ${FLOOR}, < ${CEILING})"
+  # The first concrete version is the effective lower/anchor bound ONLY when the
+  # constraint actually carries a lower bound (>=, >, or ~> — all contain '>').
+  # An upper-bound-only constraint (e.g. "< 2.0.0") has no lower anchor; its first
+  # concrete version is the ceiling, so anchoring on it would spuriously flag a
+  # legitimately upper-bounded constraint as out-of-band (issue #209).
+  if [[ "$constraint" == *">"* ]]; then
+    low="$(printf '%s' "$constraint" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
+    if [ -n "$low" ]; then
+      # Normalize to X.Y.Z for comparison.
+      [[ "$low" =~ ^[0-9]+\.[0-9]+$ ]] && low="${low}.0"
+      if ! in_band "$low"; then
+        emit_fail "$file" "$lineno" "required_version '${constraint}' anchors at ${low}, outside the band [>= ${FLOOR}, < ${CEILING})"
+      fi
     fi
   fi
 done < <(grep -rnE 'required_version[[:space:]]*=' "$ROOT" \

--- a/tests/auto-merge-decide.test.sh
+++ b/tests/auto-merge-decide.test.sh
@@ -12,14 +12,14 @@
 # Each fixture under tests/fixtures/auto-merge-decide/*.env sets the complete
 # input environment for one of the four decision paths and is asserted against
 # the exact decision AND blocked_labels the gate emits:
-#   major_blocked       -> block   / " blocked/major-bump blocked/major-bump"
+#   major_blocked       -> block   / " blocked/major-bump"
 #   osv_blocked         -> block   / " blocked/known-vuln"
 #   parse_error_manual  -> manual  / ""            (fail-closed, no blocker)
 #   first_party_waiver  -> approve / ""            (Scorecard waived, RFC-0010)
 #
-# NOTE on the doubled blocked/major-bump: both the group-aware UPDATE_TYPE_META
-# gate and the aggregate SEMVER_TYPE=major gate append the label. That is the
-# characterized present-day behavior — asserted verbatim, not "fixed" here.
+# NOTE on blocked/major-bump: both the group-aware UPDATE_TYPE_META gate and the
+# aggregate SEMVER_TYPE=major gate detect a major bump, but the gate dedupes
+# BLOCKED_LABELS before emitting, so the label appears exactly once (issue #207).
 
 set -uo pipefail
 
@@ -66,7 +66,7 @@ assert_path() {
 }
 
 # ---- The four characterized decision paths (expected-PASS) ----
-assert_path major_blocked      block   " blocked/major-bump blocked/major-bump" high
+assert_path major_blocked      block   " blocked/major-bump"                    high
 assert_path osv_blocked        block   " blocked/known-vuln"                    high
 assert_path parse_error_manual manual  ""                                       high
 assert_path first_party_waiver approve ""                                       medium

--- a/tests/fixtures/auto-merge-decide/major_blocked.env
+++ b/tests/fixtures/auto-merge-decide/major_blocked.env
@@ -1,6 +1,6 @@
 # Path 1: major bump → blocked. Both the group-aware meta gate
 # (UPDATE_TYPE_META *semver-major*) and the aggregate SEMVER_TYPE=major gate fire,
-# so blocked/major-bump is appended twice (characterized baseline, not a bug).
+# but the gate dedupes BLOCKED_LABELS, so blocked/major-bump appears once (#207).
 DEP_NAME='actions/checkout'
 TO_VERSION='5.0.0'
 UPDATE_TYPE_META='version-update:semver-major'

--- a/tests/version-band-check.test.sh
+++ b/tests/version-band-check.test.sh
@@ -37,6 +37,18 @@ out="$(STRICT=true "$CHECK" "$pass" "$FLOOR" "$CEILING" 2>&1)"; code=$?
 echo "$out" | grep -q "::error" && fail "PASS tree emitted an error: $out"
 echo "OK: in-band concrete + bounded/pessimistic constraints pass (exit $code)"
 
+# ---- PASS: ceiling-only required_version (upper-bounded, no lower anchor) — issue #209 ----
+ceil="$root/ceil"; mkdir -p "$ceil"
+cat > "$ceil/main.tf" <<'EOF'
+terraform {
+  required_version = "< 2.0.0"
+}
+EOF
+out="$(STRICT=true "$CHECK" "$ceil" "$FLOOR" "$CEILING" 2>&1)"; code=$?
+[ "$code" -eq 0 ] || fail "ceiling-only constraint should pass under strict, got $code: $out"
+echo "$out" | grep -q "::error" && fail "ceiling-only constraint emitted an error: $out"
+echo "OK: ceiling-only required_version '< 2.0.0' passes under strict (exit $code)"
+
 # ---- FAIL: below floor (.terraform-version) ----
 low="$root/low"; mkdir -p "$low"; printf '1.14.9\n' > "$low/.terraform-version"
 out="$(STRICT=true "$CHECK" "$low" "$FLOOR" "$CEILING" 2>&1)"; code=$?


### PR DESCRIPTION
## Summary

Two low-severity script-correctness fixes, each TDD'd (test updated to assert the
correct behavior, watched fail, then fixed).

### #207 — `auto-merge-decide.sh` appended `blocked/major-bump` twice
Both the group-aware `UPDATE_TYPE_META` gate and the aggregate `SEMVER_TYPE=major`
gate append the label, so `blocked_labels` carried a duplicate. Label application
is idempotent on GitHub, but any consumer that splits/counts `blocked_labels` saw a
phantom. Fix: order- and leading-space-preserving dedupe of `BLOCKED_LABELS` before emit.

### #209 — `version-band-check.sh` mis-flagged ceiling-only constraints
A constraint like `< 2.0.0` (no lower bound) had its ceiling picked as the "anchor",
and `in_band 2.0.0` is false, so a legitimately upper-bounded constraint was reported
out-of-band. Fix: run the lower-anchor check only when the constraint carries a lower
bound (`>=`, `>`, or `~>`, all of which contain `>`).

## Testing
- `tests/auto-merge-decide.test.sh` — updated `major_blocked` expectation to a single label.
- `tests/version-band-check.test.sh` — added a ceiling-only (`< 2.0.0`) PASS fixture.
- Both watched RED before fix, GREEN after.
- Full `tests/*.test.sh` suite passes (the unrelated `tree-readme-section` failure is a
  pre-existing macOS/BSD tooling artifact, green on CI's ubuntu runners).
- `shellcheck scripts/*.sh` clean.

Closes #207
Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)