### PR TITLE
fix(terraform): make the TF gates actually enforce (H4/M1/M8/L12)

### DIFF
--- a/.github/workflows/org-terraform-apply.yml
+++ b/.github/workflows/org-terraform-apply.yml
@@ -247,21 +247,24 @@ jobs:
         env:
           INPUT_BACKEND_CONFIG: ${{ inputs.backend_config }}
         run: |
-          INIT_ARGS=""
+          # L12/#218: bash array so a backend_config value with spaces is passed
+          # as a single argument (not word-split), and empty args add nothing.
+          INIT_ARGS=()
           if [ -n "$INPUT_BACKEND_CONFIG" ]; then
-            INIT_ARGS="-backend-config=$INPUT_BACKEND_CONFIG"
+            INIT_ARGS+=("-backend-config=$INPUT_BACKEND_CONFIG")
           fi
-          terraform init $INIT_ARGS
+          terraform init "${INIT_ARGS[@]}"
 
       - name: Terraform Plan
         env:
           INPUT_VAR_FILE: ${{ inputs.var_file }}
         run: |
-          PLAN_ARGS="-no-color -input=false -out=tfplan"
+          # L12/#218: bash array so a var_file path with spaces survives intact.
+          PLAN_ARGS=(-no-color -input=false -out=tfplan)
           if [ -n "$INPUT_VAR_FILE" ]; then
-            PLAN_ARGS="$PLAN_ARGS -var-file=$INPUT_VAR_FILE"
+            PLAN_ARGS+=("-var-file=$INPUT_VAR_FILE")
           fi
-          terraform plan $PLAN_ARGS
+          terraform plan "${PLAN_ARGS[@]}"
 
       - name: Upload plan artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -278,11 +281,12 @@ jobs:
         env:
           INPUT_VAR_FILE: ${{ inputs.var_file }}
         run: |
-          DESTROY_ARGS="-no-color -input=false -auto-approve"
+          # L12/#218: bash array so a var_file path with spaces survives intact.
+          DESTROY_ARGS=(-no-color -input=false -auto-approve)
           if [ -n "$INPUT_VAR_FILE" ]; then
-            DESTROY_ARGS="$DESTROY_ARGS -var-file=$INPUT_VAR_FILE"
+            DESTROY_ARGS+=("-var-file=$INPUT_VAR_FILE")
           fi
-          terraform destroy $DESTROY_ARGS
+          terraform destroy "${DESTROY_ARGS[@]}"
 
   notify-failure:
     needs: apply

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -32,8 +32,11 @@ concurrency:
   group: terraform-fmt-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Least privilege (#198): the fmt gate now only checks + comments; it no longer
+# writes a commit, so contents:read suffices (pull-requests:write is for the
+# failure comment).
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -76,14 +79,13 @@ jobs:
       with:
         terraform_version: ${{ steps.tf-version.outputs.version }}
 
-    - name: Run Terraform fmt
-      run: terraform fmt -recursive
-
-    - name: Commit changes
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git diff --quiet && git diff --staged --quiet || (git add -A && git commit -m "Apply terraform fmt")
+    - name: Check Terraform formatting
+      # M1/#198: this is an ENFORCE gate (job name "Check Terraform Formatting" +
+      # the failure comment telling authors to run fmt). The old `terraform fmt
+      # -recursive` reformatted in place, exited 0 (never failed), and committed
+      # locally without pushing — a no-op discarded on teardown. `-check` fails on
+      # drift; `-diff` surfaces exactly what needs formatting.
+      run: terraform fmt -check -recursive -diff
 
     - name: Post comment on failure
       if: failure()

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -234,23 +234,26 @@ jobs:
         env:
           INPUT_BACKEND_CONFIG: ${{ inputs.backend_config }}
         run: |
-          INIT_ARGS=""
+          # L12/#218: bash array so a backend_config value with spaces is passed
+          # as a single argument (not word-split), and empty args add nothing.
+          INIT_ARGS=()
           if [ -n "$INPUT_BACKEND_CONFIG" ]; then
-            INIT_ARGS="-backend-config=$INPUT_BACKEND_CONFIG"
+            INIT_ARGS+=("-backend-config=$INPUT_BACKEND_CONFIG")
           fi
-          terraform init $INIT_ARGS
+          terraform init "${INIT_ARGS[@]}"
 
       - name: Terraform Plan
         id: plan
         env:
           INPUT_VAR_FILE: ${{ inputs.var_file }}
         run: |
-          PLAN_ARGS="-no-color -input=false -out=tfplan"
+          # L12/#218: bash array so a var_file path with spaces survives intact.
+          PLAN_ARGS=(-no-color -input=false -out=tfplan)
           if [ -n "$INPUT_VAR_FILE" ]; then
-            PLAN_ARGS="$PLAN_ARGS -var-file=$INPUT_VAR_FILE"
+            PLAN_ARGS+=("-var-file=$INPUT_VAR_FILE")
           fi
           set +e
-          terraform plan $PLAN_ARGS -detailed-exitcode 2>&1 | tee "$GITHUB_WORKSPACE/plan_output.txt"
+          terraform plan "${PLAN_ARGS[@]}" -detailed-exitcode 2>&1 | tee "$GITHUB_WORKSPACE/plan_output.txt"
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
 

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -108,16 +108,21 @@ jobs:
     - name: Validate Terraform
       id: validate
       run: |
+        # H4/#197: capture stderr (validate writes diagnostics there) AND preserve
+        # terraform's exit code, then re-fail on it. Previously $() captured only
+        # stdout and the code was discarded into the substitution, with
+        # continue-on-error and no later re-check — so invalid Terraform passed
+        # green with an empty comment. Mirrors the org-terraform-plan.yml idiom.
         set +e
-        OUTPUT=$(terraform validate)
-        CLEAN_OUTPUT=$(echo "$OUTPUT" | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
-        echo "$CLEAN_OUTPUT"
-        echo "$CLEAN_OUTPUT" > "$GITHUB_WORKSPACE/validate_output.txt"
+        terraform validate 2>&1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" | tee "$GITHUB_WORKSPACE/validate_output.txt"
+        RC=${PIPESTATUS[0]}
         set -e
-      continue-on-error: true
+        exit "$RC"
 
     - name: Create comment
-      if: github.event_name == 'pull_request'
+      # always() so the diagnostics comment still posts when validate FAILS
+      # (the step above now exits non-zero on invalid Terraform).
+      if: always() && github.event_name == 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/org-terraform-version-check.yml
+++ b/.github/workflows/org-terraform-version-check.yml
@@ -9,6 +9,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# M8/#205: serialize so a manual workflow_dispatch cannot overlap the monthly cron
+# (two runs racing to create the same chore/terraform-<ver> branch/PR).
+concurrency:
+  group: terraform-version-check-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   check-version:
     name: Check for New Terraform Release
@@ -16,6 +22,33 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # M8/#205: prefer a GitHub App token for the bump PR. A PR opened (and its
+      # branch pushed) by GITHUB_TOKEN does NOT trigger on:pull_request workflows
+      # (GitHub anti-recursion), so the validate/plan/fmt checklist the PR embeds
+      # never runs. Fall back to GITHUB_TOKEN when the App is not provisioned so
+      # this workflow keeps working (behavior unchanged, minus CI triggering).
+      - name: Check for App credentials
+        id: check-app
+        env:
+          TF_VERSION_APP_ID: ${{ secrets.TF_VERSION_APP_ID }}
+          TF_VERSION_APP_PRIVATE_KEY: ${{ secrets.TF_VERSION_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "$TF_VERSION_APP_ID" ] && [ -n "$TF_VERSION_APP_PRIVATE_KEY" ]; then
+            echo "has_app=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_app=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No TF_VERSION_APP_ID / TF_VERSION_APP_PRIVATE_KEY configured — the version-bump PR will be opened with GITHUB_TOKEN, which does NOT trigger pull_request CI (validate/plan/fmt). Provision a GitHub App to enable CI on auto-bump PRs (#205)."
+          fi
+
+      - name: Generate App token
+        id: app-token
+        if: steps.check-app.outputs.has_app == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.TF_VERSION_APP_ID }}
+          private-key: ${{ secrets.TF_VERSION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Get current version
         id: current
@@ -77,9 +110,13 @@ jobs:
         if: steps.compare.outputs.needs_update == 'true' && steps.existing-pr.outputs.exists == 'false'
         env:
           LATEST_VERSION: ${{ steps.latest.outputs.version }}
+          # App token when available (so the push is authored by the App and CI
+          # fires); GITHUB_TOKEN fallback preserves prior behavior (#205).
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout -b "chore/terraform-${LATEST_VERSION}"
           echo "$LATEST_VERSION" > .terraform-version
           # F36 (Plan B): keep the baked DEFAULT_TF_VERSION literals in lockstep
@@ -94,7 +131,8 @@ jobs:
       - name: Create Pull Request
         if: steps.compare.outputs.needs_update == 'true' && steps.existing-pr.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App token when available so the PR triggers pull_request CI (#205).
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           CURRENT_VERSION: ${{ steps.current.outputs.version }}
           LATEST_VERSION: ${{ steps.latest.outputs.version }}
         run: |


### PR DESCRIPTION
Batch B of the 2026-07-08 audit sweep — four workflow gates that silently passed.

## Fixes
- **#197 (H4)** — `org-terraform-validate` now captures stderr + exit code and re-fails (`terraform validate 2>&1 | sed | tee`; `PIPESTATUS[0]`; `exit $RC`), drops `continue-on-error`, and posts the diagnostics comment `if: always()`. Invalid Terraform no longer passes green.
- **#198 (M1)** — `org-terraform-fmt` switches to enforce mode (`terraform fmt -check -recursive -diff`); removes the dead local-commit step and the now-unneeded `contents: write`.
- **#205 (M8)** — version-bump PR opens with a GitHub App token (`TF_VERSION_APP_ID`/`TF_VERSION_APP_PRIVATE_KEY`) so it triggers `pull_request` CI, **falling back to `GITHUB_TOKEN` + a warning when unprovisioned** (non-breaking). Adds a `concurrency:` group.
- **#218 (L12)** — `INIT_ARGS`/`PLAN_ARGS`/`DESTROY_ARGS` converted to bash arrays in plan.yml + apply.yml (values with spaces survive).

## Notes / validation
- `actionlint` clean at the CI gate (`SHELLCHECK_OPTS=-S warning`); the changes *reduced* pre-existing SC2086 info nits 16→11.
- The enforce-mode fmt gate was verified against this repo's own 6 `.tf` fixtures (`terraform fmt -check` = clean), so it won't self-fail.
- **#205 activation note**: CI-triggering on auto-bump PRs turns on once `TF_VERSION_APP_*` secrets are provisioned; until then behavior is unchanged (GITHUB_TOKEN + warning).

Closes #197
Closes #198
Closes #205
Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)