### PR TITLE
fix(ci): harden github-script/run against ${{ }} interpolation (H3/L11/L13)

### DIFF
--- a/.github/workflows/org-gitleaks-pr.yml
+++ b/.github/workflows/org-gitleaks-pr.yml
@@ -46,11 +46,15 @@ jobs:
     - name: Create PR comment
       if: always()
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      # L13/#219: pass the step output via env: + process.env instead of
+      # interpolating ${{ }} into the JS (repo hardening convention).
+      env:
+        GITLEAKS_PASSED: ${{ steps.gitleaks.outputs.passed }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const fs = require('fs');
-          const passed = '${{ steps.gitleaks.outputs.passed }}' === 'true';
+          const passed = process.env.GITLEAKS_PASSED === 'true';
 
           if (passed) {
             const output = `#### Gitleaks Secret Scan Results\n\n` +

--- a/.github/workflows/org-opa.yml
+++ b/.github/workflows/org-opa.yml
@@ -97,6 +97,9 @@ jobs:
         id: guard
         env:
           POLICY_REF: ${{ inputs.policy_ref }}
+          # L11/#217: route policy_repo through env: for consistency with the
+          # repo's hardening pattern, rather than interpolating ${{ }} into run:.
+          POLICY_REPO: ${{ inputs.policy_repo }}
           CHECKOUT_OUTCOME: ${{ steps.policies.outcome }}
         run: |
           set -eo pipefail
@@ -104,7 +107,7 @@ jobs:
             echo "::notice::org-opa: no policy_ref provided — skipping (advisory). Pin org-opa-policies by release SHA to enable."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           elif [ "$CHECKOUT_OUTCOME" != "success" ]; then
-            echo "::notice::org-opa: policy repo/ref unreachable (${{ inputs.policy_repo }}@${POLICY_REF}) — skipping (advisory)."
+            echo "::notice::org-opa: policy repo/ref unreachable (${POLICY_REPO}@${POLICY_REF}) — skipping (advisory)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -277,12 +277,16 @@ jobs:
       - name: Post plan to PR
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        # L13/#219: pass the step output via env: + process.env instead of
+        # interpolating ${{ }} into the JS (repo hardening convention).
+        env:
+          PLAN_EXITCODE: ${{ steps.plan.outputs.exitcode }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             let plan = fs.readFileSync(process.env.GITHUB_WORKSPACE + '/plan_output.txt', 'utf8');
-            const exitCode = '${{ steps.plan.outputs.exitcode }}';
+            const exitCode = process.env.PLAN_EXITCODE;
 
             let status = '✅ No changes';
             if (exitCode === '2') status = '⚠️ Changes detected';

--- a/.github/workflows/org-trivy-exception-review.yml
+++ b/.github/workflows/org-trivy-exception-review.yml
@@ -109,13 +109,22 @@ jobs:
     - name: Create issue for expired exceptions
       if: steps.check_expired.outputs.has_expired == 'true'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      # H3/#196: .trivyignore.yaml `statement` content flows into expired_list /
+      # expiring_soon_list. Interpolating it into the JS template literal let a
+      # backtick or ${…} in a statement break out and run arbitrary code on a
+      # runner whose token has issues:write. Pass via env: + process.env instead,
+      # mirroring the "Generate summary" step below.
+      env:
+        EXPIRED_LIST: ${{ steps.check_expired.outputs.expired_list }}
+        EXPIRING_SOON_LIST: ${{ steps.check_expired.outputs.expiring_soon_list }}
+        HAS_EXPIRING_SOON: ${{ steps.check_expired.outputs.has_expiring_soon }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const today = new Date().toISOString().split('T')[0];
-          const expiredList = `${{ steps.check_expired.outputs.expired_list }}`;
-          const expiringSoonList = `${{ steps.check_expired.outputs.expiring_soon_list }}`;
-          const hasExpiringSoon = '${{ steps.check_expired.outputs.has_expiring_soon }}' === 'true';
+          const expiredList = process.env.EXPIRED_LIST || '';
+          const expiringSoonList = process.env.EXPIRING_SOON_LIST || '';
+          const hasExpiringSoon = process.env.HAS_EXPIRING_SOON === 'true';
 
           let body = `## SAST Exception Review Required\n\n`;
           body += `The following security exceptions in \`.trivyignore.yaml\` have expired and require review.\n\n`;

--- a/.github/workflows/org-trivy-pr.yml
+++ b/.github/workflows/org-trivy-pr.yml
@@ -67,11 +67,15 @@ jobs:
     - name: Create comment with Trivy results
       if: always()
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      # L13/#219: pass the step output via env: + process.env instead of
+      # interpolating ${{ }} into the JS (repo hardening convention).
+      env:
+        HAS_TF_FILES: ${{ steps.get_changed_files.outputs.has_tf_files }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const fs = require('fs');
-          const hasTfFiles = '${{ steps.get_changed_files.outputs.has_tf_files }}' === 'true';
+          const hasTfFiles = process.env.HAS_TF_FILES === 'true';
 
           if (!hasTfFiles) {
             const output = `🌟 No Terraform files were modified in this PR. Trivy scan skipped. 🌟`;


### PR DESCRIPTION
Batch C of the 2026-07-08 audit sweep. Routes values through `env:` + `process.env` instead of interpolating `${{ }}` into `github-script` JS (or `run:`) — the repo's hardened convention.

## Fixes
- **#196 (H3)** — `org-trivy-exception-review`: `.trivyignore.yaml` `statement` content (expired_list / expiring_soon_list) was interpolated into a github-script **template literal** in a job with `issues: write` — a genuine code-injection vector (a backtick/`${…}` in a statement runs arbitrary code). Now passed via `env:` + `process.env`.
- **#217 (L11)** — `org-opa`: `inputs.policy_repo` routed through a `POLICY_REPO` env var (matches the existing `POLICY_REF` handling).
- **#219 (L13)** — `org-gitleaks-pr`, `org-trivy-pr`, `org-terraform-plan`: action-controlled step outputs moved from `${{ }}` in JS to `env:` + `process.env`.

`actionlint` clean at the CI gate (`SHELLCHECK_OPTS=-S warning`).

Closes #196
Closes #217
Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)