### PR TITLE
fix(reconcile): pr-green-merge compare-and-swap merge (M5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Issue labels:
     |       |-- pass_sha.yml
     |       |-- warn_tag.yml
     |-- gate-config-resolve.test.sh
+    |-- pr-green-merge.test.sh
     |-- prompt-build.test.sh
     |-- reconcile-sweeper.test.sh
     |-- release-patch-merge.test.sh

--- a/scripts/pr-green-merge.sh
+++ b/scripts/pr-green-merge.sh
@@ -101,6 +101,7 @@ log() { echo "[pr-green-merge] $*" >&2; }
 # success; on any failure logs the last stderr line (STDERR only) and returns
 # $RETRY_TRANSIENT_RC so with_retry treats a gh blip as transient (matches the
 # prior retry-any-failure behavior).
+# shellcheck disable=SC2317,SC2329  # invoked indirectly via `with_retry -- _gh_read_once` (SC2317/SC2329 are the version-dependent codes for the same "unreachable/unused function" false positive)
 _gh_read_once() {
   local out errf
   errf="$(mktemp)"
@@ -228,6 +229,24 @@ fi
 
 # Merge via the REST endpoint (see MERGE MECHANISM in the header): `gh pr merge`
 # refuses a BLOCKED PR and does not exercise ruleset bypass; PUT .../merge does.
-log "MERGE #${PR_NUMBER} (checks GREEN${BYPASS_NOTE}) via REST --${MERGE_METHOD}"
-gh api --method PUT "repos/${REPO}/pulls/${PR_NUMBER}/merge" -f "merge_method=${MERGE_METHOD}" >/dev/null
-echo "MERGED #${PR_NUMBER}"
+# M5/#202: compare-and-swap on the head SHA pinned at green-gate time. The REST
+# endpoint's `sha` requires the PR head to still match at merge time; if a commit
+# was pushed (or the head otherwise moved) between our classification and now,
+# GitHub returns 409 and refuses — so we can never merge unreviewed/unchecked code
+# that landed after the gate. A 409 is a benign race → clean SKIP, not an error.
+log "MERGE #${PR_NUMBER} (checks GREEN${BYPASS_NOTE}) via REST --${MERGE_METHOD}, CAS sha=${HEAD_SHA}"
+MERGE_ERR="$(mktemp)"
+if gh api --method PUT "repos/${REPO}/pulls/${PR_NUMBER}/merge" \
+     -f "merge_method=${MERGE_METHOD}" -f "sha=${HEAD_SHA}" >/dev/null 2>"$MERGE_ERR"; then
+  rm -f "$MERGE_ERR"
+  echo "MERGED #${PR_NUMBER}"
+  exit 0
+fi
+ERRTXT="$(cat "$MERGE_ERR" 2>/dev/null)"; rm -f "$MERGE_ERR"
+if printf '%s' "$ERRTXT" | grep -qiE '409|Head branch was modified|did not match|Conflict'; then
+  log "SKIP #${PR_NUMBER} (head moved after green-gate; CAS sha=${HEAD_SHA} rejected): ${ERRTXT}"
+  echo "SKIP #${PR_NUMBER} (head-moved)"
+  exit 0
+fi
+log "MERGE FAILED #${PR_NUMBER}: ${ERRTXT}"
+exit 1

--- a/tests/pr-green-merge.test.sh
+++ b/tests/pr-green-merge.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Meta-test for scripts/pr-green-merge.sh (grade-A #14). A mock `gh` shim records
+# every invocation and serves PR snapshot + check-runs fixtures, so the full
+# green-gate + merge path runs offline. Focus of this suite (M5/#202): the merge
+# is a compare-and-swap — the REST merge carries `sha=$HEAD_SHA` (head pinned at
+# green-gate time), and a 409 (head moved) is a clean SKIP, never a merge of
+# newer/unreviewed code.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/pr-green-merge.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$SCRIPT" ] || fail "pr-green-merge.sh not found at $SCRIPT"
+[ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"; mkdir -p "$BIN"
+HEAD_SHA="headsha111"
+
+# ---- mock gh: pr view (snapshot) + api (check-runs GET / merge PUT) + argv trace ----
+cat > "$BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_TRACE"
+sub="$1 ${2:-}"
+case "$sub" in
+  "pr view") cat "$MOCK_PRJSON"; exit 0 ;;
+  "api "*|"api")
+    # A merge is `gh api --method PUT .../merge …`; anything else is the read.
+    for a in "$@"; do
+      if [ "$a" = "PUT" ]; then
+        if [ -n "${MOCK_MERGE_ERR:-}" ]; then echo "$MOCK_MERGE_ERR" >&2; exit 1; fi
+        exit 0
+      fi
+    done
+    cat "$MOCK_CHECKS"; exit 0 ;;
+esac
+exit 0
+MOCK
+chmod +x "$BIN/gh"
+
+# Fixtures.
+GREEN_CHECKS="$WORK/checks.green.json"
+printf '%s' '{"check_runs":[{"name":"CI / build","status":"completed","conclusion":"SUCCESS"}]}' > "$GREEN_CHECKS"
+FAIL_CHECKS="$WORK/checks.fail.json"
+printf '%s' '{"check_runs":[{"name":"CI / build","status":"completed","conclusion":"FAILURE"}]}' > "$FAIL_CHECKS"
+
+prjson() { # <author-login> -> path (state OPEN, not draft, review null, head pinned)
+  local out="$WORK/pr.$RANDOM.json"
+  printf '{"state":"OPEN","isDraft":false,"author":{"login":"%s"},"reviewDecision":"","headRefOid":"%s"}' \
+    "$1" "$HEAD_SHA" > "$out"; echo "$out"
+}
+
+OUT=""; RC=0; TRACE=""
+run() {
+  : > "$WORK/trace"
+  set +e
+  OUT="$(env "PATH=$BIN:$PATH" "GH_TRACE=$WORK/trace" \
+    REPO="Coalfire-CF/demo" PR_NUMBER=7 MERGE_METHOD=squash RETRY_MAX=1 \
+    "$@" bash "$SCRIPT" 2>/dev/null)"
+  RC=$?
+  set -e
+  TRACE="$(cat "$WORK/trace")"
+}
+assert_line() { echo "$OUT" | grep -qF "$1" || fail "${CASE}: expected '$1', got '$OUT'"; }
+assert_rc0()  { [ "$RC" -eq 0 ] || fail "${CASE}: expected rc 0, got $RC (out: $OUT)"; }
+assert_nomerge() { echo "$TRACE" | grep -qE 'api --method PUT' && fail "${CASE}: a merge PUT was issued but must not be"; return 0; }
+
+# ---- happy dry-run → WOULD-MERGE, zero mutations ----
+CASE="happy dry-run → WOULD-MERGE (no PUT)"
+run TOKEN=x MOCK_PRJSON="$(prjson 'app/dependabot')" MOCK_CHECKS="$GREEN_CHECKS"
+assert_rc0; assert_line "WOULD-MERGE #7"; assert_nomerge
+echo "OK: ${CASE}"
+
+# ---- live happy → MERGED, and the PUT carries sha=$HEAD_SHA (M5/#202 CAS) ----
+CASE="live happy → MERGED with compare-and-swap sha"
+run DRY_RUN=false MOCK_PRJSON="$(prjson 'app/dependabot')" MOCK_CHECKS="$GREEN_CHECKS"
+assert_rc0; assert_line "MERGED #7"
+echo "$TRACE" | grep -qE 'api --method PUT .*pulls/7/merge' || fail "${CASE}: merge must go via REST PUT .../pulls/7/merge"
+echo "$TRACE" | grep -q "sha=${HEAD_SHA}" || fail "${CASE}: merge must pin the head via sha=${HEAD_SHA} (CAS, #202)"
+echo "OK: ${CASE}"
+
+# ---- CAS mismatch: head moved between gate and merge (409) → SKIP head-moved ----
+CASE="409 head-moved → SKIP (never merges newer code)"
+run DRY_RUN=false MOCK_MERGE_ERR="HTTP 409: Head branch was modified. Review and try the merge again." \
+  MOCK_PRJSON="$(prjson 'app/dependabot')" MOCK_CHECKS="$GREEN_CHECKS"
+assert_rc0; assert_line "SKIP #7 (head-moved)"
+echo "OK: ${CASE}"
+
+# ---- failing checks → SKIP, no merge ----
+CASE="red checks → SKIP checks-FAIL"
+run DRY_RUN=false MOCK_PRJSON="$(prjson 'app/dependabot')" MOCK_CHECKS="$FAIL_CHECKS"
+assert_rc0; assert_line "SKIP #7 (checks-FAIL)"; assert_nomerge
+echo "OK: ${CASE}"
+
+# ---- untrusted author → SKIP, no merge ----
+CASE="author not allowlisted → SKIP"
+run DRY_RUN=false MOCK_PRJSON="$(prjson 'mallory')" MOCK_CHECKS="$GREEN_CHECKS"
+assert_rc0; assert_line "SKIP #7 (author-not-allowlisted)"; assert_nomerge
+echo "OK: ${CASE}"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Batch F of the 2026-07-08 audit sweep.

## Fix (#202, M5)
`pr-green-merge.sh` green-gated then merged the current head with no head pin — a commit or a check turning red between the read and the merge could land unreviewed/failing code (TOCTOU). Now passes `sha=$HEAD_SHA` to the REST merge endpoint; GitHub enforces it atomically (409 on mismatch) — a true compare-and-swap. A 409 is a benign race → clean `SKIP (head-moved)`.

## Testing
Adds `tests/pr-green-merge.test.sh` (the script previously had **no** tests). Mock `gh` drives the gate + merge offline: asserts the PUT carries `sha=$HEAD_SHA`, a 409 → SKIP head-moved, red-checks / untrusted-author → SKIP with no PUT, plus dry-run/live happy paths. RED→GREEN; `shellcheck scripts/*.sh` clean.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)