### PR TITLE
fix(release): paginate comment lookup, bound watch, classify gh failures (M6/L7/L8)

### DIFF
--- a/scripts/release-patch-merge.sh
+++ b/scripts/release-patch-merge.sh
@@ -64,8 +64,22 @@ MARKER="<!-- org-release-auto-patch -->"
 log() { echo "[release-patch-merge] $*" >&2; }
 
 # ---- gh read wrappers (transient blip → retry via with_retry) ----
+# L8/#214: classify on evidence — only retry transient classes (429 rate-limit,
+# 5xx, timeouts/conn resets). A definitive 4xx (esp. 404 for an absent manifest)
+# is permanent: return 1 so with_retry stops immediately instead of spinning
+# RETRY_MAX times. Unknown failures also default permanent (retry-lib philosophy:
+# never spin on an unclassifiable error).
 # shellcheck disable=SC2317,SC2329  # invoked indirectly via `with_retry -- _gh_once` (SC2317/SC2329 are the version-dependent codes for the same "unreachable/unused function" false positive)
-_gh_once()      { local o; if o="$(gh "$@" 2>/dev/null)"; then printf '%s' "$o"; return 0; fi; return "$RETRY_TRANSIENT_RC"; }
+_gh_once() {
+  local o err rc
+  err="$(mktemp)"
+  if o="$(gh "$@" 2>"$err")"; then rm -f "$err"; printf '%s' "$o"; return 0; fi
+  rc=$?
+  if grep -qiE 'HTTP (429|5[0-9][0-9])|rate limit|timeout|timed out|temporar|connection reset|connection refused|no such host|i/o timeout|EOF' "$err"; then
+    rm -f "$err"; return "$RETRY_TRANSIENT_RC"      # transient — retry
+  fi
+  rm -f "$err"; return "$rc"                          # permanent (4xx / unknown) — no spin
+}
 gh_read()       { with_retry "$RETRY_MAX" 2 20 -- _gh_once "$@"; }
 # Read a repo file's decoded content at a pinned SHA (empty string if absent).
 read_file_at() { # <path> <sha>
@@ -93,9 +107,12 @@ upsert_comment() { # <decision-text>
 **org-release auto-patch** — ${1}
 ${DECISION_BODY}
 _run: ${RUN_URL:-n/a}_"
-  # Locate an existing marker comment (edit, never re-post).
-  id="$(gh_read api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-        --jq "map(select(.body|contains(\"${MARKER}\")))|last|.id // empty" 2>/dev/null || true)"
+  # Locate an existing marker comment (edit, never re-post). M6/#203: --paginate so
+  # a PR with >30 comments still finds the marker (else the upsert appends a new
+  # comment every run). With --paginate the --jq filter runs per page, so emit each
+  # matching id and take the last (most recent) rather than a per-page `last`.
+  id="$(gh_read api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+        --jq ".[]|select(.body|contains(\"${MARKER}\"))|.id" 2>/dev/null | tail -n1 || true)"
   if [ -n "$id" ]; then
     gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null 2>&1 || log "comment edit failed (non-fatal)"
   else
@@ -240,10 +257,26 @@ case "$CHECK_STATE" in
   EMPTY)   [ "$ALLOW_ZERO_CHECKS" = "true" ] || { DECISION_BODY="No status checks registered on the PR."; skip "zero-checks"; }; CHECK_STATE="GREEN" ;;
   FAIL)    DECISION_BODY="A required check failed."; skip "checks-fail" ;;
   PENDING)
-    if gh pr checks "$PR_NUMBER" --repo "$REPO" --watch --fail-fast >/dev/null 2>&1; then
-      CHECK_STATE="GREEN"
+    # L7/#213: bound the watch so a stuck/never-completing check can't hang the
+    # step until the workflow-level timeout. `timeout` exits 124 on deadline →
+    # treated as checks-not-green. Fall back to an unbounded watch only where
+    # coreutils `timeout` is unavailable (stock macOS); CI runners have it.
+    WATCH_TIMEOUT="${CHECKS_WATCH_TIMEOUT:-900}"
+    if command -v timeout >/dev/null 2>&1; then
+      watch_cmd=(timeout "$WATCH_TIMEOUT" gh pr checks "$PR_NUMBER" --repo "$REPO" --watch --fail-fast)
     else
-      DECISION_BODY="Checks did not go green (failed or timed out while watching)."
+      watch_cmd=(gh pr checks "$PR_NUMBER" --repo "$REPO" --watch --fail-fast)
+    fi
+    # `|| watch_rc=$?` keeps set -e from aborting on a non-zero (failed/timeout) watch.
+    watch_rc=0
+    "${watch_cmd[@]}" >/dev/null 2>&1 || watch_rc=$?
+    if [ "$watch_rc" -eq 0 ]; then
+      CHECK_STATE="GREEN"
+    elif [ "$watch_rc" -eq 124 ]; then
+      DECISION_BODY="Checks did not complete within ${WATCH_TIMEOUT}s while watching."
+      skip "checks-not-green"
+    else
+      DECISION_BODY="Checks did not go green (failed while watching)."
       skip "checks-not-green"
     fi ;;
 esac

--- a/tests/release-patch-merge.test.sh
+++ b/tests/release-patch-merge.test.sh
@@ -32,7 +32,7 @@ case "$sub" in
     if [ "$jf" = "headRefOid,state,labels,reviewDecision" ] && [ -n "${MOCK_RESNAP:-}" ]; then cat "$MOCK_RESNAP"; exit 0; fi
     if [ "$jf" = "statusCheckRollup" ] && [ -n "${MOCK_ROLLUP2:-}" ]; then cat "$MOCK_ROLLUP2"; exit 0; fi
     cat "$MOCK_SNAP"; exit 0 ;;
-  "pr checks") exit "${MOCK_WATCH_RC:-0}" ;;
+  "pr checks") [ -n "${MOCK_WATCH_SLEEP:-}" ] && sleep "$MOCK_WATCH_SLEEP"; exit "${MOCK_WATCH_RC:-0}" ;;
   "pr merge")
     if [ "${MOCK_REJECT_WRITES:-0}" = "1" ]; then echo "MOCK: merge rejected (dry-run must not merge)" >&2; exit 90; fi
     if [ -n "${MOCK_MERGE_ERR:-}" ]; then echo "$MOCK_MERGE_ERR" >&2; exit "${MOCK_MERGE_RC:-1}"; fi
@@ -41,8 +41,11 @@ case "$sub" in
     if [ "${MOCK_REJECT_WRITES:-0}" = "1" ]; then echo "MOCK: review rejected" >&2; exit 90; fi
     exit 0 ;;
   "api "*|"api")
-    ep="$2"
-    if [ "$ep" = "-X" ]; then exit 0; fi            # comment upsert (PATCH/POST) — allowed write
+    # Any `-X` (PATCH/POST) is an allowed mutation (comment upsert).
+    for a in "$@"; do [ "$a" = "-X" ] && exit 0; done
+    # Endpoint = first non-flag arg after `api` (robust to --paginate, --jq, …).
+    shift; ep=""
+    while [ $# -gt 0 ]; do case "$1" in -*) shift ;; *) ep="$1"; break ;; esac; done
     case "$ep" in
       */contents/*)
         ref="${ep##*ref=}"; path="${ep#*/contents/}"; path="${path%%\?*}"
@@ -254,7 +257,33 @@ E; run TOKEN_IS_APP=true DRY_RUN=false MOCK_COMMENT_ID=555 MOCK_SNAP="$MOCK_SNAP
 assert_rc0; assert_line "MERGED #42"
 echo "$TRACE" | grep -q 'api -X PATCH repos/Coalfire-CF/demo/issues/comments/555' || fail "${CASE}: expected a PATCH edit of comment 555 (not a re-post)"
 echo "$TRACE" | grep -q 'api -X POST repos/Coalfire-CF/demo/issues/42/comments' && fail "${CASE}: must NOT POST a new comment when one exists"
+# M6/#203: the marker lookup must paginate, or a PR with >30 comments never finds
+# the existing marker and the upsert degrades to append.
+echo "$TRACE" | grep -qE 'api --paginate .*issues/42/comments' || fail "${CASE}: comment lookup must use --paginate (#203)"
 echo "OK: ${CASE}"
+
+CASE="#214 permanent 404 is not retried (base-manifest read happens once)"
+E; run TOKEN_IS_APP=true DRY_RUN=false RETRY_MAX=3 MOCK_SNAP="$MOCK_SNAP" \
+  MOCK_MANIFEST_BASE="$WORK/nope-manifest.json" MOCK_MANIFEST_HEAD="$MOCK_MANIFEST_HEAD" \
+  MOCK_CL_BASE="$MOCK_CL_BASE" MOCK_CL_HEAD="$MOCK_CL_HEAD"
+assert_rc0; assert_line "SKIP #42 (missing-manifest)"; assert_nomerge
+n=$(echo "$TRACE" | grep -cE 'contents/.*manifest.*ref=basesha000')
+[ "$n" -eq 1 ] || fail "${CASE}: base-manifest 404 attempted ${n}× (expected 1 — a 404 is permanent, must not spin RETRY_MAX times)"
+echo "OK: ${CASE}"
+
+# L7/#213: bound the pending-checks watch so a stuck check can't hang the step.
+# Requires coreutils `timeout` (present on CI ubuntu; skipped where absent, e.g. stock macOS).
+if command -v timeout >/dev/null 2>&1; then
+  CASE="#213 watch times out → checks-not-green (bounded, no hang)"
+  E; s="$(snap '.statusCheckRollup=[{"status":"IN_PROGRESS","conclusion":null}]')"
+  run TOKEN_IS_APP=true DRY_RUN=false CHECKS_WATCH_TIMEOUT=1 MOCK_WATCH_SLEEP=8 MOCK_SNAP="$s" \
+    MOCK_MANIFEST_BASE="$MOCK_MANIFEST_BASE" MOCK_MANIFEST_HEAD="$MOCK_MANIFEST_HEAD" \
+    MOCK_CL_BASE="$MOCK_CL_BASE" MOCK_CL_HEAD="$MOCK_CL_HEAD"
+  assert_rc0; assert_line "SKIP #42 (checks-not-green)"; assert_nomerge
+  echo "OK: ${CASE}"
+else
+  echo "SKIP (no timeout(1) on this host): #213 watch-timeout case"
+fi
 
 CASE="missing-manifest (404 at base) → SKIP, no merge"
 E; run TOKEN_IS_APP=true DRY_RUN=false RETRY_MAX=1 MOCK_SNAP="$MOCK_SNAP" \


### PR DESCRIPTION
Batch E of the 2026-07-08 audit sweep — three correctness bugs in `scripts/release-patch-merge.sh`.

## Fixes
- **#203 (M6)** — marker-comment lookup now `--paginate`s (a PR with >30 comments no longer degrades the upsert to append).
- **#213 (L7)** — `gh pr checks --watch` is wrapped in `timeout` (`CHECKS_WATCH_TIMEOUT`, default 900s); a deadline (exit 124) → `checks-not-green`. Falls back to unbounded only where `timeout` is absent (CI has it).
- **#214 (L8)** — `_gh_once` classifies failures on stderr evidence: retry only 429/5xx/timeout/conn classes; a 404/4xx or unknown failure is permanent (no `RETRY_MAX` spin).

## Testing
Extended `tests/release-patch-merge.test.sh`: mock parses the endpoint past `--paginate` + simulates a hanging watch. New assertions — lookup uses `--paginate` (#203), a 404 is attempted once not `RETRY_MAX` times (#214), bounded watch → checks-not-green (#213, runs where `timeout` exists). RED→GREEN; `shellcheck scripts/*.sh` clean.

Closes #203
Closes #213
Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)