### PR TITLE
fix(terraform-validate): add working_directory input (directory-targeting fail-open)

### DIFF
--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ''
         type: string
+      working_directory:
+        description: 'Directory in the caller repo to validate. Default "." preserves the previous root-only behaviour. A repo with no root module (modules/*, examples/*) MUST set this — or matrix over it — or the gate validates an empty directory and passes having examined nothing.'
+        required: false
+        type: string
+        default: '.'
       slack_channel_id:
         description: 'Slack channel ID for failure notifications (optional)'
         required: false
@@ -31,6 +36,11 @@ on:
         required: false
         default: ''
         type: string
+      working_directory:
+        description: 'Directory in the caller repo to validate'
+        required: false
+        type: string
+        default: '.'
 
 permissions:
   contents: read
@@ -103,10 +113,17 @@ jobs:
         git config --global url."https://actions:${APP_TOKEN}@github.com/".insteadOf ssh://git@github.com/
         
     - name: Initialise with no backend
-      run: terraform init -backend=false
+      env:
+        # Default "." is the previous behaviour. A repo with no root module must
+        # set working_directory (or matrix over it), else init/validate run in an
+        # empty directory and pass having examined nothing.
+        WORKDIR: ${{ inputs.working_directory || '.' }}
+      run: terraform -chdir="$WORKDIR" init -backend=false
 
     - name: Validate Terraform
       id: validate
+      env:
+        WORKDIR: ${{ inputs.working_directory || '.' }}
       run: |
         # H4/#197: capture stderr (validate writes diagnostics there) AND preserve
         # terraform's exit code, then re-fail on it. Previously $() captured only
@@ -114,7 +131,7 @@ jobs:
         # continue-on-error and no later re-check — so invalid Terraform passed
         # green with an empty comment. Mirrors the org-terraform-plan.yml idiom.
         set +e
-        terraform validate 2>&1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" | tee "$GITHUB_WORKSPACE/validate_output.txt"
+        terraform -chdir="$WORKDIR" validate 2>&1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" | tee "$GITHUB_WORKSPACE/validate_output.txt"
         RC=${PIPESTATUS[0]}
         set -e
         exit "$RC"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Called by downstream repos on pull requests.
 |----------|------|-------------|
 | Trivy PR | `org-trivy-pr.yml` | Security scanning of changed Terraform files |
 | Gitleaks | `org-gitleaks-pr.yml` | Secret detection on PR commits |
-| Terraform Validate | `org-terraform-validate.yml` | `terraform init` + `terraform validate` with PR comment |
+| Terraform Validate | `org-terraform-validate.yml` | `terraform init` + `terraform validate` with PR comment. Takes `working_directory` (default `.`) — **repos with no root module must set or matrix it**, or the gate validates an empty directory |
 | Terraform fmt | `org-terraform-fmt.yml` | Format check and auto-fix for Terraform files |
 | Terraform Docs | `org-terraform-docs.yml` | Auto-generate and commit terraform-docs output (check-only on Dependabot PRs — read-only token can't push; drift surfaced as a warning, [#149](https://github.com/Coalfire-CF/Actions/issues/149)) |
 | Terraform Plan | `org-terraform-plan.yml` | Terraform plan with PR comment |


### PR DESCRIPTION
Adds a `working_directory` input to `org-terraform-validate.yml` and threads it through `terraform -chdir` on both init and validate.

## Why

The workflow only ever ran `init`/`validate` in the **repository root**, so a repo with no root module validated an *empty directory* and reported success having examined nothing:

```
Terraform initialized in an empty directory!
Success! The configuration is valid.
```

Found live in `terraform-aws-burpsuite` (modules-only — `modules/pro/linux` couldn't even plan while this gate stayed green) and `terraform-aws-gitlab` (also 0 root `.tf`). Repos with no root module set `working_directory`, or matrix over their module/example dirs.

`working_directory` defaults to `.`, so **behaviour is byte-identical for every existing caller**.

## Scope — this is intentionally minimal

This PR is **only** the directory-targeting fix. It does **not** touch the "validate can never fail" fail-open (discarded exit code + `continue-on-error`) — that was already fixed on `main` by **#259 / `764a9f5`** (issue **H4/#197**) and ships *enforcing*. This change layers on top and **preserves that enforcement** (`exit "$RC"` unchanged).

> An earlier revision of this PR also wrapped the exit code in the RFC-0010 advisory `gate-config.yml` mechanism (advisory-by-default). **That was dropped** — it re-litigated #259's deliberate decision to *enforce*. If softening enforcement to advisory-first is wanted, it belongs in a separate change against the #259 rollout, not bundled with a directory-targeting fix.

Related: **#259's enforce fix is on `main` but unreleased** (v0.15.0 predates it), so all callers still run the fail-open version. Cutting an Actions release ships both #259's enforcement and this `working_directory` input together.

(Branch name still says `...-and-strict-gate` from the earlier revision; the strict-gate content is gone.)

## Verification

- `working_directory` present on `workflow_call` + `workflow_dispatch`, default `.`
- `WORKDIR` env (never string-interpolated) on both init and validate; `-chdir="$WORKDIR"` on both
- enforce preserved: `exit "$RC"` unconditional
- no strict-gate residue: `gate-config.yml`, the resolver, docs, and tests are untouched (diff is the workflow + one README line)
- YAML parses

## Checklist

- [x] **fix:** Resolves a bug or unintended behavior.
- [x] **I used AI assistance** (Claude Code / Opus 4.8) — found the fail-open, wrote the minimal change, verified scope.

Testing: local YAML-parse + structural assertions (inputs, WORKDIR wiring, enforce preserved, zero strict-gate residue). Not yet run in CI on this revision — will confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
