### PR TITLE
chore(ci): create-github-app-token: app-id → client-id

### DIFF
--- a/.github/workflows/org-caliper.yml
+++ b/.github/workflows/org-caliper.yml
@@ -126,7 +126,7 @@ jobs:
         # token dies with the job. Mirrors org-terraform-validate's pattern.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_TF_PULL_PRIVATE_APP_CLIENTID }}
+          client-id: ${{ secrets.CF_TF_PULL_PRIVATE_APP_CLIENTID }}
           private-key: ${{ secrets.CF_TF_PULL_PRIVATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: caliper
@@ -301,7 +301,7 @@ jobs:
         if: steps.provisioned.outputs.ready == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CF_TF_PULL_PRIVATE_APP_CLIENTID }}
+          client-id: ${{ secrets.CF_TF_PULL_PRIVATE_APP_CLIENTID }}
           private-key: ${{ secrets.CF_TF_PULL_PRIVATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: caliper

--- a/.github/workflows/org-release-clean.yml
+++ b/.github/workflows/org-release-clean.yml
@@ -118,7 +118,7 @@ jobs:
       if: steps.check-app.outputs.available == 'true'
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.RELEASE_APP_ID }}
+        client-id: ${{ secrets.RELEASE_APP_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
     - name: Create clean archive

--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -223,7 +223,7 @@ jobs:
         if: steps.check-app.outputs.available == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Run Release Please
@@ -269,7 +269,7 @@ jobs:
         if: steps.check-app.outputs.available == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout Actions repo (decision script)

--- a/.github/workflows/org-terraform-apply.yml
+++ b/.github/workflows/org-terraform-apply.yml
@@ -186,7 +186,7 @@ jobs:
         if: steps.check-app-secrets.outputs.has_secrets == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TF_APPLY_APP_CLIENT_ID }}
+          client-id: ${{ secrets.TF_APPLY_APP_CLIENT_ID }}
           private-key: ${{ secrets.TF_APPLY_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/org-terraform-plan.yml
+++ b/.github/workflows/org-terraform-plan.yml
@@ -173,7 +173,7 @@ jobs:
         if: steps.check-app-secrets.outputs.has_secrets == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TF_PLAN_APP_CLIENT_ID }}
+          client-id: ${{ secrets.TF_PLAN_APP_CLIENT_ID }}
           private-key: ${{ secrets.TF_PLAN_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -100,7 +100,7 @@ jobs:
       if: steps.check-secrets.outputs.has_secrets == 'true'
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.TF_VALIDATE_APP_CLIENT_ID }}
+        client-id: ${{ secrets.TF_VALIDATE_APP_CLIENT_ID }}
         private-key: ${{ secrets.TF_VALIDATE_APP_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     

--- a/.github/workflows/org-terraform-version-check.yml
+++ b/.github/workflows/org-terraform-version-check.yml
@@ -46,7 +46,7 @@ jobs:
         if: steps.check-app.outputs.has_app == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.TF_VERSION_APP_ID }}
+          client-id: ${{ secrets.TF_VERSION_APP_ID }}
           private-key: ${{ secrets.TF_VERSION_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
         if: steps.check-app.outputs.available == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Run Release Please


### PR DESCRIPTION
## Summary

Renames the `app-id:` input to `client-id:` on `actions/create-github-app-token` steps.

Files changed:
- `.github/workflows/org-caliper.yml` (2 occurrences)
- `.github/workflows/org-release-clean.yml` (1 occurrence)
- `.github/workflows/org-release.yml` (2 occurrences)
- `.github/workflows/org-terraform-apply.yml` (1 occurrence)
- `.github/workflows/org-terraform-plan.yml` (1 occurrence)
- `.github/workflows/org-terraform-validate.yml` (1 occurrence)
- `.github/workflows/org-terraform-version-check.yml` (1 occurrence)
- `.github/workflows/release.yml` (1 occurrence)

## Why

In `actions/create-github-app-token` v3, `action.yml` marks the `app-id` input as deprecated:

> `deprecationMessage: "Use 'client-id' instead."`

The same secret value works unchanged — GitHub accepts either the numeric App ID or the App's
Client ID as the JWT issuer, so this is a pure input-key rename with **no behavior change**.
(Several of these steps already pass a secret named `*_CLIENT_ID`, so the new key is also the
more accurate label for what is being passed.)

Today this is **warning-only** — the workflows still succeed. This clears the deprecation notice
before a future major version removes the old key.

**Caller-invisible.** This changes an input *consumed by* the `actions/create-github-app-token` step inside these reusable workflows. It does not alter any `workflow_call` input, output, secret name, or the `uses:` ref of any action. Downstream repos that pin this repo by release tag or SHA are unaffected and need no change; existing pins keep working, and pins picking up this commit see identical behavior.

## Scope / safety

- Only `app-id` inputs on `actions/create-github-app-token` steps pinned to **v3 or newer** were touched.
  `client-id` does **not exist** in v1/v2 of the action (and `app-id` is `required: true` in v2), so
  renaming on an older pin would break the run. Occurrences on v1/v2 pins were deliberately left alone.
- No `uses:` ref, SHA pin, comment, secret name, or spacing was changed — the diff is the input key only.

## Testing

No runtime behavior change; the deprecated and new key are accepted interchangeably by v3. Verified
statically that every renamed line sits inside a `uses: actions/create-github-app-token@<v3+>` step's
`with:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Pull Request Checklist

> Take your time to read through these, don't just click through them. Only check the boxes if they apply.

## Admin
<!--- Ensure  -->
- [ ] **Required:** I have read the [contributing guidelines](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/2648440862/Pull+Request+Best+Practices) for submitting a PR.

## Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkle: New feature (non-breaking change which adds functionality)
- [ ] :collision: Breaking change (fix or feature that would cause existing functionality to change)

## Testing
- [ ] **Required:** I have tested the proposed changes to code (i.e. `packer build`, `terraform apply`), and they are working.
- [ ] **Required:** All GitHub Actions ran successfully. If they didn't, I left a note in the description to address this.
- [ ] **Optional:** I have already applied/deployed the changes in my environment.

#### Please check where this code has been tested:
- [ ] Locally
- [ ] Customer Environment
- [ ] Coalfire Sandbox Environment (AWS GovCloud, Azure Gov, GCP, etc.)

## Documentation
- [ ] **Optional, recommended:** I have updated ***`README.md`***.
- [ ] **Optional, recommended:** I have updated documentation in ***Confluence/Organization's relevant Wiki***.
- [ ] **Optional, recommended:** I left comments ***in-line in the code*** to help others understand the changes.

## Tagging / Assigning
- [ ] **Required:** I have tagged a ***Reviewer(s)***.
- [ ] **Required:** I have tagged an ***Assignee(s)***.
- [ ] **Optional:** I have tagged relevant stakeholders in a ***Comment***.