### PR TITLE
fix(gitleaks): fail-closed outputs on error + sudo install (L4/L5)

### DIFF
--- a/actions/gitleaks/action.yml
+++ b/actions/gitleaks/action.yml
@@ -59,7 +59,10 @@ runs:
         curl -sSfL -o "${TARBALL}" \
           "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
         echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum -c -
-        tar -xzf "${TARBALL}" -C /usr/local/bin gitleaks
+        # L5/#211: sudo the extract — /usr/local/bin is not writable by the runner
+        # user on hardened/self-hosted runners (EACCES). Matches test-scripts.yml's
+        # actionlint install (sudo tar … -C /usr/local/bin).
+        sudo tar -xzf "${TARBALL}" -C /usr/local/bin gitleaks
         rm -f "${TARBALL}"
         echo "Installed gitleaks $(gitleaks version)"
 
@@ -112,6 +115,11 @@ runs:
           echo "finding-count=${FINDING_COUNT}" >> "$GITHUB_OUTPUT"
           echo "::warning::${FINDING_COUNT} potential secret(s) detected"
         else
+          # L4/#210: write defined, fail-closed outputs on the error path so a
+          # consumer reading outputs.passed after continue-on-error sees "false"
+          # (not an empty string) and finding-count a sentinel, not unset.
+          echo "passed=false" >> "$GITHUB_OUTPUT"
+          echo "finding-count=-1" >> "$GITHUB_OUTPUT"
           echo "::error::Gitleaks encountered an unexpected error (exit code: ${GITLEAKS_EXIT})"
           exit "$GITLEAKS_EXIT"
         fi


### PR DESCRIPTION
Batch H of the 2026-07-08 audit sweep — `actions/gitleaks/action.yml`.

## Fixes
- **#210 (L4)** — the scan step's error branch exited without setting `passed`/`finding-count`; a consumer reading `outputs.passed` after `continue-on-error` got an empty string, so `== 'false'` wouldn't fire on a scanner error. Now writes `passed=false` + `finding-count=-1` (sentinel) before exiting.
- **#211 (L5)** — install extracted to `/usr/local/bin` without `sudo` (EACCES on hardened/self-hosted runners). Now `sudo tar … -C /usr/local/bin`, matching `test-scripts.yml`.

YAML validated; changes are trivial embedded-bash additions. (actionlint mis-parses composite actions as workflows, so it isn't the right linter here.)

Closes #210
Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)