### PR TITLE
fix(ci): workflow hygiene — notify coverage, event guard, perms, dead code (L9/L10/L16/L17)

### DIFF
--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Parse dependency details
         id: parse
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          # #223: removed unused PR_TITLE env (no run: script referenced it).
           META_DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
           META_PREV_VER: ${{ steps.metadata.outputs.previous-version }}
           META_NEW_VER: ${{ steps.metadata.outputs.new-version }}
@@ -210,7 +210,7 @@ jobs:
         env:
           ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
           DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          # #223: removed unused PR_TITLE env (no run: script referenced it).
           FIRST_PARTY_PREFIX: ${{ inputs.first_party_prefix }}
         run: |
           set -euo pipefail

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -43,8 +43,9 @@ on:
         required: false
 
 permissions:
+  # #222: this generator commits + pushes the generated dependabot.yml (needs
+  # contents:write) but makes no PR-API calls — drop the unused pull-requests grant.
   contents: write
-  pull-requests: write
 
 jobs:
   sync:

--- a/.github/workflows/org-jira-sync.yml
+++ b/.github/workflows/org-jira-sync.yml
@@ -94,12 +94,9 @@ jobs:
         # Set API version (default to 3 for Cloud, can be overridden to 2 for older instances)
         API_VERSION="${JIRA_API_VERSION:-3}"
 
-        # Prepare the issue description with link back to GitHub
-        ISSUE_BODY=$(cat <<'EOF'
-        ${ISSUE_BODY_INPUT}
-        EOF
-        )
-        # Substitute the actual value via envsubst-free approach
+        # Prepare the issue description, appending a link back to the GitHub issue.
+        # (#223: removed a dead `${ISSUE_BODY_INPUT}` heredoc — wrong var name,
+        # never substituted, immediately overwritten by the line below.)
         ISSUE_BODY="${INPUT_ISSUE_BODY}
 
         ---

--- a/.github/workflows/org-markdown-lint.yml
+++ b/.github/workflows/org-markdown-lint.yml
@@ -108,7 +108,9 @@ jobs:
 
     - name: Create Fail Comment
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-      if: failure()
+      # #216: guard on pull_request — on a non-PR trigger context.issue.number is
+      # undefined and github.rest.issues.createComment throws.
+      if: failure() && github.event_name == 'pull_request'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -345,7 +345,9 @@ jobs:
 
   notify-failure:
     name: Slack Failure Notification
-    needs: [release, release-clean, trivy-scan, gitleaks-scan]
+    # #215: include auto-merge-patch + notify-release so a failure in either is
+    # covered by the failure() Slack alert below (previously omitted).
+    needs: [release, release-clean, trivy-scan, gitleaks-scan, auto-merge-patch, notify-release]
     if: failure() && inputs.slack_channel_id != ''
     uses: ./.github/workflows/org-slack-notify.yml
     secrets:

--- a/scripts/breaking-change-check.sh
+++ b/scripts/breaking-change-check.sh
@@ -299,10 +299,6 @@ if [ "$SHARED_CACHE_HIT" = "false" ]; then
     AI_RESPONSE='{"output":{"message":{"content":[{"text":"{\"breaking\":false,\"confidence\":0,\"risks\":[\"API call failed\"],\"summary\":\"Analysis errored — routed to manual review\"}"}]}}}'
   fi
 
-  if [ -s /tmp/bedrock_err.log ]; then
-    echo "Bedrock stderr: $(cat /tmp/bedrock_err.log)"
-  fi
-
   # Parse the Bedrock Converse response
   AI_TEXT=$(echo "$AI_RESPONSE" | jq -r '.output.message.content[0].text // "{}"')
   # Strip markdown fences if present, then validate JSON


### PR DESCRIPTION
Batch I of the 2026-07-08 audit sweep.

## Fixes
- **#215 (L9)** — `org-release` `notify-failure` now `needs:` `auto-merge-patch` + `notify-release`, so a failure there fires the Slack alert.
- **#216 (L10)** — `org-markdown-lint` fail-comment guarded with `github.event_name == 'pull_request'` (avoids a throw on non-PR triggers).
- **#222 (L16)** — dropped unused `pull-requests: write` from `org-dependabot.yml`. (The `org-terraform-fmt` `contents: write` half was already removed in the #198/M1 fix.)
- **#223 (L17)** — removed three dead spots: `/tmp/bedrock_err.log` surface (breaking-change-check.sh), the never-substituted `ISSUE_BODY` heredoc (org-jira-sync.yml), and the unused `PR_TITLE` env (org-dependabot-auto-merge.yml, 2 steps).

actionlint clean at CI gate; `shellcheck scripts/*.sh` clean; cache-integrity suite green.

Closes #215
Closes #216
Closes #222
Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)