### PR TITLE
fix(docs/ci): tree-readme quote-strip, risk-label matrix, current example pins (L2/L14/L15)

### DIFF
--- a/.github/workflows/org-tree-readme.yml
+++ b/.github/workflows/org-tree-readme.yml
@@ -107,6 +107,10 @@ jobs:
                 inList && /^[[:space:]]*-/ {
                   gsub(/^[[:space:]]*-[[:space:]]*/, "", $0);
                   gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0);
+                  # #208: strip surrounding quotes so a quoted include (e.g. - "modules")
+                  # yields modules, not the literal "modules" (which fails the -e test
+                  # and is silently skipped, falling back to repo root).
+                  gsub(/^["'\'']|["'\'']$/, "", $0);
                   print $0; next
                 }
                 inList && !/^[[:space:]]*-/ {inList=0}

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ permissions:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     secrets: inherit
     with:
       slack_channel_id: 'C0123456789'
@@ -108,7 +108,7 @@ Access to private Terraform module repositories is controlled using a GitHub App
 # Private repo — pass app credentials for module access
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
     secrets:
@@ -118,7 +118,7 @@ jobs:
 # Public repo — no app credentials needed
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
 ```
@@ -138,7 +138,7 @@ Wrapper around [terraform-docs GitHub Actions](https://github.com/terraform-docs
 # Root module and submodules
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       recursive: true
 ```

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Issue labels:
     |-- auto-merge-decide.test.sh
     |-- cache-integrity.test.sh
     |-- cache-read.test.sh
+    |-- example-pin-check.test.sh
     |-- fixtures
     |   |-- auto-merge-decide
     |   |   |-- first_party_waiver.env

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -224,7 +224,7 @@ Run the label sync workflow on each repo before enabling auto-merge:
 ```yaml
 jobs:
   sync-labels:
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     secrets: inherit
 ```
 
@@ -251,7 +251,7 @@ jobs:
     if: >-
       github.event_name == 'check_suite' ||
       github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     secrets: inherit
 ```
 
@@ -283,9 +283,9 @@ pass `actions_ref`:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
-      actions_ref: 72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+      actions_ref: 0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     secrets: inherit
 ```
 
@@ -317,7 +317,8 @@ jobs:
 | Condition | Decision | Labels Applied |
 |-----------|----------|---------------|
 | Terraform module/provider | Skip | `merge/skipped`, `blocked/terraform-no-tests` |
-| All checks green (patch/minor, no vulns, good scorecard, no breaking changes) | Approve + auto-merge | `merge/approved`, `risk/low` |
+| All checks green — **patch** (no vulns, good scorecard, no breaking changes) | Approve + auto-merge | `merge/approved`, `risk/low` |
+| All checks green — **minor** (no vulns, good scorecard, no breaking changes) | Approve + auto-merge | `merge/approved`, `risk/medium` |
 | Known vulnerability | Block | `merge/blocked`, `risk/high`, `blocked/known-vuln` |
 | Low scorecard | Block | `merge/blocked`, `risk/high`, `blocked/low-scorecard` |
 | Major version bump | Block | `merge/blocked`, `risk/high`, `blocked/major-bump` |

--- a/tests/example-pin-check.test.sh
+++ b/tests/example-pin-check.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Guard for the copy-paste caller examples (#221). The README/docs pin
+# Coalfire-CF/Actions reusable workflows by SHA with a `# vX.Y.Z` tag comment;
+# that comment is fleet-wide onboarding guidance and silently drifts every
+# release. This test fails when any example's tag comment does not match the
+# current release in .release-please-manifest.json, so a release that forgets to
+# refresh the examples is caught in CI rather than shipping N releases behind.
+#
+# NOTE: this checks the `# vX.Y.Z` comment (the visible-drift symptom). The 40-hex
+# SHA must be refreshed to the new release tag's commit by hand alongside it — a
+# release cannot know its own tag SHA at release-PR time, so it cannot be
+# auto-bumped without introducing a SHA/tag mismatch.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+
+VER="$(jq -r '."."' "${REPO_ROOT}/.release-please-manifest.json" 2>/dev/null)"
+[ -n "$VER" ] && [ "$VER" != "null" ] || fail "could not read version from .release-please-manifest.json"
+WANT="v${VER}"
+
+FILES=(README.md docs/ORG_DEPENDABOT_AUTO_MERGE.md)
+# Lines that pin an Actions reusable workflow (or actions_ref) with a version tag comment.
+PIN_RE='(/Actions/\.github/workflows/[^@]*@[0-9a-fA-F]{40}|actions_ref:[[:space:]]*[0-9a-fA-F]{40})[[:space:]]*#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+'
+
+bad=0
+checked=0
+for f in "${FILES[@]}"; do
+  [ -f "${REPO_ROOT}/${f}" ] || continue
+  while IFS= read -r line; do
+    tag="$(printf '%s' "$line" | sed -nE 's/.*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+    [ -n "$tag" ] || continue
+    checked=$((checked + 1))
+    if [ "$tag" != "$WANT" ]; then
+      echo "  ${f}: example pins ${tag}, expected ${WANT} -> ${line}"
+      bad=1
+    fi
+  done < <(grep -hoE "$PIN_RE" "${REPO_ROOT}/${f}" 2>/dev/null || true)
+done
+
+[ "$checked" -gt 0 ] || fail "no example pins found — did the pin format change? (loosen PIN_RE)"
+[ "$bad" -eq 0 ] || fail "example pin(s) out of date vs manifest ${WANT} — refresh the README/docs caller examples on release (#221)"
+echo "OK: all ${checked} example pin(s) advertise ${WANT}"
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
Batch J (final) of the 2026-07-08 audit sweep.

## Fixes
- **#208 (L2)** — the `org-tree-readme` include parser now strips surrounding quotes (a quoted non-root include like `- "modules"` was silently skipped, falling back to repo root). Verified: `"modules"`→`modules`, `'.'`→`.`, `plain`→`plain`.
- **#220 (L14)** — reconciled the auto-merge decision-matrix doc with the code: approved **patch** → `risk/low`, **minor** → `risk/medium` (the code's intent).
- **#221 (L15)** — bumped the 8 stale caller-example pins from `v0.10.0` to the current `0324cf8… # v0.15.0`, and added `tests/example-pin-check.test.sh` — a CI guard that fails when an example's `# vX.Y.Z` drifts from the manifest, so future staleness is caught (the SHA is refreshed by hand alongside, since a release can't know its own tag SHA at PR time).

Full suite green; shellcheck + actionlint clean. (`tree-readme-section` is a pre-existing macOS-only artifact — my change touches the include parser, not the updater it extracts; passes on CI.)

Closes #208
Closes #220
Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)