### PR TITLE
fix(auto-merge): check-script robustness + test coverage (M2/M3/L19)

### DIFF
--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -255,8 +255,10 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
     RELEASE_NOTES="No release notes available."
   fi
 
-  # Truncate to ~4000 chars to keep Claude API costs low
-  RELEASE_NOTES=$(echo "$RELEASE_NOTES" | head -c 4000)
+  # Truncate to ~4000 chars to keep Claude API costs low. L19/#225: bash substring
+  # counts CHARACTERS in a UTF-8 locale, so it won't split a multibyte character
+  # mid-sequence the way byte-based `head -c` did.
+  RELEASE_NOTES="${RELEASE_NOTES:0:4000}"
 
   # ---------------------------------------------------------
   # Bedrock Converse API analysis
@@ -326,6 +328,11 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
   fi
   HAS_BREAKING=$(echo "$AI_TEXT" | jq -r '.breaking // false')
   CONFIDENCE=$(echo "$AI_TEXT" | jq -r '.confidence // 0')
+  # M2/#199: a valid-JSON verdict with a non-numeric confidence (e.g. a prompt-
+  # injected "high", or "") would make `--argjson conf` invalid JSON → jq abort
+  # under set -e. `// 0` does not fire on a present-but-non-numeric value, so
+  # validate explicitly and default to 0.
+  [[ "$CONFIDENCE" =~ ^[0-9]+(\.[0-9]+)?$ ]] || CONFIDENCE=0
   RISK_SUMMARY=$(echo "$AI_TEXT" | jq -r '.summary // "Analysis unavailable"')
   AI_RISKS=$(echo "$AI_TEXT" | jq -r '.risks // []')
   APPLIES_TO_REPO=$(echo "$AI_TEXT" | jq -r '.applies_to_repo // true')
@@ -510,6 +517,9 @@ echo "confidence=${AGG_CONF}" >> "$GITHUB_OUTPUT"
 echo "applies_to_repo=${AGG_APPLIES}" >> "$GITHUB_OUTPUT"
 echo "check_errors=${CHECK_ERRORS}" >> "$GITHUB_OUTPUT"
 
-# Escape newlines + truncate for GITHUB_OUTPUT
-SAFE_SUMMARY=$(echo "$AGG_SUMMARY" | tr '\n' ' ' | head -c 900)
+# Escape newlines + truncate for GITHUB_OUTPUT. L19/#225: char-based substring
+# (UTF-8-aware) instead of byte-based `head -c`, so a multibyte char at the cut
+# point is not split.
+SAFE_SUMMARY=$(printf '%s' "$AGG_SUMMARY" | tr '\n' ' ')
+SAFE_SUMMARY="${SAFE_SUMMARY:0:900}"
 echo "risk_summary=${SAFE_SUMMARY}" >> "$GITHUB_OUTPUT"

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -182,7 +182,12 @@ if [ "$CACHE_HIT" = "false" ]; then
       http_retryable --max-time 30 \
       "https://api.securityscorecards.dev/projects/${SCORECARD_REPO}" \
       || echo '{}')
-    SCORECARD_SCORE=$(echo "$SCORECARD_RESPONSE" | jq -r '.score // 0')
+    # M3/#200: a 2xx-but-non-JSON body (proxy/HTML error page) makes jq exit
+    # non-zero → set -e abort; a valid-JSON non-numeric .score leaves a value bc
+    # can't compare → integer-expr error. Guard the read and fail closed to 0
+    # (below any threshold → not-pass) on anything non-numeric.
+    SCORECARD_SCORE=$(echo "$SCORECARD_RESPONSE" | jq -r '.score // 0' 2>/dev/null || echo 0)
+    [[ "$SCORECARD_SCORE" =~ ^[0-9]+(\.[0-9]+)?$ ]] || SCORECARD_SCORE=0
 
     if [ "$(echo "$SCORECARD_SCORE < $SCORECARD_THRESHOLD" | bc -l)" -eq 1 ]; then
       SCORECARD_PASS="false"
@@ -238,7 +243,9 @@ fi
 [ "$OSV_CLEAR" = "true" ]      || AGG_OSV_CLEAR="false"
 [ "$SCORECARD_PASS" = "true" ] || AGG_SC_PASS="false"
 [ "$CACHE_HIT" = "true" ]      || AGG_CACHE_HIT="false"
-if [ "$SCORECARD_SCORE" != "N/A" ]; then
+# M3/#200: only fold a genuinely numeric score into the aggregate min — a "N/A"
+# (no repo) or a garbage cache-hit score must not reach bc (integer-expr abort).
+if [ "$SCORECARD_SCORE" != "N/A" ] && [[ "$SCORECARD_SCORE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
   if [ -z "$AGG_SC_SCORE" ] || [ "$(echo "$SCORECARD_SCORE < $AGG_SC_SCORE" | bc -l)" -eq 1 ]; then
     AGG_SC_SCORE="$SCORECARD_SCORE"
   fi

--- a/tests/cache-integrity.test.sh
+++ b/tests/cache-integrity.test.sh
@@ -94,6 +94,13 @@ cat > "$BEDROCK_GOOD" <<'EOF'
 {"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":80,\"risks\":[],\"summary\":\"no breaking changes\",\"applies_to_repo\":true}"}]}}}
 EOF
 
+# Valid-JSON verdict with a NON-numeric confidence — a prompt-injection could make
+# the model emit this; the fix must default confidence to 0, not crash --argjson.
+BEDROCK_BADCONF="$WORK/bedrock_badconf.json"
+cat > "$BEDROCK_BADCONF" <<'EOF'
+{"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":\"high\",\"risks\":[],\"summary\":\"x\",\"applies_to_repo\":true}"}]}}}
+EOF
+
 b64() { printf '%b' "$1" | base64 | tr -d '\n'; }
 s3put() { cp "$2" "$FAKE_S3_DIR/$(printf '%s' "$1" | sed 's#[/:]#_#g')"; }
 NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -207,5 +214,42 @@ DEP2_OBJ="$S3/analyses_shared_actions--setup-go_5.0.0.json"
 osv_field="$(jq -c '.osv // "ABSENT"' "$DEP2_OBJ")"
 [ "$osv_field" = '"ABSENT"' ] || fail "#195 breaking: dep2 object inherited dep1's supply-chain fields (.osv=${osv_field}) — stale /tmp contamination"
 echo "OK: #195 breaking-change dep2 (cache miss) does not inherit dep1's cached fields"
+
+# ============================================================================
+# #200 (M3) — supply-chain: a non-JSON / non-numeric Scorecard body fails closed
+# (SCORECARD_PASS=false) instead of crashing bc / jq under set -e.
+# ============================================================================
+S3="$WORK/s3_t6"; mkdir -p "$S3"; UL="$WORK/ul_t6"; : > "$UL"; GHO="$WORK/gho_t6"; : > "$GHO"
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 SCORECARD_THRESHOLD=7
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\n')"
+  export OSV_BODY='{"vulns":[]}' OSV_CODE=200 SC_BODY='<html>502 Bad Gateway</html>' SC_CODE=200
+  bash "$SUPPLY" >>"$WORK/log_t6" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "#200 supply: non-JSON Scorecard body crashed the job (exit $rc): $(cat "$WORK/log_t6")"
+grep -q '^scorecard_pass=false$' "$GHO" || fail "#200 supply: garbage score must fail closed (scorecard_pass=false), got: $(grep scorecard_pass "$GHO")"
+echo "OK: #200 supply-chain non-numeric/garbage Scorecard body fails closed (no crash)"
+
+# ============================================================================
+# #199 (M2) — breaking-change: a non-numeric model confidence defaults to 0
+# instead of crashing `jq --argjson conf` under set -e.
+# ============================================================================
+S3="$WORK/s3_t7"; mkdir -p "$S3"; UL="$WORK/ul_t7"; : > "$UL"; GHO="$WORK/gho_t7"; : > "$GHO"
+(
+  export PATH="$BIN:$PATH" FAKE_S3_DIR="$S3" UPLOAD_LOG="$UL" GITHUB_OUTPUT="$GHO"
+  export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 BEDROCK_MODEL_ID=test-model
+  export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+  export GH_TOKEN=x GITHUB_REPOSITORY=test-org/test-repo BEDROCK_RESP_FILE="$BEDROCK_BADCONF"
+  export DEPS_B64="$(b64 'actions/checkout\t4.0.0\t5.0.0\n')"
+  export GH_CODE=404
+  bash "$BREAKING" >>"$WORK/log_t7" 2>&1
+)
+rc=$?
+[ "$rc" -eq 0 ] || fail "#199 breaking: non-numeric confidence crashed the job (exit $rc): $(cat "$WORK/log_t7")"
+grep -q '^confidence=0$' "$GHO" || fail "#199 breaking: non-numeric confidence should default to 0, got: $(grep '^confidence=' "$GHO")"
+echo "OK: #199 breaking-change non-numeric confidence defaults to 0 (no --argjson crash)"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
Batch D of the 2026-07-08 audit sweep. Both check scripts ran under `set -e` in an unguarded `check_one`, so one malformed value aborted the whole gate.

## Fixes
- **#200 (M3)** — supply-chain: guard the Scorecard `.score` read (non-JSON body no longer crashes jq) and fail closed to `0` on non-numeric; numeric-gate the aggregate-min `bc`.
- **#199 (M2)** — breaking-change: validate model `.confidence` is numeric before `jq --argjson` (a prompt-injected `"high"`/`""` no longer aborts the job); default `0`.
- **#225 (L19)** — UTF-8-aware bash substring instead of byte-based `head -c` for release notes (4000) and summary (900).
- **#206 (Task)** — extended `tests/cache-integrity.test.sh` (added in Batch A) with the M2/M3 cases; it now asserts all four of #206's coverage goals for both previously-untested scripts.

Full suite green; `shellcheck scripts/*.sh` clean. Each fix watched RED→GREEN. (The unrelated `tree-readme-section` failure is a pre-existing macOS artifact, green on CI.)

Closes #199
Closes #200
Closes #225
Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)