### PR TITLE
feat(org-terratest): security hardening, teardown net, telemetry, flake strategy (#231 #235 #236 #237 #273)

### DIFF
--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -51,6 +51,17 @@ on:
         required: false
         default: 60
         type: number
+      # Flake resilience (#236 / WI-3.5). Opt-in automatic re-run of ONLY the failed tests, via
+      # gotestsum --rerun-fails, capped low. 0 (default) keeps the current single-attempt
+      # behavior — no caller changes unless it sets this. Real-infra flakiness (eventual
+      # consistency, transient API errors) is the primary blocker to promoting the check to
+      # required (ADR-0011); a bounded rerun distinguishes a flake from a real failure without
+      # re-running the whole suite. Keep it low (1–2): a high cap masks a genuinely broken test.
+      rerun_fails:
+        description: 'Max automatic re-runs of failed tests (gotestsum --rerun-fails). 0 disables (default).'
+        required: false
+        default: 0
+        type: number
       working_directory:
         description: 'Working directory (repo root by default)'
         required: false
@@ -398,13 +409,32 @@ jobs:
         env:
           TEST_DIR: ${{ inputs.test_directory }}
           TEST_TIMEOUT: ${{ inputs.test_timeout }}
+          RERUN_FAILS: ${{ inputs.rerun_fails }}
         run: |
           set +e
           cd "${TEST_DIR}"
-          gotestsum \
-            --format standard-verbose \
-            --junitfile "${GITHUB_WORKSPACE}/terratest-results.xml" \
-            -- -tags terratest -timeout "${TEST_TIMEOUT}" ./... 2>&1 | tee "${GITHUB_WORKSPACE}/terratest_output.txt"
+
+          # Opt-in flake resilience (#236). gotestsum --rerun-fails re-runs ONLY the tests that
+          # failed, up to the cap, and reports green if a rerun passes — turning a transient infra
+          # flake into a pass without a human re-run, while a test that fails every attempt still
+          # fails. gotestsum requires that in rerun mode the packages come from --packages and are
+          # NOT also passed as positional args after `--` (doing both is an error), so the package
+          # spec `./...` moves into --packages in that mode. When RERUN_FAILS is 0 (default) we
+          # keep the original single-attempt invocation with `./...` positional, so no caller's
+          # behavior changes unless it opts in.
+          if [ "${RERUN_FAILS:-0}" -gt 0 ]; then
+            echo "::notice::flake resilience on — up to ${RERUN_FAILS} rerun(s) of failed tests"
+            gotestsum \
+              --format standard-verbose \
+              --junitfile "${GITHUB_WORKSPACE}/terratest-results.xml" \
+              --rerun-fails="${RERUN_FAILS}" --rerun-fails-max-failures=15 --packages=./... \
+              -- -tags terratest -timeout "${TEST_TIMEOUT}" 2>&1 | tee "${GITHUB_WORKSPACE}/terratest_output.txt"
+          else
+            gotestsum \
+              --format standard-verbose \
+              --junitfile "${GITHUB_WORKSPACE}/terratest-results.xml" \
+              -- -tags terratest -timeout "${TEST_TIMEOUT}" ./... 2>&1 | tee "${GITHUB_WORKSPACE}/terratest_output.txt"
+          fi
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
 

--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -15,6 +15,8 @@ name: Terratest
 #   - GitHub App token scoped to repo owner for private module access (AC-6, IA-2)
 #   - Test timeout enforced to prevent runaway resource creation (SC-6)
 #   - Step summary and artifacts for audit trail (AU-3)
+#   - Optional protected-environment gate for credentialed runs (#237, AC-6/CM-3)
+#   - Optional if:always() run-scoped NAT-EIP sweep backstops SIGKILL teardown (#273, CP-10)
 
 on:
   workflow_call:
@@ -102,6 +104,24 @@ on:
         required: false
         default: ''
         type: string
+      # Protected-environment gate (#237 / WI-1.6). Opt-in: when set to the name of a
+      # GitHub Environment configured with required reviewers, the credentialed job pauses
+      # for approval before any cloud OIDC step runs. Empty (the default) = no gate, so
+      # every existing caller is unaffected until it deliberately opts in.
+      environment:
+        description: 'GitHub Environment to gate the credentialed job (e.g. terratest-gov). Empty = no gate.'
+        required: false
+        default: ''
+        type: string
+      # if:always() NAT-EIP sweep (#273 / WI-1.3). Opt-in named input, default false, so it
+      # is a no-op for every current caller and lands only when a caller both passes an AWS
+      # role AND flips this true. A caller must also stamp RunId=<run_id>-<run_attempt> on its
+      # NAT EIPs (see docs/ORG_TERRATEST.md) or the sweep has nothing to select.
+      enable_nat_eip_sweep:
+        description: 'Run an if:always() run-scoped NAT Elastic IP sweep after the tests (AWS only; requires RunId-tagged EIPs).'
+        required: false
+        default: false
+        type: boolean
     secrets:
       TERRATEST_APP_CLIENT_ID:
         description: 'GitHub App client ID for private module access'
@@ -165,6 +185,11 @@ jobs:
   terratest:
     name: Terratest
     runs-on: ubuntu-latest
+    # Opt-in protected-environment gate (#237 / WI-1.6). When the caller passes a non-empty
+    # `environment` naming a GitHub Environment with required reviewers, this credentialed job
+    # (it configures cloud OIDC and runs a real apply) pauses for approval before any step runs.
+    # An empty value resolves to no environment, so callers that do not opt in are unaffected.
+    environment: ${{ inputs.environment }}
     # Cap the job so a hung 'terraform apply' cannot burn the 6-hour default while
     # holding cloud resources (the header's 'prevent runaway resource creation' claim).
     timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
@@ -629,6 +654,145 @@ jobs:
         run: |
           echo "::error::Terratest failed with exit code ${EXIT_CODE} — blocking pipeline"
           exit 1
+
+  # if:always() NAT Elastic IP sweep (#273 / WI-1.3). The suite's only teardown guard is a Go
+  # `defer terraform.Destroy(...)`, which covers panics and assertion failures but does NOT run
+  # on SIGKILL — which is exactly what a cancelled job, a `timeout-minutes` expiry, or a runner
+  # eviction does to the process group. So that guard covers the case that was already safe and
+  # misses the one that orphans addresses; seven NAT EIPs leaked this way, one triplet ~15 months,
+  # ~$302/yr (Coalfire-CF/terraform-aws-vpc-nfw#214). This job is the net for that gap.
+  #
+  # It is a SEPARATE runner from the terratest job, so it configures its own OIDC credentials; it
+  # cannot inherit them. It runs `if: always()`, including on cancellation, which is the whole
+  # point. Idempotent by construction: it releases only addresses tagged with THIS run's RunId
+  # that are also unassociated, and treats an already-released address as success — so it usually
+  # runs after a destroy that already succeeded and finds nothing.
+  #
+  # Opt-in twice: only when the caller flips `enable_nat_eip_sweep` true AND passes an AWS role.
+  # An unset role = clean skip, so no existing caller starts running (or failing) this at its next
+  # run. Requires callers to stamp RunId=<run_id>-<run_attempt> on their NAT EIPs; see
+  # docs/ORG_TERRATEST.md "Run-scoped resource tagging".
+  nat-eip-sweep:
+    name: NAT EIP sweep
+    needs: terratest
+    if: ${{ always() && inputs.enable_nat_eip_sweep && inputs.aws_role_arn != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # cloud OIDC
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ inputs.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Sweep NAT EIPs belonging to this run
+        env:
+          # Never interpolate ${{ }} directly into a run: body. These are passed through env and
+          # are trusted (numeric / repo-controlled), but the pattern must not vary by trust level.
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          TERRATEST_RESULT: ${{ needs.terratest.result }}
+          AWS_REGION: ${{ inputs.aws_region }}
+        run: |
+          set -euo pipefail
+
+          # -- Positive control -------------------------------------------------------
+          # An empty address list is indistinguishable from broken credentials, a wrong
+          # region, or a missing IAM permission: all four print "0 orphans" and exit 0.
+          # describe-regions cannot legitimately return 0 in a working account, so it
+          # separates "the API works and found nothing" from "the API did not work".
+          # Without this the sweep would certify a clean account forever.
+          echo "::group::Positive control"
+          aws sts get-caller-identity --output json | jq -r '"sweeping as: \(.Arn)"'
+          region_count="$(aws ec2 describe-regions --output json | jq '.Regions | length')"
+          echo "control: describe-regions returned ${region_count} region(s)"
+          if [ "${region_count}" -lt 1 ]; then
+            echo "::error title=EIP sweep control failed::describe-regions returned 0 regions in ${AWS_REGION}." \
+                 "The enumeration below cannot be trusted, so this is a hard failure rather than a clean sweep."
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          # -- Enumerate --------------------------------------------------------------
+          # Count with default pagination + jq over the raw array. Deliberately NOT
+          # `--query 'length(Addresses)'`, which prints once PER PAGE (100/100/92 reads
+          # as 100, not 292), and NOT `--no-paginate`, which returns only the first page.
+          # DescribeAddresses happens to be unpaginated today; the form is correct
+          # regardless and does not silently under-report if that ever changes.
+          all_addresses="$(aws ec2 describe-addresses --output json)"
+          total="$(printf '%s' "${all_addresses}" | jq '.Addresses | length')"
+          echo "examined ${total} Elastic IP(s) in ${AWS_REGION}"
+
+          mine="$(printf '%s' "${all_addresses}" \
+            | jq --arg rid "${RUN_ID}" \
+                '[.Addresses[] | select(any(.Tags[]?; .Key == "RunId" and .Value == $rid))]')"
+          mine_count="$(printf '%s' "${mine}" | jq 'length')"
+          echo "tagged RunId=${RUN_ID}: ${mine_count}"
+
+          # -- Selector sanity --------------------------------------------------------
+          # If the test job did not finish cleanly, there SHOULD be addresses carrying
+          # this RunId. Matching zero in that situation more likely means the selector
+          # is broken (nat_eip_tags not plumbed, wrong account, wrong region) than that
+          # teardown succeeded. Warn loudly rather than reporting a clean sweep.
+          if [ "${mine_count}" -eq 0 ] && [ "${TERRATEST_RESULT}" != "success" ]; then
+            echo "::warning title=EIP sweep selector may be broken::terratest result was" \
+                 "'${TERRATEST_RESULT}' yet 0 of ${total} addresses carry RunId=${RUN_ID}." \
+                 "Either destroy completed before the job died, or the RunId tag is not" \
+                 "reaching the module - verify the RunId tag is actually being applied."
+          fi
+
+          # -- Still-associated addresses are not this job's problem to release --------
+          # An associated EIP means its NAT gateway still exists, i.e. destroy did not
+          # complete. AWS refuses to release an associated address anyway. Surface it as
+          # a leak needing a real destroy instead of failing on a doomed release call.
+          associated="$(printf '%s' "${mine}" | jq -r '[.[] | select(.AssociationId != null)] | length')"
+          if [ "${associated}" -gt 0 ]; then
+            printf '%s' "${mine}" | jq -r '.[] | select(.AssociationId != null)
+              | "  still associated: \(.AllocationId) \(.PublicIp) assoc=\(.AssociationId)"'
+            echo "::error title=Incomplete teardown::${associated} address(es) from this run are still" \
+                 "associated, so their NAT gateways survive. This needs a real terraform destroy;" \
+                 "release-address cannot free an associated EIP."
+          fi
+
+          # -- Release the orphans ----------------------------------------------------
+          released=0
+          failed=0
+          for alloc in $(printf '%s' "${mine}" | jq -r '.[] | select(.AssociationId == null) | .AllocationId'); do
+            echo "releasing orphan ${alloc}"
+            if err="$(aws ec2 release-address --allocation-id "${alloc}" 2>&1)"; then
+              released=$((released + 1))
+            elif printf '%s' "${err}" | grep -q 'InvalidAllocationID.NotFound'; then
+              # Already gone - a concurrent destroy or an earlier attempt of this sweep
+              # got there first. Idempotent re-run, not a failure.
+              echo "  already released (InvalidAllocationID.NotFound) - treating as success"
+              released=$((released + 1))
+            else
+              echo "::error title=EIP release failed::${alloc}: ${err}"
+              failed=$((failed + 1))
+            fi
+          done
+
+          {
+            echo "## NAT EIP sweep"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| terratest result | \`${TERRATEST_RESULT}\` |"
+            echo "| addresses examined | ${total} |"
+            echo "| tagged this run | ${mine_count} |"
+            echo "| still associated | ${associated} |"
+            echo "| released | ${released} |"
+            echo "| release failures | ${failed} |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          # Fail on anything that left billable state behind. A sweep that exits 0 after
+          # failing to release is the silent-green failure this whole change exists to
+          # remove.
+          if [ "${failed}" -gt 0 ] || [ "${associated}" -gt 0 ]; then
+            exit 1
+          fi
+          echo "sweep clean: examined ${total}, released ${released}, none left behind"
 
   notify-failure:
     needs: terratest

--- a/.github/workflows/org-terratest.yml
+++ b/.github/workflows/org-terratest.yml
@@ -404,7 +404,6 @@ jobs:
           gotestsum \
             --format standard-verbose \
             --junitfile "${GITHUB_WORKSPACE}/terratest-results.xml" \
-            --jsonfile "${GITHUB_WORKSPACE}/terratest-results.json" \
             -- -tags terratest -timeout "${TEST_TIMEOUT}" ./... 2>&1 | tee "${GITHUB_WORKSPACE}/terratest_output.txt"
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
@@ -419,15 +418,104 @@ jobs:
 
       # --- Reporting ---
 
+      # Durable per-run telemetry record (#235 / WI-2.2). The old terratest-results.json was
+      # gotestsum's raw event stream, uploaded but read by NOTHING and expiring with the 30-day
+      # artifact. Replace it with a purpose-built record — repo / module / commit SHA / result /
+      # counts / duration — keyed by the tested commit SHA so the MTCS terratest-posture collector
+      # can bind evidence to the exact code tested and it outlives the artifact. Built with
+      # `jq -n` (never string interpolation) so an embedded quote/newline can't corrupt it, and
+      # the counts come from the same JUnit XML the step summary parses (one source of truth).
+      - name: Emit telemetry record
+        if: always()
+        env:
+          RESULT_SHA: ${{ github.sha }}
+          RUN_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TEST_MODE: ${{ inputs.test_mode }}
+          TEST_DIR: ${{ inputs.test_directory }}
+          TF_VERSION: ${{ steps.tf-version.outputs.version }}
+          GO_VERSION: ${{ inputs.go_version }}
+          EXIT_CODE: ${{ steps.terratest.outputs.exitcode }}
+        run: |
+          set -euo pipefail
+          XML="${GITHUB_WORKSPACE}/terratest-results.xml"
+
+          # Counts from the JUnit root aggregate (same parse as the step summary). If the XML is
+          # missing, the test binary died before writing it (SIGKILL/timeout) — emit a record with
+          # a null test count and a 'no-report' note rather than silently omitting the run, so a
+          # killed run is still visible in the posture surface instead of vanishing.
+          tests=null; failures=null; errors=null; skipped=null; time=null; have_report=false
+          if [ -f "$XML" ]; then
+            have_report=true
+            root="$(grep -m1 -oE '<testsuites[^>]*>' "$XML" || true)"
+            tests="$(printf '%s' "$root"    | grep -oE ' tests="[0-9]+"'   | grep -oE '[0-9]+' || echo 0)"
+            failures="$(printf '%s' "$root" | grep -oE 'failures="[0-9]+"' | grep -oE '[0-9]+' || echo 0)"
+            errors="$(printf '%s' "$root"   | grep -oE 'errors="[0-9]+"'   | grep -oE '[0-9]+' || echo 0)"
+            time="$(printf '%s' "$root"     | grep -oE 'time="[0-9.]+"'    | grep -oE '[0-9.]+' || echo 0)"
+            skipped="$(grep -oE '<testsuite [^>]*>' "$XML" | grep -oE 'skipped="[0-9]+"' | grep -oE '[0-9]+' | awk '{s+=$1} END{print s+0}')"
+          fi
+
+          # result is derived from the gate exit code, NOT from the presence of the XML — a green
+          # XML with a non-zero exit is still a failure.
+          if [ "${EXIT_CODE}" = "0" ]; then result="pass"; else result="fail"; fi
+
+          jq -n \
+            --arg repo "${RUN_REPO}" \
+            --arg module "${TEST_DIR}" \
+            --arg sha "${RESULT_SHA}" \
+            --arg mode "${TEST_MODE}" \
+            --arg result "${result}" \
+            --arg exit_code "${EXIT_CODE}" \
+            --arg run_id "${RUN_ID}" \
+            --arg run_attempt "${RUN_ATTEMPT}" \
+            --arg run_url "${RUN_URL}" \
+            --arg tf "${TF_VERSION}" \
+            --arg go "${GO_VERSION}" \
+            --argjson have_report "${have_report}" \
+            --argjson tests "${tests}" \
+            --argjson failures "${failures}" \
+            --argjson errors "${errors}" \
+            --argjson skipped "${skipped}" \
+            --argjson time "${time}" \
+            '{
+               schema: "terratest-posture/v1",
+               repo: $repo, module: $module, commit_sha: $sha, mode: $mode,
+               result: $result, exit_code: ($exit_code | tonumber),
+               run_id: $run_id, run_attempt: ($run_attempt | tonumber), run_url: $run_url,
+               terraform_version: $tf, go_version: $go,
+               have_report: $have_report,
+               counts: (if $have_report
+                        then { tests: $tests, failures: $failures, errors: $errors,
+                               skipped: $skipped,
+                               passed: ($tests - $failures - $errors - $skipped) }
+                        else null end),
+               duration_seconds: $time
+             }' > "${GITHUB_WORKSPACE}/terratest-record.json"
+
+          # Fail loud if the record did not serialize to a non-empty object — a zero-byte or
+          # empty record read as "run had no telemetry" downstream, which is the silent-green
+          # trap (a tool that fails quiet rather than loud).
+          if ! jq -e 'type == "object" and (.commit_sha | length > 0)' \
+                 "${GITHUB_WORKSPACE}/terratest-record.json" >/dev/null; then
+            echo "::error title=Telemetry record malformed::terratest-record.json did not serialize"
+            exit 1
+          fi
+          echo "emitted terratest-record.json for ${RUN_REPO}@${RESULT_SHA} result=${result}"
+          cat "${GITHUB_WORKSPACE}/terratest-record.json"
+
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: terratest-results-${{ github.run_id }}
+          # SHA-stamped (#235 / RPT-04) so an archived run binds to the exact commit tested,
+          # not just an opaque run-id. run_id keeps the name unique across re-runs of one SHA.
+          name: terratest-results-${{ github.sha }}-${{ github.run_id }}
           path: |
             terratest_output.txt
             terratest-results.xml
-            terratest-results.json
+            terratest-record.json
           retention-days: 30
 
       - name: Post results to PR
@@ -602,6 +690,7 @@ jobs:
           GO_VERSION: ${{ inputs.go_version }}
           TF_VERSION: ${{ steps.tf-version.outputs.version }}
           EXIT_CODE: ${{ steps.terratest.outputs.exitcode }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           if [ "${EXIT_CODE}" = "0" ]; then
             STATUS="Passed"
@@ -615,6 +704,7 @@ jobs:
             echo "| Property | Value |"
             echo "| --- | --- |"
             echo "| Status | ${STATUS} |"
+            echo "| Commit | \`${COMMIT_SHA}\` |"
             echo "| Mode | \`${TEST_MODE}\` |"
             echo "| Test Directory | \`${TEST_DIR}\` |"
             echo "| Timeout | \`${TEST_TIMEOUT}\` |"

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Issue labels:
 |   |-- ORG_SLACK_NOTIFY.md
 |   |-- ORG_SOURCE_PIN.md
 |   |-- ORG_TERRATEST.md
+|   |-- ORG_TERRATEST_HARDENING_RUNBOOK.md
 |   |-- ORG_TERRATEST_PROVISIONING.md
 |   |-- ORG_VERSION_BAND.md
 |   |-- superpowers
@@ -268,6 +269,7 @@ Issue labels:
     |       |-- pass_sha.yml
     |       |-- warn_tag.yml
     |-- gate-config-resolve.test.sh
+    |-- nat-eip-sweep.test.sh
     |-- pr-green-merge.test.sh
     |-- prompt-build.test.sh
     |-- reconcile-sweeper.test.sh
@@ -276,6 +278,8 @@ Issue labels:
     |-- retry-lib.test.sh
     |-- source-pin-check.test.sh
     |-- stagger-slot.test.sh
+    |-- terratest-rerun.test.sh
+    |-- terratest-telemetry.test.sh
     |-- tree-readme-section.test.sh
     |-- uses-pin-check.test.sh
     |-- version-band-check.test.sh

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -13,8 +13,12 @@
 > roles are scoped to dedicated test accounts/subscriptions with appropriate spending limits.
 
 All caller examples in this document are drawn from the two **proven, green** callers in the
-org and are pinned to the current release **v0.11.3**
-(`9451b979c22b3762b3c8a7d4d9493fefaee7edc5`):
+org. Pin the reusable workflow to the **immutable commit SHA of the latest release** with an
+adjacent `# vX.Y.Z` comment (SHA-preferred pinning, RFC-0008/ADR-0018) — check the
+[releases page](https://github.com/Coalfire-CF/Actions/releases) for the current SHA rather
+than trusting a number frozen in this doc. The snippets below pin **v0.15.0**
+(`0324cf8a90b4b9c523465f53a892a722f613e318`); the `environment` and `enable_nat_eip_sweep`
+inputs ship from the release that lands #237/#273 — pin at or above it to use them.
 
 - **AWS (GovCloud):** [`terraform-aws-vpc-nfw`](https://github.com/Coalfire-CF/terraform-aws-vpc-nfw)
   `.github/workflows/org-terratest.yml` — the canonical **module-repo self-test** (PR #198).
@@ -189,7 +193,7 @@ concurrency:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@33a5e8e2f7fe782ea151eb2bd8c653b5d2778a68 # v0.12.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       test_mode: pr
       go_version: "1.26"
@@ -237,7 +241,7 @@ concurrency:
 
 jobs:
   terratest-azure:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@33a5e8e2f7fe782ea151eb2bd8c653b5d2778a68 # v0.12.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       test_mode: pr
       go_version: "1.26"
@@ -273,7 +277,7 @@ concurrency:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@33a5e8e2f7fe782ea151eb2bd8c653b5d2778a68 # v0.12.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       test_mode: pr
       go_version: "1.26"
@@ -296,7 +300,7 @@ on:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@33a5e8e2f7fe782ea151eb2bd8c653b5d2778a68 # v0.12.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       test_mode: release
       go_version: "1.26"
@@ -305,7 +309,7 @@ jobs:
 
   release-clean:
     needs: terratest
-    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@33a5e8e2f7fe782ea151eb2bd8c653b5d2778a68 # v0.12.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
     with:
       tag_name: ${{ github.event.release.tag_name }}
 ```
@@ -326,8 +330,20 @@ allowed to finish. **Cancelling a run while `terraform apply` (or `destroy`) is 
 kills the process before the deferred destroy**, leaking real resources into the test
 account. This is why every caller sets `concurrency.cancel-in-progress: false`.
 
-If a run *is* cancelled mid-apply (or times out mid-apply), **sweep the test account by
-tag/prefix**. For the AWS GovCloud account, check for leaked:
+Two automated backstops cover this gap so it does not depend on manual discipline:
+
+1. **Per-run net — the `if: always()` NAT-EIP sweep** (opt-in `enable_nat_eip_sweep`). Runs
+   in a separate job, on cancellation too, and releases the run's own orphaned NAT Elastic IPs.
+   See [Run-scoped resource tagging](#run-scoped-resource-tagging-and-the-nat-eip-sweep).
+1. **Scheduled reaper — [`terraform-aws-terratest-janitor`](https://github.com/Coalfire-CF/terraform-aws-terratest-janitor)**
+   is the authoritative standing backstop for everything the per-run net does not cover
+   (non-EIP resources, a `SIGKILL` before the sweep job runs, cross-cloud). It is an hourly,
+   account-allowlisted Lambda that sweeps abandoned prefix-cohorts (a cohort is reaped only when
+   **every** timestamped sibling is older than `abandon_hours`, so an active run is never raced)
+   and alerts loudly on both action and failure.
+
+**Break-glass (only if the backstops are unavailable):** manually sweep the test account by
+tag/prefix. For the AWS GovCloud account, check for leaked:
 
 - VPCs and their dependencies (subnets, NAT gateways, EIPs, route tables)
 - KMS **aliases** (the keys go to `PendingDeletion`, but the alias name blocks re-runs)
@@ -337,6 +353,61 @@ tag/prefix**. For the AWS GovCloud account, check for leaked:
 
 For Azure, sweep the ephemeral resource group (`rg-terratest-*`) — deleting the RG reclaims
 everything in it.
+
+### Run-scoped resource tagging and the NAT-EIP sweep
+
+`defer terraform.Destroy()` covers panics and assertion failures but **does not run on
+`SIGKILL`** — which is exactly what a cancelled job, a `timeout-minutes` expiry, or a runner
+eviction sends to the process group. So the guard covers the case that was already safe and
+misses the one that orphans addresses; seven NAT EIPs leaked this way, one triplet for ~15
+months (~$302/yr,
+[terraform-aws-vpc-nfw#214](https://github.com/Coalfire-CF/terraform-aws-vpc-nfw/issues/214)).
+
+To backstop it, opt in with `enable_nat_eip_sweep: true` **and** stamp every NAT Elastic IP with
+the run's identity so the sweep can select only its own orphans:
+
+```hcl
+# in the fixture / module: tag NAT EIPs with the run id passed from CI
+variable "nat_eip_tags" { type = map(string), default = {} }
+# ... aws_eip.this: tags = merge(local.tags, var.nat_eip_tags)
+```
+
+```yaml
+# caller: pass RunId=<run_id>-<run_attempt> through to the fixture, and opt the sweep in
+env:
+  TF_VAR_nat_eip_tags: '{"RunId":"${{ github.run_id }}-${{ github.run_attempt }}"}'
+with:
+  enable_nat_eip_sweep: true
+  aws_role_arn: arn:aws-us-gov:iam::358745275192:role/github-action-test-role
+```
+
+The **attempt suffix matters** — a re-run reuses `GITHUB_RUN_ID`, so `RunId` must include
+`run_attempt` to stay unique per attempt. The sweep releases **only** addresses that are both
+tagged this exact `RunId` **and** unassociated; it treats an already-released address as success
+(idempotent), fails hard on a still-associated address (its NAT gateway survives — that needs a
+real `destroy`, not a doomed release), fails hard on a denied release (e.g. a role missing
+`ec2:ReleaseAddress`), and runs a positive control so an empty enumeration can never read as a
+clean sweep. It requires `ec2:ReleaseAddress` on the terratest role (see the provisioning
+runbook §2).
+
+### Protected-environment gate for credentialed runs
+
+The credentialed job checks out PR-supplied code and runs a real `apply` with cloud write
+credentials. On a private, trusted-member sandbox that is acceptable, but the exposure grows with
+every adopting repo. To gate it, create a GitHub Environment (e.g. `terratest-gov`) with **≥1
+required reviewer** and pass its name as the `environment` input:
+
+```yaml
+with:
+  environment: terratest-gov
+```
+
+When set, the Terratest job pauses for approval **before any cloud step runs**; a PR from a
+non-maintainer waits for a reviewer. Complement it with the org setting *"require approval for
+all outside collaborators / first-time contributors"*. Leave `environment` empty to keep the
+current ungated behavior. **Approval policy:** only repo maintainers / `cs-*-codeowners` team
+members may approve a Terratest run; approving means you have reviewed the PR's Terraform and
+test code for anything that would abuse the cloud credentials.
 
 ### Pending-run auto-cancel is safe (and desirable)
 
@@ -406,6 +477,8 @@ The essentials:
 | `gcp_workload_identity_provider` | No | | GCP Workload Identity Provider |
 | `gcp_service_account` | No | | GCP service account email |
 | `slack_channel_id` | No | | Slack channel for failure notifications |
+| `environment` | No | | GitHub Environment to gate the credentialed job (e.g. `terratest-gov`). Empty = no gate. See [Protected-environment gate](#protected-environment-gate-for-credentialed-runs). |
+| `enable_nat_eip_sweep` | No | `false` | Run an `if: always()` run-scoped NAT Elastic IP sweep after the tests (AWS only; requires `RunId`-tagged EIPs). See [Run-scoped resource tagging](#run-scoped-resource-tagging-and-the-nat-eip-sweep). |
 
 ## Secrets Reference
 
@@ -543,8 +616,13 @@ When adding Terratest to a Terraform module repo:
 If your Terraform modules reference other private modules in the org, the workflow needs
 a GitHub App token to authenticate `go mod download` against private repos.
 
-**Option A (dev-phase, in use today):** alias the existing org private-module pull App into
-the names org-terratest expects, right in the caller's `secrets:` block:
+**Use Option B.** A dedicated Terratest App is the target posture (issue #231): callers back
+`TERRATEST_APP_*` directly from org secrets and pass nothing App-related in their own
+`secrets:` block. Option A below is the retired dev-phase fallback, kept only for context.
+
+**Option A (retired dev-phase fallback — do not use for new callers):** alias the existing org
+private-module pull App into the names org-terratest expects, right in the caller's `secrets:`
+block:
 
 ```yaml
     secrets:
@@ -552,11 +630,11 @@ the names org-terratest expects, right in the caller's `secrets:` block:
       TERRATEST_APP_PRIVATE_KEY: ${{ secrets.CF_TF_PULL_PRIVATE_APP_PRIVATE_KEY }}
 ```
 
-This reuses an already-provisioned App, so no new registration is needed to get a lane green.
-Note these org secrets are **selected-repos scoped** — a brand-new repo may need to be added
-to each secret's repository list before the pull works.
+This reused an already-provisioned App to get lanes green quickly, but couples the Terratest
+token to the plan/apply pull App and inherits its broad, org-wide `Contents:read`. Replaced by
+Option B; drop this alias from callers once the dedicated App backs the org secrets.
 
-**Option B (go-live hardening): a dedicated Terratest App.** Create a purpose-built App so the
+**Option B (target posture): a dedicated Terratest App.** Create a purpose-built App so the
 Terratest token is minimal, separately audited, and independently revocable:
 
 - **Minimal permissions** — the app only needs `Contents: read` to pull module source

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -694,6 +694,18 @@ When adding Terratest to a Terraform module repo:
    [`ORG_TERRATEST_PROVISIONING.md`](./ORG_TERRATEST_PROVISIONING.md))
 1. **Add the caller workflow** with `paths` scoping, a `concurrency` block
    (`cancel-in-progress: false`), and the `permissions` block including `id-token: write`
+1. **Decide which opt-in hardening inputs to enable** — all default off, so a caller only gets
+   them by asking. None is required to go green, but each closes a known gap:
+
+   | Input | Enable when | Reference |
+   | --- | --- | --- |
+   | `enable_nat_eip_sweep: true` (+ stamp `RunId` on NAT EIPs) | the module creates NAT gateways (any VPC-with-NAT module) — backstops SIGKILL teardown | [Run-scoped resource tagging](#run-scoped-resource-tagging-and-the-nat-eip-sweep) |
+   | `environment: terratest-gov` | the repo takes external/first-time-contributor PRs, or you want an approval gate on credentialed runs | [Protected-environment gate](#protected-environment-gate-for-credentialed-runs) |
+   | `rerun_fails: 1` | the suite hits transient cloud flakiness; recommended for any scheduled caller | [Flake strategy](#flake-strategy-rerun-and-quarantine) |
+   | a `schedule:` caller | you want provider/cloud drift caught between PRs | [Scheduled/nightly regression runs](#schedulednightly-regression-runs) |
+
+   Telemetry (the durable per-run record feeding `fleet/TERRATEST-POSTURE.md` and metric #9) is
+   **automatic** — no input; every run emits it once this workflow version is pinned.
 1. **Open a PR and shepherd the run to green** — approve any `action_required` gate, prune
    redundant queued applies, never cancel mid-apply
 

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -409,6 +409,91 @@ current ungated behavior. **Approval policy:** only repo maintainers / `cs-*-cod
 members may approve a Terratest run; approving means you have reviewed the PR's Terraform and
 test code for anything that would abuse the cloud credentials.
 
+### Flake strategy: rerun and quarantine
+
+Real-infra tests are inherently flaky (eventual consistency, transient cloud API errors). Go's
+`terraform.WithDefaultRetryableErrors` handles known-retryable Terraform errors inside a test;
+this covers the layer above it. Flake reliability is the **primary blocker to promoting
+`org-terratest` to a required check** (ADR-0011: a check can only block if it is reliably green
+on correct code).
+
+**Automatic rerun (opt-in).** Set `rerun_fails` to a low cap (1–2):
+
+```yaml
+with:
+  rerun_fails: 1
+```
+
+`gotestsum` then re-runs **only the tests that failed**, and the run is green if a rerun passes
+— a transient flake no longer fails the whole suite or needs a human re-run, while a test that
+fails every attempt still fails. Keep the cap low: a high cap masks a genuinely broken test as
+"just flaky". `0` (the default) keeps single-attempt behavior.
+
+**Quarantine convention.** A test that is known-flaky and not yet fixed should not gate other
+work while it is being investigated. Move it behind a second build tag:
+
+```go
+//go:build terratest && terratest_quarantine
+```
+
+The reusable workflow runs `-tags terratest`, so a `terratest_quarantine`-tagged file is
+compiled out of the gating run — it does not fail the check. Run quarantined tests deliberately
+(locally or in a dedicated non-gating job with `-tags 'terratest terratest_quarantine'`), and
+keep quarantine membership visible: list quarantined tests in the repo's `test/README.md` (or a
+`test/QUARANTINE.md`) with the issue tracking each one's fix, so a quarantine is a tracked
+exception with an exit, not a silent hole. The flake rate that justifies quarantining (or
+un-quarantining) is surfaced per-module in the MTCS terratest posture scoreboard
+(`fleet/TERRATEST-POSTURE.md`).
+
+### Scheduled/nightly regression runs
+
+PR-triggered runs only catch regressions a human introduces. Nothing re-runs a suite between
+PRs, so provider-API / cloud / upstream drift goes undetected — a module can be "last known
+green" for months while the real behavior it asserts has drifted. Add a **scheduled** caller so
+the suite re-runs on a cadence:
+
+```yaml
+name: Terratest (scheduled)
+
+on:
+  schedule:
+    # Weekly is reasonable given real-infra cost. STAGGER the minute/hour across repos so a
+    # dozen suites don't all apply at once and spike concurrent spend (this repo uses off-the-
+    # hour minutes elsewhere for the same reason — e.g. org-repo-bootstrap.yml).
+    - cron: "37 7 * * 1" # Mondays 07:37 UTC — pick a distinct slot per repo
+  workflow_dispatch:
+
+# Same per-repo concurrency group as the PR caller so a scheduled run never races a PR run.
+concurrency:
+  group: org-terratest-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  terratest:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@0324cf8a90b4b9c523465f53a892a722f613e318 # v0.15.0
+    with:
+      test_directory: test
+      test_timeout: 45m
+      aws_role_arn: arn:aws-us-gov:iam::358745275192:role/github-action-test-role
+      aws_region: us-gov-west-1
+      # Non-gating: a scheduled drift failure alerts, it does not block a branch. Route it to
+      # #cs-alerts via the built-in failure-notify path instead of failing a required check.
+      slack_channel_id: C0A96K23KPF # #cs-alerts (invite the bot first)
+      # A scheduled run is exactly the case where a flake would page someone at night — a low
+      # rerun cap absorbs transient flakes so only a real drift alerts.
+      rerun_fails: 1
+      enable_nat_eip_sweep: true
+    secrets: inherit
+```
+
+A drift that a pinned provider bump introduces is then caught by the Monday run and posted to
+Slack, not left until the next human PR. Because scheduled runs are non-gating, a flake or a
+transient cloud outage is an alert to triage, not a blocked branch.
+
 ### Pending-run auto-cancel is safe (and desirable)
 
 GitHub's concurrency group auto-cancels *superseded pending* runs — a run that is queued but
@@ -479,6 +564,7 @@ The essentials:
 | `slack_channel_id` | No | | Slack channel for failure notifications |
 | `environment` | No | | GitHub Environment to gate the credentialed job (e.g. `terratest-gov`). Empty = no gate. See [Protected-environment gate](#protected-environment-gate-for-credentialed-runs). |
 | `enable_nat_eip_sweep` | No | `false` | Run an `if: always()` run-scoped NAT Elastic IP sweep after the tests (AWS only; requires `RunId`-tagged EIPs). See [Run-scoped resource tagging](#run-scoped-resource-tagging-and-the-nat-eip-sweep). |
+| `rerun_fails` | No | `0` | Max automatic re-runs of *failed* tests (`gotestsum --rerun-fails`). `0` disables. See [Flake strategy](#flake-strategy-rerun-and-quarantine). |
 
 ## Secrets Reference
 

--- a/docs/ORG_TERRATEST_HARDENING_RUNBOOK.md
+++ b/docs/ORG_TERRATEST_HARDENING_RUNBOOK.md
@@ -1,0 +1,144 @@
+# org-terratest hardening — operator runbook
+
+Privileged / live steps that complete the org-terratest hardening effort — the dedicated App
+(#231), the environment gate (#237), the EIP sweep (#273), and the janitor (#234). The
+**workflow, tooling, and doc changes have already shipped** on the feature
+branch; the steps below are the ones that mutate real GitHub-org / cloud / cross-repo state and
+must be executed by an operator with the right credentials, then verified. Each step is idempotent
+and re-runnable, and states its own verification.
+
+Order: do the App (1a) and the AWS release-permission check (2a) first — they unblock everything
+else. The Environment (1b) is only meaningful once a caller opts in. GCP and Azure live work are
+**out of scope for this effort** (backburnered).
+
+---
+
+## 1a. Dedicated Terratest GitHub App (#231)
+
+GitHub App creation has **no REST endpoint** — it is a browser manifest flow, so this is an
+operator step, not scriptable.
+
+1. As an org owner, create a GitHub App **`coalfire-terratest`**:
+   `https://github.com/organizations/Coalfire-CF/settings/apps/new`
+   - **Repository permissions → Contents: Read-only** (nothing else).
+   - Uncheck "Webhook → Active".
+   - "Where can this be installed": Only on this account.
+1. Generate a **private key** (downloads a `.pem`) and note the **Client ID**.
+1. Install the App on the org — **All repositories** (or select the `terraform-*` module repos).
+1. Set the two org secrets from it (org owner; scope to the module repos that call terratest):
+
+   ```bash
+   gh secret set TERRATEST_APP_CLIENT_ID  --org Coalfire-CF --visibility selected --body "<client-id>"
+   gh secret set TERRATEST_APP_PRIVATE_KEY --org Coalfire-CF --visibility selected --body "$(cat coalfire-terratest.*.pem)"
+   # then grant the repos that need it:
+   gh api -X PUT orgs/Coalfire-CF/actions/secrets/TERRATEST_APP_CLIENT_ID/repositories/<repo_id>
+   ```
+
+1. **Drop the Option A alias** from each caller's `secrets:` block (the
+   `CF_TF_PULL_PRIVATE_APP_*` pass-through) — the org secrets now back the dedicated App directly.
+
+**Verify:** trigger a caller PR that pulls a private sibling module; the "Get GitHub App Token"
+and "Configure Git for private modules" steps succeed and `go mod download` pulls the private
+module. In the App's **Advanced → Recent Deliveries / installation token log**, confirm the
+token was minted by `coalfire-terratest`, not the fleet pull App.
+
+**Rollback:** re-add the Option A alias to callers; the workflow needs no change.
+
+---
+
+## 1b. Protected Environment `terratest-gov` (#237)
+
+The `environment` input has shipped. The Environment itself is **repo-scoped**, so create it on
+each repo that will opt in (start with the first adopter). Only meaningful after the workflow
+release is pinned by that caller and the caller passes `environment: terratest-gov`.
+
+```bash
+REPO=Coalfire-CF/terraform-aws-vpc-nfw
+# Create the environment with a required reviewer (a team or user id).
+gh api -X PUT "repos/$REPO/environments/terratest-gov" \
+  -f 'reviewers[][type]=Team' -F "reviewers[][id]=<cs-aws-codeowners-team-id>" \
+  -F 'deployment_branch_policy=null'
+# Org setting: require approval for first-time / outside contributors (org → Actions settings).
+```
+
+Then in that repo's caller add `with: { environment: terratest-gov }`.
+
+**Verify:** open a PR from a non-maintainer identity; the Terratest job shows **"Waiting for
+review"** and no cloud OIDC step runs until a reviewer approves. A maintainer PR still runs (if
+the maintainer is an allowed reviewer). Document who may approve in the repo's `test/README.md`.
+
+**Rollback:** delete the environment (`gh api -X DELETE repos/$REPO/environments/terratest-gov`)
+and drop the input; the job reverts to ungated.
+
+---
+
+## 2a. Verify `ec2:ReleaseAddress` on the terratest role (#273)
+
+The `nat-eip-sweep` job has shipped (opt-in). It needs `ec2:ReleaseAddress` (+ `DescribeAddresses`,
+`DescribeRegions`) on the terratest role. `ec2:*` in the current starter policy already covers it,
+but this **cannot be proven on paper** — a normal green run never exercises a release, so IAM
+Access-Analyzer tightening (`ORG_TERRATEST_PROVISIONING.md` §4) would silently drop it. Confirm
+against the live account:
+
+```bash
+# From a session assuming the terratest role in 358745275192 (us-gov-west-1):
+aws sts get-caller-identity
+# Simulate the release permission without deleting anything:
+aws iam simulate-principal-policy \
+  --policy-source-arn arn:aws-us-gov:iam::358745275192:role/github-action-test-role \
+  --action-names ec2:ReleaseAddress ec2:DescribeAddresses ec2:DescribeRegions \
+  --query 'EvaluationResults[].{action:EvalActionName,decision:EvalDecision}' --output table
+```
+
+All three must show `allowed`. Then do a **live proof**: enable the sweep on a caller
+(`enable_nat_eip_sweep: true` + stamp `RunId` on its NAT EIPs), force a mid-apply cancel, and
+confirm the sweep releases the orphan and the run leaves zero unassociated tagged EIPs
+(`ORG_TERRATEST.md` → "Run-scoped resource tagging"). Keep the three actions in the enumerated
+policy after any Access-Analyzer tightening.
+
+**Verify:** the deliberately-cancelled run's `nat-eip-sweep` job summary shows `released ≥ 1`,
+`release failures 0`, `still associated 0`; a follow-up `describe-addresses` shows zero
+unassociated addresses tagged that `RunId`.
+
+---
+
+## 2b. Extend the janitor to the general terratest account (#234)
+
+**This is a sub-project, not a config edit — flag before starting.** The existing
+`terraform-aws-terratest-janitor` Lambda has scope-specific handlers (`security`, `pca`) covering
+Config/GuardDuty/CloudTrail/IAM/KMS/S3/logs and Security-Hub/ACM-PCA respectively. The general
+terratest account (`358745275192`) creates **VPC + subnets + NAT + route tables + Network
+Firewall + flow-log roles/policies + KMS aliases + log groups + S3** residue — the network
+classes are **not** covered by either existing handler. Extending the janitor therefore means:
+
+1. Author a new scope (e.g. `network`/`general`) handler in `modules/janitor/lambda` that reaps
+   the VPC-dependency + NFW + flow-log classes, keyed on the same prefix-cohort-abandonment
+   safety model (a cohort is swept only when every timestamped sibling is older than
+   `abandon_hours`; hard account allowlist twice; loud-on-action-and-failure SNS).
+1. Add `358745275192` to the deploy's account allowlist and instantiate the module with the new
+   scope; add the general account's suite `resourcePrefix` tokens to `test_prefixes`.
+1. Deploy **operator-only** (OAAR from `occ-dev`), supervised `dry_run=true` first, read the
+   report, then `dry_run=false`.
+
+**Decision needed** (see the message accompanying this runbook): build the new handler now as a
+janitor PR, or keep #234 covered by the shipped per-run NAT-EIP net + the documented manual
+break-glass until the network-scope handler is prioritized.
+
+**Verify (once built):** a `dry_run=true` apply's report enumerates only the allowlisted accounts
+and lists the intended (not executed) deletions for a known orphaned cohort; the positive control
+(non-empty enumeration) passes so an empty result is a hard error, never a silent "clean".
+
+---
+
+## What has already shipped (no operator action)
+
+- `org-terratest.yml`: opt-in `environment` gate, opt-in `nat-eip-sweep` job, durable
+  `terratest-record.json` telemetry emit + SHA stamping, opt-in `rerun_fails`.
+- `docs/ORG_TERRATEST.md` / `ORG_TERRATEST_PROVISIONING.md`: Option B active, run-scoped tagging,
+  protected-environment pattern, flake/quarantine/scheduled guidance, Azure RBAC narrowing note,
+  `ec2:ReleaseAddress` tightening warning, reconciled version pins.
+- `Coalfire-CF/MTCS`: `tools/terratest_posture.py` + `fleet/TERRATEST-POSTURE.md` + the
+  `terratest-posture.yml` CI, and metric #9 wired into `metrics.py`.
+- Meta-tests: `tests/nat-eip-sweep.test.sh`, `tests/terratest-telemetry.test.sh`,
+  `tests/terratest-rerun.test.sh` (Actions); `tools/test_terratest_posture.py` (MTCS) — all
+  mutation-proven.

--- a/docs/ORG_TERRATEST_PROVISIONING.md
+++ b/docs/ORG_TERRATEST_PROVISIONING.md
@@ -254,6 +254,15 @@ until green (then tighten — see §4).
   Firewall service principals (both spellings exist across partitions).
 - **Subnet groups + resolver DNSSEC** cover the database/cache subnet groups and the DNSSEC
   config the module optionally manages; enumerated because they are low-volume and easy to pin.
+- **`ec2:ReleaseAddress` is required by the `if: always()` NAT-EIP sweep** (`enable_nat_eip_sweep`,
+  issue #273), not just by `terraform destroy`. It is already inside the `ec2:*` wildcard above,
+  but a normal green run never *exercises* a release (destroy usually frees the EIP first), so
+  the §4 Access-Analyzer tightening below would **drop it** — leaving the sweep to fail with
+  `UnauthorizedOperation` exactly when it is finally needed (a killed run). When tightening,
+  keep `ec2:ReleaseAddress` (and `ec2:DescribeAddresses`, `ec2:DescribeRegions`) in the
+  enumerated set explicitly. Verify once against the live account:
+  `aws ec2 release-address` is denied only by IAM, so a dry sweep on a run with a known orphan is
+  the only way to confirm the grant — it cannot be proven on paper.
 
 Attach it:
 
@@ -312,6 +321,32 @@ az ad app federated-credential delete --id <azure_client_id> \
   --federated-credential-id coalfire-<repo>-pr
 ```
 
+### RBAC scope — least-privilege, not Contributor-at-subscription (#231)
+
+The federated credential above governs *who* can assume the identity; the identity's **RBAC
+role assignment** governs *what* it can do once assumed. The pilot granted the principal
+**Contributor at subscription scope**, which is far broader than any single module self-test
+needs. Narrow it to the dedicated test subscription's terratest resource group (or a custom
+role scoped to the module's actual resource providers):
+
+```bash
+# Scope the assignment to the ephemeral-RG parent, not the whole subscription.
+az role assignment create --assignee <azure_client_id> \
+  --role Contributor \
+  --scope "/subscriptions/<test_sub_id>/resourceGroups/rg-terratest"
+
+# Remove any pre-existing subscription-scoped grant once the scoped one is verified green.
+az role assignment delete --assignee <azure_client_id> \
+  --scope "/subscriptions/<test_sub_id>"
+```
+
+The tests create their own ephemeral `rg-terratest-*` resource groups, so scope the assignment
+to the parent that can create sibling RGs (or grant `Microsoft.Resources/subscriptions/
+resourceGroups/write` via a custom role) rather than leaving Contributor at the subscription
+root. Same "tighten after first green" discipline as the AWS §4 flow. If you cannot manage role
+assignments in the Gov tenant, record the exact `az role assignment` commands as a blocker for
+the identity owner (Doug), same as the credential step.
+
 ### Org secret visibility
 
 The private-module pull secrets (`CF_TF_PULL_PRIVATE_APP_CLIENTID` /
@@ -356,8 +391,14 @@ starter:
 
 1. Diff the generated policy against the starter, replace the service wildcards
    (`ec2:*`, `s3:*`, `logs:*`) with the enumerated action set Access Analyzer observed, keep the
-   already-tight IAM/KMS statements, and `put-role-policy` the result.
-1. Re-run the lane to confirm it is still green under the tightened policy.
+   already-tight IAM/KMS statements, and `put-role-policy` the result. **Manually add back
+   `ec2:ReleaseAddress`, `ec2:DescribeAddresses`, and `ec2:DescribeRegions`** — the NAT-EIP
+   sweep needs them, but a clean run never triggers a release so CloudTrail (and therefore
+   Access Analyzer) will not have observed it. Dropping them is the silent-green trap called
+   out in §2.
+1. Re-run the lane to confirm it is still green under the tightened policy, and run one sweep
+   against a run with a known orphan to confirm `ec2:ReleaseAddress` actually works (paper
+   review cannot prove an IAM grant).
 
 This converts the "wildcard to get green, then tighten" starter into a real least-privilege
 policy grounded in observed behavior — the same iteration that produced the vpc-nfw KMS/IAM

--- a/tests/nat-eip-sweep.test.sh
+++ b/tests/nat-eip-sweep.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Meta-test for the if:always() NAT Elastic IP sweep step in
+# .github/workflows/org-terratest.yml (#273 / WI-1.3).
+#
+# The sweep logic lives INLINE in the workflow's `run:` body (not a scripts/*.sh)
+# on purpose: a reusable workflow cannot reliably fetch its own repo's helper
+# scripts at the calling ref — github.job_workflow_sha is empty for cross-repo
+# reusable-workflow calls (see the workflow header), so github.sha would resolve
+# to the CALLER's commit and 404. The inline block is therefore the testable
+# safety surface. This test EXTRACTS that block from the YAML (so the test can
+# never drift from what actually ships) and drives it through a MOCK `aws` shim
+# placed first on PATH, which serves canned describe-* JSON and records every
+# release-address call.
+#
+# Every assertion is mutation-proven: for each safety property we also run the
+# scenario that SHOULD trip it and confirm the outcome flips. A check that passes
+# no matter what the sweep does is worse than no check (CLAUDE.md silent-green).
+#
+# Invariants covered:
+#   1. Positive control: describe-regions returning 0 is a HARD FAIL, not a clean
+#      sweep (an empty enumeration must never read as "found 0 problems").
+#   2. Clean case: an unassociated address tagged THIS RunId is released; exit 0.
+#   3. Idempotent: release-address returning InvalidAllocationID.NotFound = success.
+#   4. Still-associated tagged address = incomplete teardown = HARD FAIL, and the
+#      doomed release-address call is NOT attempted.
+#   5. Real release failure (AccessDenied, e.g. missing ec2:ReleaseAddress) = HARD FAIL.
+#   6. Scoping: an unassociated orphan tagged a DIFFERENT RunId is left untouched.
+#   7. Inverted sanity: terratest !success + 0 matches → warns (does not silently
+#      report clean), but does not itself fail.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WF="${REPO_ROOT}/.github/workflows/org-terratest.yml"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$WF" ] || fail "workflow not found at $WF"
+command -v jq   >/dev/null || fail "jq is required"
+command -v ruby >/dev/null || fail "ruby is required (YAML extraction)"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+# ---- Extract the inline sweep script from the YAML, verbatim. -----------------
+SWEEP="$WORK/sweep.sh"
+ruby -ryaml -e '
+  d = YAML.load_file(ARGV[0])
+  job = d.fetch("jobs").fetch("nat-eip-sweep")
+  step = job.fetch("steps").find { |s| s["name"] == "Sweep NAT EIPs belonging to this run" }
+  abort "sweep step not found" unless step
+  print step.fetch("run")
+' "$WF" > "$SWEEP" || fail "could not extract sweep step from $WF"
+[ -s "$SWEEP" ] || fail "extracted sweep script is empty"
+
+# ---- Mock aws: serves describe-regions / describe-addresses from env-pointed
+#      JSON files, records release-address allocation IDs to $AWS_TRACE, and
+#      returns a configurable error string for a given allocation. ----
+cat > "$BIN/aws" <<'MOCK'
+#!/usr/bin/env bash
+svc="$1"; cmd="$2"; shift 2
+case "$svc $cmd" in
+  "sts get-caller-identity")
+    echo '{"Arn":"arn:aws-us-gov:sts::358745275192:assumed-role/github-action-test-role/x"}' ;;
+  "ec2 describe-regions")
+    cat "$MOCK_REGIONS_JSON" ;;
+  "ec2 describe-addresses")
+    cat "$MOCK_ADDRESSES_JSON" ;;
+  "ec2 release-address")
+    # parse --allocation-id <id>
+    alloc=""
+    while [ $# -gt 0 ]; do [ "$1" = "--allocation-id" ] && { alloc="$2"; shift 2; continue; }; shift; done
+    printf '%s\n' "$alloc" >> "$AWS_TRACE"
+    if [ -n "${MOCK_RELEASE_ERR:-}" ]; then echo "$MOCK_RELEASE_ERR" >&2; exit 1; fi
+    ;;
+  *) echo "mock aws: unhandled '$svc $cmd'" >&2; exit 2 ;;
+esac
+MOCK
+chmod +x "$BIN/aws"
+
+REGIONS_OK="$WORK/regions_ok.json";   echo '{"Regions":[{"RegionName":"us-gov-west-1"}]}' > "$REGIONS_OK"
+REGIONS_EMPTY="$WORK/regions_empty.json"; echo '{"Regions":[]}' > "$REGIONS_EMPTY"
+
+# Build an addresses JSON: $1=AllocationId $2=RunId-tag-value $3=AssociationId(or "null")
+addr() {
+  local id="$1" rid="$2" assoc="$3"
+  local a='null'; [ "$assoc" != "null" ] && a="\"$assoc\""
+  printf '{"AllocationId":"%s","PublicIp":"1.2.3.4","AssociationId":%s,"Tags":[{"Key":"RunId","Value":"%s"}]}' "$id" "$a" "$rid"
+}
+addrs_json() { printf '{"Addresses":[%s]}' "$1" > "$2"; }
+
+RID="1000-1"  # matches env RUN_ID we pass in
+
+# run_sweep <summary> <regions_json> <addresses_json> <terratest_result>
+#   sets globals: RC, OUT (stdout+stderr), TRACE (released allocation ids)
+run_sweep() {
+  local regions="$2" addrs="$3" result="$4"
+  local trace="$WORK/trace.$$"; : > "$trace"
+  local summary="$WORK/summary.$$"; : > "$summary"
+  set +e
+  OUT="$(
+    PATH="$BIN:$PATH" \
+    MOCK_REGIONS_JSON="$regions" MOCK_ADDRESSES_JSON="$addrs" \
+    MOCK_RELEASE_ERR="${MOCK_RELEASE_ERR:-}" \
+    AWS_TRACE="$trace" \
+    RUN_ID="$RID" TERRATEST_RESULT="$result" AWS_REGION="us-gov-west-1" \
+    GITHUB_STEP_SUMMARY="$summary" \
+    bash "$SWEEP" 2>&1
+  )"
+  RC=$?
+  set -e
+  TRACE="$(cat "$trace")"
+}
+
+echo "== 1. positive control: 0 regions is a hard fail (not clean) =="
+addrs_json "" "$WORK/a.json"
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_EMPTY" "$WORK/a.json" "success"
+[ "$RC" -ne 0 ] || fail "1: empty describe-regions must FAIL, got exit 0 (silent-green)"
+echo "$OUT" | grep -q "control failed" || fail "1: expected control-failed error"
+# mutation: same input but a WORKING control (1 region) and no addresses → clean pass
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_OK" "$WORK/a.json" "success"
+[ "$RC" -eq 0 ] || fail "1(mut): working control + 0 tagged addresses should pass, got $RC"
+
+echo "== 2. clean case: unassociated + my RunId is released, exit 0 =="
+addrs_json "$(addr alloc-mine "$RID" null)" "$WORK/b.json"
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_OK" "$WORK/b.json" "success"
+[ "$RC" -eq 0 ] || fail "2: clean release should exit 0, got $RC"
+[ "$TRACE" = "alloc-mine" ] || fail "2: expected release of alloc-mine, trace='$TRACE'"
+
+echo "== 3. idempotent: NotFound counts as success =="
+addrs_json "$(addr alloc-gone "$RID" null)" "$WORK/c.json"
+MOCK_RELEASE_ERR="An error occurred (InvalidAllocationID.NotFound) when calling ReleaseAddress" \
+  run_sweep "" "$REGIONS_OK" "$WORK/c.json" "success"
+[ "$RC" -eq 0 ] || fail "3: InvalidAllocationID.NotFound must be success, got $RC"
+echo "$OUT" | grep -q "already released" || fail "3: expected 'already released' note"
+
+echo "== 4. still-associated = incomplete teardown = hard fail, NO release attempted =="
+addrs_json "$(addr alloc-assoc "$RID" eipassoc-123)" "$WORK/d.json"
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_OK" "$WORK/d.json" "failure"
+[ "$RC" -ne 0 ] || fail "4: associated address must FAIL, got exit 0"
+echo "$OUT" | grep -q "Incomplete teardown" || fail "4: expected incomplete-teardown error"
+[ -z "$TRACE" ] || fail "4: must NOT attempt release on an associated address, trace='$TRACE'"
+
+echo "== 5. real release failure (AccessDenied / missing ec2:ReleaseAddress) = hard fail =="
+addrs_json "$(addr alloc-denied "$RID" null)" "$WORK/e.json"
+MOCK_RELEASE_ERR="An error occurred (UnauthorizedOperation) when calling ReleaseAddress" \
+  run_sweep "" "$REGIONS_OK" "$WORK/e.json" "success"
+[ "$RC" -ne 0 ] || fail "5: a denied release must FAIL, got exit 0 (silent-green)"
+echo "$OUT" | grep -q "release failed" || fail "5: expected release-failed error"
+
+echo "== 6. scoping: an orphan tagged a DIFFERENT RunId is left untouched =="
+addrs_json "$(addr alloc-other 9999-9 null)" "$WORK/f.json"
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_OK" "$WORK/f.json" "success"
+[ "$RC" -eq 0 ] || fail "6: unrelated orphan should not fail us, got $RC"
+[ -z "$TRACE" ] || fail "6: must NOT touch an address tagged another run, trace='$TRACE'"
+
+echo "== 7. inverted sanity: terratest failed + 0 matches → warn, not silent-clean =="
+addrs_json "" "$WORK/g.json"
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_OK" "$WORK/g.json" "failure"
+[ "$RC" -eq 0 ] || fail "7: 0-match warn path should not itself fail, got $RC"
+echo "$OUT" | grep -q "selector may be broken" || fail "7: expected selector-may-be-broken warning"
+# mutation: terratest SUCCESS + 0 matches is the normal clean case → NO warning
+MOCK_RELEASE_ERR="" run_sweep "" "$REGIONS_OK" "$WORK/g.json" "success"
+echo "$OUT" | grep -q "selector may be broken" && fail "7(mut): must NOT warn on the clean success+0 case"
+
+echo "OK: nat-eip-sweep.test.sh — all invariants held and mutation-proven"

--- a/tests/terratest-rerun.test.sh
+++ b/tests/terratest-rerun.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Meta-test for the opt-in flake-rerun branch of the "Run Terratest" step in
+# .github/workflows/org-terratest.yml (#236 / WI-3.5).
+#
+# gotestsum has a hard constraint: in --rerun-fails mode the packages must come from
+# --packages and must NOT also be passed positionally after `--` (passing both is an
+# error). The single-attempt mode is the opposite: packages ARE positional and
+# --packages must be absent. A wrong branch here fails only at runtime on a live
+# apply, so this test extracts the step from the YAML and drives it through a mock
+# gotestsum that RECORDS its argv, asserting each mode invokes gotestsum correctly.
+# Mutation-oriented: the two modes must differ in exactly the packages-passing shape.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WF="${REPO_ROOT}/.github/workflows/org-terratest.yml"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$WF" ] || fail "workflow not found at $WF"
+command -v ruby >/dev/null || fail "ruby is required (YAML extraction)"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+RUN="$WORK/run.sh"
+ruby -ryaml -e '
+  d = YAML.load_file(ARGV[0])
+  step = d.fetch("jobs").fetch("terratest").fetch("steps").find { |s| s["name"] == "Run Terratest" }
+  abort "Run Terratest step not found" unless step
+  print step.fetch("run")
+' "$WF" > "$RUN" || fail "could not extract Run Terratest step"
+[ -s "$RUN" ] || fail "extracted run script is empty"
+
+# Mock gotestsum: record full argv, always succeed. Mock go/tee so the step body runs.
+cat > "$BIN/gotestsum" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\0' "$@" > "$GOTESTSUM_ARGV"
+exit 0
+MOCK
+chmod +x "$BIN/gotestsum"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/go"; chmod +x "$BIN/go"
+# real tee is fine; keep PATH's tee
+
+run_step() {
+  local rerun="$1"
+  local ws="$WORK/ws.$RANDOM"; mkdir -p "$ws/test"
+  : > "$ws/argv"
+  set +e
+  OUT="$(
+    PATH="$BIN:$PATH" \
+    GITHUB_WORKSPACE="$ws" GITHUB_OUTPUT="$ws/out" GOTESTSUM_ARGV="$ws/argv" \
+    TEST_DIR="test" TEST_TIMEOUT="30m" RERUN_FAILS="$rerun" \
+    bash "$RUN" 2>&1
+  )"
+  RC=$?
+  set -e
+  # argv as newline-joined (NUL-delimited -> lines) for grep
+  ARGV="$(tr '\0' '\n' < "$ws/argv")"
+}
+
+echo "== 1. default (rerun_fails=0): packages positional ./..., NO --rerun-fails, NO --packages =="
+run_step "0"
+[ "$RC" -eq 0 ] || fail "1: step should succeed, got $RC ($OUT)"
+printf '%s\n' "$ARGV" | grep -qx -- '--rerun-fails=0' && fail "1: must NOT pass --rerun-fails when disabled"
+printf '%s\n' "$ARGV" | grep -q -- '--rerun-fails' && fail "1: must NOT pass --rerun-fails when disabled"
+printf '%s\n' "$ARGV" | grep -q -- '--packages' && fail "1: must NOT pass --packages in single-attempt mode"
+printf '%s\n' "$ARGV" | grep -qx -- './...' || fail "1: single-attempt mode must pass ./... positionally"
+
+echo "== 2. rerun_fails=2: --rerun-fails=2 + --packages=./..., and ./... NOT also positional =="
+run_step "2"
+[ "$RC" -eq 0 ] || fail "2: step should succeed, got $RC ($OUT)"
+printf '%s\n' "$ARGV" | grep -qx -- '--rerun-fails=2' || fail "2: expected --rerun-fails=2"
+printf '%s\n' "$ARGV" | grep -qx -- '--packages=./...' || fail "2: expected --packages=./..."
+# In rerun mode ./... must NOT appear as a bare positional arg (that would be the gotestsum error).
+if printf '%s\n' "$ARGV" | grep -qx -- './...'; then
+  fail "2: ./... must NOT be a positional arg in rerun mode (gotestsum rejects packages given both ways)"
+fi
+
+echo "OK: terratest-rerun.test.sh — both invocation modes correct and mutation-proven"

--- a/tests/terratest-telemetry.test.sh
+++ b/tests/terratest-telemetry.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Meta-test for the "Emit telemetry record" step in
+# .github/workflows/org-terratest.yml (#235 / WI-2.2).
+#
+# Like the sweep test, the emit logic lives INLINE in the workflow run: body, so
+# this test EXTRACTS it from the YAML (it can never drift from what ships) and
+# runs it directly with a temp GITHUB_WORKSPACE and canned JUnit XML. Every
+# assertion is mutation-proven: we feed the input that SHOULD flip the outcome
+# and confirm it does.
+#
+# Invariants:
+#   1. Green XML + exit 0 → result=pass, counts computed (passed = tests-fail-err-skip).
+#   2. Failing XML + non-zero exit → result=fail, counts reflect failures.
+#   3. result is derived from the EXIT CODE, not the XML: a green-looking XML with a
+#      non-zero exit still records result=fail (silent-green guard).
+#   4. Killed run (no XML at all) → still emits a record, have_report=false,
+#      counts=null, keyed by the commit SHA (the run does not vanish).
+#   5. The record is valid JSON, schema-tagged, and keyed by the commit SHA.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WF="${REPO_ROOT}/.github/workflows/org-terratest.yml"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$WF" ] || fail "workflow not found at $WF"
+command -v jq   >/dev/null || fail "jq is required"
+command -v ruby >/dev/null || fail "ruby is required (YAML extraction)"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+EMIT="$WORK/emit.sh"
+ruby -ryaml -e '
+  d = YAML.load_file(ARGV[0])
+  step = d.fetch("jobs").fetch("terratest").fetch("steps").find { |s| s["name"] == "Emit telemetry record" }
+  abort "emit step not found" unless step
+  print step.fetch("run")
+' "$WF" > "$EMIT" || fail "could not extract emit step"
+[ -s "$EMIT" ] || fail "extracted emit script is empty"
+
+SHA="abc123def4567890abc123def4567890abc123de"
+
+# run_emit <xml-or-empty> <exit_code> ; sets RC, and RECORD (path to record json)
+run_emit() {
+  local xml="$1" exit_code="$2"
+  local ws="$WORK/ws.$RANDOM"; mkdir -p "$ws"
+  if [ -n "$xml" ]; then printf '%s' "$xml" > "$ws/terratest-results.xml"; fi
+  set +e
+  OUT="$(
+    GITHUB_WORKSPACE="$ws" \
+    RESULT_SHA="$SHA" RUN_REPO="Coalfire-CF/terraform-aws-demo" RUN_ID="42" RUN_ATTEMPT="1" \
+    RUN_URL="https://github.com/Coalfire-CF/terraform-aws-demo/actions/runs/42" \
+    TEST_MODE="pr" TEST_DIR="test" TF_VERSION="1.15.7" GO_VERSION="1.26" \
+    EXIT_CODE="$exit_code" \
+    bash "$EMIT" 2>&1
+  )"
+  RC=$?
+  set -e
+  RECORD="$ws/terratest-record.json"
+}
+
+XML_PASS='<testsuites tests="5" failures="0" errors="0" time="12.5"><testsuite skipped="1"></testsuite></testsuites>'
+XML_FAIL='<testsuites tests="5" failures="2" errors="1" time="30.0"><testsuite skipped="0"></testsuite></testsuites>'
+
+echo "== 1. green XML + exit 0 → pass, counts correct =="
+run_emit "$XML_PASS" "0"
+[ "$RC" -eq 0 ] || fail "1: emit should succeed, got $RC ($OUT)"
+[ "$(jq -r .result "$RECORD")" = "pass" ] || fail "1: result should be pass"
+[ "$(jq -r .counts.passed "$RECORD")" = "4" ] || fail "1: passed should be 5-0-0-1=4, got $(jq -r .counts.passed "$RECORD")"
+[ "$(jq -r .counts.skipped "$RECORD")" = "1" ] || fail "1: skipped should be 1"
+[ "$(jq -r .duration_seconds "$RECORD")" = "12.5" ] || fail "1: duration should be 12.5"
+
+echo "== 2. failing XML + non-zero exit → fail, counts reflect failures =="
+run_emit "$XML_FAIL" "1"
+[ "$RC" -eq 0 ] || fail "2: emit itself should still succeed, got $RC"
+[ "$(jq -r .result "$RECORD")" = "fail" ] || fail "2: result should be fail"
+[ "$(jq -r .counts.failures "$RECORD")" = "2" ] || fail "2: failures should be 2"
+[ "$(jq -r .counts.passed "$RECORD")" = "2" ] || fail "2: passed should be 5-2-1-0=2"
+
+echo "== 3. result derives from EXIT CODE, not XML (silent-green guard) =="
+run_emit "$XML_PASS" "1"   # green-looking XML but the gate exit was non-zero
+[ "$(jq -r .result "$RECORD")" = "fail" ] || fail "3: a green XML with non-zero exit must record fail"
+
+echo "== 4. killed run (no XML) still emits a record, have_report=false, counts=null =="
+run_emit "" "1"
+[ "$RC" -eq 0 ] || fail "4: emit should succeed even with no XML, got $RC ($OUT)"
+[ "$(jq -r .have_report "$RECORD")" = "false" ] || fail "4: have_report should be false"
+[ "$(jq -r '.counts == null' "$RECORD")" = "true" ] || fail "4: counts should be null with no report"
+[ "$(jq -r .commit_sha "$RECORD")" = "$SHA" ] || fail "4: record must still be keyed by the commit SHA"
+[ "$(jq -r .result "$RECORD")" = "fail" ] || fail "4: no-XML + non-zero exit is a fail"
+
+echo "== 5. record is valid, schema-tagged, SHA-keyed JSON =="
+run_emit "$XML_PASS" "0"
+jq -e 'type=="object"' "$RECORD" >/dev/null || fail "5: not a JSON object"
+[ "$(jq -r .schema "$RECORD")" = "terratest-posture/v1" ] || fail "5: schema tag missing"
+[ "$(jq -r .commit_sha "$RECORD")" = "$SHA" ] || fail "5: not keyed by commit SHA"
+[ "$(jq -r .repo "$RECORD")" = "Coalfire-CF/terraform-aws-demo" ] || fail "5: repo missing"
+
+echo "OK: terratest-telemetry.test.sh — record emission correct and mutation-proven"


### PR DESCRIPTION
Resolves the org-terratest issue cluster. **Every workflow change is opt-in** — gated on an
unset input/variable = clean skip, so no existing caller (~18 repos) changes behavior at its
next run. Companion telemetry lands in `Coalfire-CF/MTCS#<posture PR>`.

## What ships here

- **#237** — opt-in `environment:` input; when set, the credentialed job pauses for a
  protected-Environment review before any cloud step runs.
- **#273** — `nat-eip-sweep` job ported from `terraform-aws-vpc-nfw#216` so all callers inherit
  the `if:always()` run-scoped NAT-EIP net (opt-in via `enable_nat_eip_sweep` + AWS role).
  Positive control, still-associated = hard fail, denied release = hard fail, idempotent — no
  silent-green.
- **#235** — durable `terratest-record.json` telemetry keyed by commit SHA (replaces the dead
  `terratest-results.json`); SHA-stamped artifact + step summary.
- **#236** — opt-in `rerun_fails` (gotestsum `--rerun-fails`), quarantine convention, and a
  staggered weekly non-gating scheduled-run template.
- **Runbook** (`docs/ORG_TERRATEST_HARDENING_RUNBOOK.md`) for the privileged steps that can't be
  code: mint the dedicated `coalfire-terratest` App (#231), create the `terratest-gov`
  Environment, verify `ec2:ReleaseAddress`.

#234 is backstopped for now by the #273 net + documented manual break-glass; a follow-up tracks
the janitor network-scope handler. #231's docs shipped; its App mint is in the runbook.

## Pull Request Checklist

### Types of changes
- [x] :sparkle: New feature (non-breaking change which adds functionality)

### Testing
- [x] **Required:** I have tested the proposed changes. Three mutation-proven meta-tests
  (`tests/nat-eip-sweep.test.sh` 7/7, `tests/terratest-telemetry.test.sh` 5/5,
  `tests/terratest-rerun.test.sh`) extract the inline workflow logic and drive it through mocks;
  actionlint + markdownlint clean. Live cloud proof (`ec2:ReleaseAddress`) is a documented
  post-merge operator step (a clean run never exercises release — can't be proven on paper).
- [x] **Required:** GitHub Actions — will run on this PR.

#### Tested:
- [x] Locally

### Documentation
- [x] Updated `docs/ORG_TERRATEST.md` and `docs/ORG_TERRATEST_PROVISIONING.md`.
- [x] In-line comments explain each opt-in gate and safety property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)