### PR TITLE
fix(config): npm dependabot ecosystem, renovate key, glob-safe allowlists (M7/L18/L6)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,15 @@ updates:
         patterns: ["*"]
         exclude-patterns: ["Coalfire-CF/*"]
         update-types: ["minor", "patch"]
+  # npm (#204): this repo ships package.json + package-lock.json (markdownlint-cli2),
+  # which org-dependabot.yml maps to the npm ecosystem — so the dogfood must declare
+  # it too, or advisories against the pinned tree open no bump PRs. The generator
+  # emits groups only for github-actions (the Coalfire-CF/* first-party split does
+  # not apply to npm), so npm is a plain block; majors arrive as singleton PRs.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/renovate/terraform-ref-pins.json5
+++ b/renovate/terraform-ref-pins.json5
@@ -18,7 +18,9 @@
     {
       "customType": "regex",
       "description": "Coalfire-CF git-module sources pinned as ?ref=<sha> # vX.Y.Z (source-pin PASS shape)",
-      "fileMatch": ["\\.tf$"],
+      // #224: use managerFilePatterns (the current key) rather than the deprecated
+      // alias; a /regex/-wrapped value preserves the prior regex-match semantics.
+      "managerFilePatterns": ["/\\.tf$/"],
       "matchStrings": [
         "(?<host>git::https://github\\.com/|github\\.com/)(?<depName>Coalfire-CF/[A-Za-z0-9._-]+?)(?<gitsuffix>\\.git)?(?<subdir>//[^\"?]*)?\\?ref=(?<currentDigest>[a-fA-F0-9]{40})\"(?<sp>[ \\t]*)#[ \\t]*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],

--- a/scripts/pr-green-merge.sh
+++ b/scripts/pr-green-merge.sh
@@ -154,7 +154,12 @@ fi
 # "triager labels an arbitrary PR into a live merge" vector on repos without
 # required status checks.
 author_ok=false
-for a in $AUTHOR_ALLOWLIST; do
+# L6/#212: read into an array (word-split, NO pathname expansion). An unquoted
+# `for a in $AUTHOR_ALLOWLIST` globs — and `dependabot[bot]` is a valid glob
+# ([bot] is a char class), so a matching file in CWD would corrupt the token and
+# make a trusted author wrongly fail the allowlist.
+read -ra _allow <<< "$AUTHOR_ALLOWLIST"
+for a in "${_allow[@]}"; do
   [ "$AUTHOR" = "$a" ] && { author_ok=true; break; }
 done
 if [ "$author_ok" != "true" ]; then

--- a/scripts/release-patch-merge.sh
+++ b/scripts/release-patch-merge.sh
@@ -174,14 +174,19 @@ printf '%s' "$SNAP" | jq -e '.labels[]?|select(.name=="autorelease: pending")' >
 
 # ================= GATE 7 — author allowlist =================
 author_ok=false
-for a in $AUTHOR_ALLOWLIST; do [ "$AUTHOR" = "$a" ] && { author_ok=true; break; }; done
+# L6/#212: array read (word-split, NO globbing) — `coalfire-release[bot]` is a
+# valid glob, so an unquoted expansion could match a CWD file and corrupt the token.
+read -ra _authors <<< "$AUTHOR_ALLOWLIST"
+for a in "${_authors[@]}"; do [ "$AUTHOR" = "$a" ] && { author_ok=true; break; }; done
 [ "$author_ok" = "true" ] || { DECISION_BODY="Author '${AUTHOR}' not in allowlist."; skip "author-not-allowlisted"; }
 
 # ================= GATE 8 — changed files ⊆ allowlist =================
+# L6/#212: array read (word-split, no globbing) for the file allowlist too.
+read -ra _allow_files <<< "$RELEASE_FILE_ALLOWLIST"
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   ok=false
-  for a in $RELEASE_FILE_ALLOWLIST; do [ "$f" = "$a" ] && { ok=true; break; }; done
+  for a in "${_allow_files[@]}"; do [ "$f" = "$a" ] && { ok=true; break; }; done
   [ "$ok" = "true" ] || { DECISION_BODY="Changed file outside the release allowlist: \`${f}\`."; skip "unexpected-file"; }
 done < <(printf '%s' "$SNAP" | jq -r '.files[].path')
 

--- a/tests/pr-green-merge.test.sh
+++ b/tests/pr-green-merge.test.sh
@@ -102,4 +102,19 @@ run DRY_RUN=false MOCK_PRJSON="$(prjson 'mallory')" MOCK_CHECKS="$GREEN_CHECKS"
 assert_rc0; assert_line "SKIP #7 (author-not-allowlisted)"; assert_nomerge
 echo "OK: ${CASE}"
 
+# ---- L6/#212: `dependabot[bot]` is a valid glob ([bot] = char class). With a
+# matching file in CWD, an unquoted `for a in $AUTHOR_ALLOWLIST` would expand the
+# allowlist token against it and corrupt the match → a trusted author wrongly SKIPs.
+CASE="#212 author allowlist is glob-safe (CWD decoy does not corrupt match)"
+gdir="$WORK/globtest"; mkdir -p "$gdir"; : > "$gdir/dependabott"   # matches dependabot[bot]
+prj="$(prjson 'dependabot[bot]')"
+( cd "$gdir"
+  env "PATH=$BIN:$PATH" "GH_TRACE=$WORK/trace212" \
+    REPO="Coalfire-CF/demo" PR_NUMBER=7 MERGE_METHOD=squash RETRY_MAX=1 DRY_RUN=false \
+    MOCK_PRJSON="$prj" MOCK_CHECKS="$GREEN_CHECKS" bash "$SCRIPT" > "$WORK/out212" 2>/dev/null
+)
+grep -qF "MERGED #7" "$WORK/out212" \
+  || fail "${CASE}: dependabot[bot] author must still MERGE despite a CWD glob-decoy, got: $(cat "$WORK/out212")"
+echo "OK: ${CASE}"
+
 echo "ALL TESTS PASSED"

--- a/tests/release-patch-merge.test.sh
+++ b/tests/release-patch-merge.test.sh
@@ -169,6 +169,22 @@ run TOKEN_IS_APP=true DRY_RUN=false MOCK_SNAP="$s"
 assert_rc0; assert_line "SKIP #42 (author-not-allowlisted)"; assert_nomerge
 echo "OK: ${CASE}"
 
+CASE="#212 author allowlist is glob-safe (CWD decoy does not corrupt match)"
+E; s="$(snap '.author.login="coalfire-release[bot]"')"
+gdir="$WORK/globtest"; mkdir -p "$gdir"; : > "$gdir/coalfire-releaseb"   # matches coalfire-release[bot]
+( cd "$gdir"
+  env "PATH=$BIN:$PATH" "GH_TRACE=$WORK/trace212" \
+    REPO="Coalfire-CF/demo" PR_NUMBER=42 MERGE_METHOD=squash RETRY_MAX=1 \
+    CHECKS_GRACE_TRIES=2 CHECKS_GRACE_SLEEP=0 "MOCK_BASE_SHA=$BASE_SHA" \
+    TOKEN_IS_APP=true DRY_RUN=false MOCK_SNAP="$s" \
+    MOCK_MANIFEST_BASE="$MOCK_MANIFEST_BASE" MOCK_MANIFEST_HEAD="$MOCK_MANIFEST_HEAD" \
+    MOCK_CL_BASE="$MOCK_CL_BASE" MOCK_CL_HEAD="$MOCK_CL_HEAD" \
+    bash "$SCRIPT" > "$WORK/out212" 2>/dev/null
+)
+grep -qF "MERGED #42" "$WORK/out212" \
+  || fail "${CASE}: coalfire-release[bot] author must still MERGE despite a CWD glob-decoy, got: $(cat "$WORK/out212")"
+echo "OK: ${CASE}"
+
 CASE="first-release (new package key in manifest)"
 E; mb="$WORK/f.base"; mh="$WORK/f.head"; printf '{".":"1.2.3"}' >"$mb"; printf '{".":"1.2.4","pkg/new":"0.1.0"}' >"$mh"
 run TOKEN_IS_APP=true DRY_RUN=false MOCK_SNAP="$MOCK_SNAP" MOCK_MANIFEST_BASE="$mb" MOCK_MANIFEST_HEAD="$mh" MOCK_CL_BASE="$MOCK_CL_BASE" MOCK_CL_HEAD="$MOCK_CL_HEAD"


### PR DESCRIPTION
Batch G of the 2026-07-08 audit sweep.

## Fixes
- **#204 (M7)** — `.github/dependabot.yml` now declares the **npm** ecosystem (the repo ships `package.json`/`package-lock.json`; the generator maps it to npm). npm advisories now open bump PRs.
- **#224 (L18)** — `renovate/terraform-ref-pins.json5`: `fileMatch` → `managerFilePatterns` (current key), value wrapped in `/…/` to keep regex semantics.
- **#212 (L6)** — author/file allowlists read into bash arrays (word-split, no globbing); `dependabot[bot]`/`coalfire-release[bot]` are valid globs so an unquoted loop could corrupt the token against a CWD file. Fixed in `pr-green-merge.sh` + `release-patch-merge.sh`.

## Testing
Glob-decoy cases added to both test files (a matching CWD file must not break the allowlist match) — RED→GREEN. `shellcheck scripts/*.sh` clean; `dependabot.yml` validated (github-actions + npm).

Closes #204
Closes #224
Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)