### PR TITLE
fix(auto-merge): cache-integrity hardening (H1/H2/M4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Issue labels:
 |       |-- terraform
 |-- tests
     |-- auto-merge-decide.test.sh
+    |-- cache-integrity.test.sh
     |-- cache-read.test.sh
     |-- fixtures
     |   |-- auto-merge-decide

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -78,6 +78,13 @@ semver_rank() {
 
 check_one() {
 local DEP_NAME="$1" FROM_VERSION="$2" TO_VERSION="$3"
+# Per-dependency error baseline (#194/H1): a dependency whose analysis errors must
+# not persist its optimistic fallback verdict to the fleet-wide shared cache.
+local ERRORS_BEFORE="$CHECK_ERRORS"
+# Clear per-iteration cache temp files (#195/H2): a cache MISS leaves aws's
+# download target absent, so a stale file from the PREVIOUS dependency in a grouped
+# PR must not linger and contaminate this dependency's written object.
+rm -f /tmp/cached_analysis.json /tmp/cached_repo_analysis.json
 
 SAFE_DEP_NAME=$(echo "$DEP_NAME" | sed 's|/|--|g')
 SAFE_REPO_NAME=$(echo "$GITHUB_REPOSITORY" | sed 's|/|--|g')
@@ -99,9 +106,12 @@ APPLIES_TO_REPO="true"
 # Check shared cache for universal changelog analysis
 CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" /tmp/cached_analysis.json 2>/dev/null && echo "ok" || echo "miss")
 if [ "$CACHED" = "ok" ]; then
-  BC_EXISTS=$(jq -r '.changelog // empty' /tmp/cached_analysis.json)
+  # Guard the pre-validation reads (#201/M4): a corrupt/non-JSON cached object
+  # makes jq exit non-zero, which under set -e would abort the whole job instead
+  # of treating the object as a miss and re-analyzing. Fail safe to empty (miss).
+  BC_EXISTS=$(jq -r '.changelog // empty' /tmp/cached_analysis.json 2>/dev/null || true)
   if [ -n "$BC_EXISTS" ]; then
-    ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json)
+    ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json 2>/dev/null || true)
     if [ -n "$ANALYZED_AT" ]; then
       ANALYZED_EPOCH=$(date -d "$ANALYZED_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$ANALYZED_AT" +%s 2>/dev/null || echo 0)
       NOW_EPOCH=$(date +%s)
@@ -130,7 +140,8 @@ fi
 # Check repo-scoped cache for applicability
 REPO_CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${REPO_CACHE_KEY}" /tmp/cached_repo_analysis.json 2>/dev/null && echo "ok" || echo "miss")
 if [ "$REPO_CACHED" = "ok" ]; then
-  REPO_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_repo_analysis.json)
+  # Guarded pre-validation read (#201/M4) — treat a corrupt object as a miss.
+  REPO_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_repo_analysis.json 2>/dev/null || true)
   if [ -n "$REPO_AT" ]; then
     REPO_EPOCH=$(date -d "$REPO_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$REPO_AT" +%s 2>/dev/null || echo 0)
     NOW_EPOCH=$(date +%s)
@@ -332,39 +343,49 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
   # ---------------------------------------------------------
   # Write shared cache (universal changelog + semver analysis)
   # ---------------------------------------------------------
-  # Read existing cache entry (from supply chain check) or start fresh
-  if [ -f /tmp/cached_analysis.json ]; then
-    EXISTING=$(cat /tmp/cached_analysis.json)
+  # Fail-closed cache write (#194/H1): if THIS dependency's analysis errored
+  # (Bedrock/parse failure → optimistic breaking=false fallback), do NOT persist
+  # that verdict to the fleet-wide shared cache — the next run must re-analyze on a
+  # genuine miss rather than cache-hit an unanalyzed dependency for the TTL window.
+  if [ "$CHECK_ERRORS" -gt "$ERRORS_BEFORE" ]; then
+    echo "::warning::Skipping shared-cache write for ${DEP_NAME}@${TO_VERSION} — analysis errored this run (fail-closed; not persisting an optimistic verdict)"
   else
-    EXISTING='{}'
+    # Merge onto THIS dependency's existing shared object only on a genuine hit
+    # (#195/H2): keying off file-existence would fold a stale /tmp file from the
+    # previous dep in a grouped PR into this dep's object. On a miss, start fresh.
+    if [ "$CACHED" = "ok" ]; then
+      EXISTING=$(cat /tmp/cached_analysis.json)
+    else
+      EXISTING='{}'
+    fi
+
+    echo "$EXISTING" | jq \
+      --arg schema "$CACHE_SCHEMA_VERSION" \
+      --arg producer "$CACHE_PRODUCER" \
+      --arg dep "$DEP_NAME" \
+      --arg ver "$TO_VERSION" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg sv_type "$SEMVER_TYPE" \
+      --arg sv_from "$FROM_VERSION" \
+      --arg sv_to "$TO_VERSION" \
+      --argjson breaking "$([ "$HAS_BREAKING" = "true" ] && echo true || echo false)" \
+      --argjson ai_breaking "$([ "$AI_BREAKING" = "true" ] && echo true || echo false)" \
+      --argjson conf "$CONFIDENCE" \
+      --arg summary "$RISK_SUMMARY" \
+      --argjson risks "$AI_RISKS" \
+      '. + {
+        schema_version: $schema,
+        producer: $producer,
+        dependency: $dep,
+        version: $ver,
+        analyzed_at: $ts,
+        semver: { type: $sv_type, from: $sv_from, to: $sv_to },
+        changelog: { breaking: $breaking, ai_breaking: $ai_breaking, confidence: ($conf | tonumber), summary: $summary, risks: $risks }
+      }' > /tmp/merged_analysis.json
+
+    aws s3 cp /tmp/merged_analysis.json "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" \
+      --content-type "application/json" --quiet
   fi
-
-  echo "$EXISTING" | jq \
-    --arg schema "$CACHE_SCHEMA_VERSION" \
-    --arg producer "$CACHE_PRODUCER" \
-    --arg dep "$DEP_NAME" \
-    --arg ver "$TO_VERSION" \
-    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    --arg sv_type "$SEMVER_TYPE" \
-    --arg sv_from "$FROM_VERSION" \
-    --arg sv_to "$TO_VERSION" \
-    --argjson breaking "$([ "$HAS_BREAKING" = "true" ] && echo true || echo false)" \
-    --argjson ai_breaking "$([ "$AI_BREAKING" = "true" ] && echo true || echo false)" \
-    --argjson conf "$CONFIDENCE" \
-    --arg summary "$RISK_SUMMARY" \
-    --argjson risks "$AI_RISKS" \
-    '. + {
-      schema_version: $schema,
-      producer: $producer,
-      dependency: $dep,
-      version: $ver,
-      analyzed_at: $ts,
-      semver: { type: $sv_type, from: $sv_from, to: $sv_to },
-      changelog: { breaking: $breaking, ai_breaking: $ai_breaking, confidence: ($conf | tonumber), summary: $summary, risks: $risks }
-    }' > /tmp/merged_analysis.json
-
-  aws s3 cp /tmp/merged_analysis.json "s3://${S3_BUCKET}/${SHARED_CACHE_KEY}" \
-    --content-type "application/json" --quiet
 fi
 
 # ---------------------------------------------------------

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -63,6 +63,9 @@ AGG_CACHE_HIT="true"
 
 check_one() {
 local DEP_NAME="$1" TO_VERSION="$2"
+# Per-dependency error baseline (#194/H1): if THIS dependency's checks error, we
+# must NOT persist its optimistic fallback verdict to the fleet-wide shared cache.
+local ERRORS_BEFORE="$CHECK_ERRORS"
 
 # -----------------------------------------------------------
 # Normalize dependency name for S3 key (replace / with --)
@@ -80,8 +83,10 @@ SCORECARD_SCORE="0"
 
 CACHED=$(aws s3 cp "s3://${S3_BUCKET}/${CACHE_KEY}" /tmp/cached_analysis.json 2>/dev/null && echo "ok" || echo "miss")
 if [ "$CACHED" = "ok" ]; then
-  # Validate TTL
-  ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json)
+  # Validate TTL. Guard the pre-validation read (#201/M4): a corrupt/non-JSON
+  # cached object makes jq exit non-zero, which under set -e would abort the whole
+  # job instead of treating the object as a miss. Fail safe to "" (→ re-analyze).
+  ANALYZED_AT=$(jq -r '.analyzed_at // ""' /tmp/cached_analysis.json 2>/dev/null || true)
   if [ -n "$ANALYZED_AT" ]; then
     ANALYZED_EPOCH=$(date -d "$ANALYZED_AT" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$ANALYZED_AT" +%s 2>/dev/null || echo 0)
     NOW_EPOCH=$(date +%s)
@@ -194,28 +199,37 @@ if [ "$CACHE_HIT" = "false" ]; then
   # Write to S3 cache (partial — supply chain fields only)
   # Breaking change check will merge its fields in separately
   # ---------------------------------------------------------
-  jq -n \
-    --arg schema "$CACHE_SCHEMA_VERSION" \
-    --arg producer "$CACHE_PRODUCER" \
-    --arg dep "$DEP_NAME" \
-    --arg ver "$TO_VERSION" \
-    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    --argjson osv_clear "$([ "$OSV_CLEAR" = "true" ] && echo true || echo false)" \
-    --argjson osv_vulns "$OSV_VULNS" \
-    --arg sc_score "$SCORECARD_SCORE" \
-    --argjson sc_pass "$([ "$SCORECARD_PASS" = "true" ] && echo true || echo false)" \
-    '{
-      schema_version: $schema,
-      producer: $producer,
-      dependency: $dep,
-      version: $ver,
-      analyzed_at: $ts,
-      osv: { clear: $osv_clear, vulns: $osv_vulns },
-      scorecard: { score: $sc_score, pass: $sc_pass }
-    }' > /tmp/supply_chain_result.json
+  # Fail-closed cache write (#194/H1): if THIS dependency errored (e.g. a transient
+  # OSV outage → OSV_CLEAR stays optimistically "true"), do NOT persist that verdict.
+  # The whole fleet reads this shared object for the full TTL window; a poisoned
+  # "clear=true" entry could auto-approve an unscanned dependency. Skip the write so
+  # the next run re-analyzes on a genuine cache miss.
+  if [ "$CHECK_ERRORS" -gt "$ERRORS_BEFORE" ]; then
+    echo "::warning::Skipping shared-cache write for ${DEP_NAME}@${TO_VERSION} — a check errored this run (fail-closed; not persisting an optimistic verdict)"
+  else
+    jq -n \
+      --arg schema "$CACHE_SCHEMA_VERSION" \
+      --arg producer "$CACHE_PRODUCER" \
+      --arg dep "$DEP_NAME" \
+      --arg ver "$TO_VERSION" \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --argjson osv_clear "$([ "$OSV_CLEAR" = "true" ] && echo true || echo false)" \
+      --argjson osv_vulns "$OSV_VULNS" \
+      --arg sc_score "$SCORECARD_SCORE" \
+      --argjson sc_pass "$([ "$SCORECARD_PASS" = "true" ] && echo true || echo false)" \
+      '{
+        schema_version: $schema,
+        producer: $producer,
+        dependency: $dep,
+        version: $ver,
+        analyzed_at: $ts,
+        osv: { clear: $osv_clear, vulns: $osv_vulns },
+        scorecard: { score: $sc_score, pass: $sc_pass }
+      }' > /tmp/supply_chain_result.json
 
-  aws s3 cp /tmp/supply_chain_result.json "s3://${S3_BUCKET}/${CACHE_KEY}" \
-    --content-type "application/json" --quiet
+    aws s3 cp /tmp/supply_chain_result.json "s3://${S3_BUCKET}/${CACHE_KEY}" \
+      --content-type "application/json" --quiet
+  fi
 fi
 
 # -----------------------------------------------------------

--- a/tests/cache-integrity.test.sh
+++ b/tests/cache-integrity.test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Integration meta-test for the cache-integrity fixes in the Dependabot
+# auto-merge check scripts (2026-07-08 deep-dive: #193/#194 H1, #195 H2, #201 M4).
+#
+# Drives scripts/supply-chain-check.sh and scripts/breaking-change-check.sh
+# end-to-end with fake `aws` (S3 cp + bedrock-runtime) and `curl`
+# (OSV / Scorecard / GitHub release-notes) binaries on PATH, so the whole gate
+# runs fully offline. The fakes are driven by environment variables and record
+# every S3 upload, letting us assert on cache-WRITE behavior — the crux of all
+# three bugs. Real jq / bc / date / base64 / sed are used throughout.
+#
+# Asserted (fixed) behavior:
+#   #193/#194 — a per-dependency check ERROR (OSV / Bedrock) SKIPS the shared-cache
+#               write, so a transient outage never persists an optimistic
+#               (clear / non-breaking) verdict to the fleet-wide cache.
+#   #195      — in a grouped PR, a dependency that MISSES the shared cache does not
+#               inherit the previous dependency's cached object (no stale /tmp
+#               contamination of the next dep's written object).
+#   #201      — a corrupt / non-JSON cached object is treated as a cache miss and
+#               re-analyzed; the pre-validation jq reads no longer abort the job
+#               under `set -e`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUPPLY="${REPO_ROOT}/scripts/supply-chain-check.sh"
+BREAKING="${REPO_ROOT}/scripts/breaking-change-check.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+
+[ -f "$SUPPLY" ]   || fail "supply-chain-check.sh not found at $SUPPLY"
+[ -f "$BREAKING" ] || fail "breaking-change-check.sh not found at $BREAKING"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+# ---- fake `aws`: S3 cp (up/down against $FAKE_S3_DIR) + bedrock-runtime --------
+cat > "$BIN/aws" <<'AWS'
+#!/usr/bin/env bash
+set -u
+key_to_path() { printf '%s' "$1" | sed 's#[/:]#_#g'; }
+svc="$1"; shift
+case "$svc" in
+  s3)
+    sub="$1"; src="$2"; dst="$3"
+    [ "$sub" = "cp" ] || exit 0
+    if [[ "$src" == s3://* ]]; then                 # download
+      key="${src#s3://*/}"
+      f="$FAKE_S3_DIR/$(key_to_path "$key")"
+      [ -f "$f" ] && { cp "$f" "$dst"; exit 0; }
+      exit 1                                         # miss
+    elif [[ "$dst" == s3://* ]]; then               # upload
+      key="${dst#s3://*/}"
+      mkdir -p "$FAKE_S3_DIR"
+      cp "$src" "$FAKE_S3_DIR/$(key_to_path "$key")"
+      [ -n "${UPLOAD_LOG:-}" ] && printf '%s\n' "$key" >> "$UPLOAD_LOG"
+      exit 0
+    fi
+    exit 0 ;;
+  bedrock-runtime)
+    if [ -n "${BEDROCK_FAIL:-}" ]; then
+      echo "ThrottlingException: rate exceeded" >&2   # transient signature
+      exit 255
+    fi
+    cat "${BEDROCK_RESP_FILE:?BEDROCK_RESP_FILE unset}"
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+AWS
+chmod +x "$BIN/aws"
+
+# ---- fake `curl`: emit `body\ncode` (http_retryable ignores real -w) -----------
+cat > "$BIN/curl" <<'CURL'
+#!/usr/bin/env bash
+set -u
+url=""
+for a in "$@"; do case "$a" in http://*|https://*) url="$a" ;; esac; done
+case "$url" in
+  *api.osv.dev*)             [ -n "${OSV_FAIL:-}" ] && exit 1
+                             printf '%s\n%s' "${OSV_BODY:-}" "${OSV_CODE:-200}" ;;
+  *securityscorecards.dev*)  [ -n "${SC_FAIL:-}" ] && exit 1
+                             printf '%s\n%s' "${SC_BODY:-}" "${SC_CODE:-200}" ;;
+  *api.github.com*)          printf '%s\n%s' "${GH_BODY:-}" "${GH_CODE:-404}" ;;
+  *)                         printf '\n000' ;;
+esac
+CURL
+chmod +x "$BIN/curl"
+
+# Canned Bedrock Converse success (no breaking changes; applies_to_repo true).
+BEDROCK_GOOD="$WORK/bedrock_good.json"
+cat > "$BEDROCK_GOOD" <<'EOF'
+{"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":80,\"risks\":[],\"summary\":\"no breaking changes\",\"applies_to_repo\":true}"}]}}}
+EOF
+
+b64() { printf '%b' "$1" | base64 | tr -d '\n'; }
+s3put() { cp "$2" "$FAKE_S3_DIR/$(printf '%s' "$1" | sed 's#[/:]#_#g')"; }
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ============================================================================
+# #193/#194 — supply-chain: OSV error SKIPS the shared-cache write
+# ============================================================================
+S3="$WORK/s3_t1"; mkdir -p "$S3"; UL="$WORK/ul_t1"; : > "$UL"; GHO="$WORK/gho_t1"; : > "$GHO"
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 SCORECARD_THRESHOLD=7
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\n')"
+  export OSV_FAIL=1 SC_BODY='{"score":9.5}' SC_CODE=200
+  bash "$SUPPLY" >>"$WORK/log_t1" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "#194 supply: script aborted (exit $rc): $(cat "$WORK/log_t1")"
+grep -q '^check_errors=1$' "$GHO" || fail "#194 supply: expected check_errors=1, got: $(grep check_errors "$GHO")"
+grep -q 'actions--checkout/5.0.0.json' "$UL" \
+  && fail "#194 supply: cache write happened despite OSV error (would poison the fleet cache): $(cat "$UL")"
+echo "OK: #193/#194 supply-chain skips cache write on OSV error (check_errors=1, no upload)"
+
+# ---- control: a clean supply-chain run DOES write the cache ----
+S3="$WORK/s3_t2"; mkdir -p "$S3"; UL="$WORK/ul_t2"; : > "$UL"; GHO="$WORK/gho_t2"; : > "$GHO"
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 SCORECARD_THRESHOLD=7
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\n')"
+  export OSV_BODY='{"vulns":[]}' OSV_CODE=200 SC_BODY='{"score":9.5}' SC_CODE=200
+  bash "$SUPPLY" >>"$WORK/log_t2" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "supply control: script aborted (exit $rc): $(cat "$WORK/log_t2")"
+grep -q '^check_errors=0$' "$GHO" || fail "supply control: expected check_errors=0"
+grep -q 'actions--checkout/5.0.0.json' "$UL" || fail "supply control: clean run should write cache, but no upload: $(cat "$UL")"
+echo "OK: control — clean supply-chain run writes the cache (check_errors=0, upload present)"
+
+# ============================================================================
+# #201 — supply-chain: corrupt cached object is treated as a miss (no abort)
+# ============================================================================
+S3="$WORK/s3_t3"; mkdir -p "$S3"; UL="$WORK/ul_t3"; : > "$UL"; GHO="$WORK/gho_t3"; : > "$GHO"
+printf 'this is not json {{{' > "$WORK/corrupt.json"
+s3put_dir() { cp "$2" "$1/$(printf '%s' "$3" | sed 's#[/:]#_#g')"; }
+s3put_dir "$S3" "$WORK/corrupt.json" 'analyses/shared/actions--checkout/5.0.0.json'
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 SCORECARD_THRESHOLD=7
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\n')"
+  export OSV_BODY='{"vulns":[]}' OSV_CODE=200 SC_BODY='{"score":9.5}' SC_CODE=200
+  bash "$SUPPLY" >>"$WORK/log_t3" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "#201 supply: corrupt cache object aborted the job (exit $rc): $(cat "$WORK/log_t3")"
+grep -q '^check_errors=' "$GHO" || fail "#201 supply: no outputs emitted — job aborted before completion"
+echo "OK: #201 supply-chain treats a corrupt cached object as a miss (no set -e abort)"
+
+# ============================================================================
+# #193/#194 — breaking-change: Bedrock error SKIPS the shared-cache write
+# ============================================================================
+S3="$WORK/s3_t4"; mkdir -p "$S3"; UL="$WORK/ul_t4"; : > "$UL"; GHO="$WORK/gho_t4"; : > "$GHO"
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 BEDROCK_MODEL_ID=test-model
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export GH_TOKEN=x GITHUB_REPOSITORY=test-org/test-repo BEDROCK_RESP_FILE="$BEDROCK_GOOD"
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\n')"
+  export BEDROCK_FAIL=1 GH_CODE=404
+  bash "$BREAKING" >>"$WORK/log_t4" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "#194 breaking: script aborted (exit $rc): $(cat "$WORK/log_t4")"
+grep -qE '^check_errors=[1-9]' "$GHO" || fail "#194 breaking: expected check_errors>=1, got: $(grep check_errors "$GHO")"
+grep -q 'analyses/shared/actions--checkout/5.0.0.json' "$UL" \
+  && fail "#194 breaking: SHARED cache write happened despite Bedrock error: $(cat "$UL")"
+echo "OK: #193/#194 breaking-change skips SHARED cache write on Bedrock error"
+
+# ============================================================================
+# #195 — breaking-change grouped PR: dep2 (miss) must NOT inherit dep1 (hit)
+# ============================================================================
+S3="$WORK/s3_t5"; mkdir -p "$S3"; UL="$WORK/ul_t5"; : > "$UL"; GHO="$WORK/gho_t5"; : > "$GHO"
+cat > "$WORK/dep1.json" <<EOF
+{
+  "schema_version":"1",
+  "producer":"coalfire-org-dependabot-auto-merge",
+  "dependency":"actions/checkout",
+  "version":"5.0.0",
+  "analyzed_at":"$NOW",
+  "semver":{"type":"minor","from":"4.0.0","to":"5.0.0"},
+  "changelog":{"breaking":false,"ai_breaking":false,"confidence":80,"summary":"ok","risks":[]},
+  "osv":{"clear":true,"vulns":[]},
+  "scorecard":{"score":"9.5","pass":true}
+}
+EOF
+s3put_dir "$S3" "$WORK/dep1.json" 'analyses/shared/actions--checkout/5.0.0.json'
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 BEDROCK_MODEL_ID=test-model
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export GH_TOKEN=x GITHUB_REPOSITORY=test-org/test-repo BEDROCK_RESP_FILE="$BEDROCK_GOOD"
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\nactions/setup-go\t4.0.0\t5.0.0\n')"
+  export GH_CODE=404
+  bash "$BREAKING" >>"$WORK/log_t5" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "#195 breaking: script aborted (exit $rc): $(cat "$WORK/log_t5")"
+DEP2_OBJ="$S3/analyses_shared_actions--setup-go_5.0.0.json"
+[ -f "$DEP2_OBJ" ] || fail "#195 breaking: dep2 shared object was never written: $(cat "$UL")"
+osv_field="$(jq -c '.osv // "ABSENT"' "$DEP2_OBJ")"
+[ "$osv_field" = '"ABSENT"' ] || fail "#195 breaking: dep2 object inherited dep1's supply-chain fields (.osv=${osv_field}) — stale /tmp contamination"
+echo "OK: #195 breaking-change dep2 (cache miss) does not inherit dep1's cached fields"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Batch A of the 2026-07-08 audit sweep. Hardens the shared S3 analysis cache that gates fleet-wide Dependabot auto-merge decisions.

## Fixes
- **#193 / #194 (H1)** — transient OSV/Bedrock failure no longer persists an optimistic `clear=true` / `breaking=false` verdict to the shared cache. Skip the write when the dependency errored (per-dep `ERRORS_BEFORE` baseline), symmetric in both scripts.
- **#195 (H2)** — grouped-PR contamination: a dep that missed the cache no longer inherits the previous dep's lingering `/tmp` object. Clear temps at top of `check_one`; gate the merge-read on `CACHED=ok`.
- **#201 (M4)** — pre-validation `jq` reads guarded so a corrupt cached object is treated as a miss instead of aborting the job under `set -e`.

## Testing
New `tests/cache-integrity.test.sh` drives both scripts end-to-end with fake `aws` (S3 + bedrock-runtime) and `curl` (OSV/Scorecard/GitHub) on PATH — fully offline. Asserts write-skip on error, no cross-dep contamination, and no-abort on corrupt objects. Each fix watched RED→GREEN. Full suite green (`shellcheck scripts/*.sh` clean; the unrelated `tree-readme-section` failure is a pre-existing macOS artifact, green on CI).

Closes #193
Closes #194
Closes #195
Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)