### PR TITLE
docs: re-point terratest-janitor to its new home + document the janitor=false tag

### DIFF
--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -335,12 +335,21 @@ Two automated backstops cover this gap so it does not depend on manual disciplin
 1. **Per-run net — the `if: always()` NAT-EIP sweep** (opt-in `enable_nat_eip_sweep`). Runs
    in a separate job, on cancellation too, and releases the run's own orphaned NAT Elastic IPs.
    See [Run-scoped resource tagging](#run-scoped-resource-tagging-and-the-nat-eip-sweep).
-1. **Scheduled reaper — [`terraform-aws-terratest-janitor`](https://github.com/Coalfire-CF/terraform-aws-terratest-janitor)**
-   is the authoritative standing backstop for everything the per-run net does not cover
-   (non-EIP resources, a `SIGKILL` before the sweep job runs, cross-cloud). It is an hourly,
-   account-allowlisted Lambda that sweeps abandoned prefix-cohorts (a cohort is reaped only when
-   **every** timestamped sibling is older than `abandon_hours`, so an active run is never raced)
-   and alerts loudly on both action and failure.
+1. **Scheduled reaper — [`terratest-janitor`](https://github.com/Coalfire-CF/cs-aws-lab-management/tree/main/tools/terratest-janitor)**
+   (formerly the standalone `terraform-aws-terratest-janitor` repo, now folded into
+   `cs-aws-lab-management/tools/terratest-janitor`) is the authoritative standing backstop for
+   everything the per-run net does not cover (non-EIP resources, a `SIGKILL` before the sweep job
+   runs, cross-cloud). It is an hourly, account-allowlisted Lambda that sweeps abandoned
+   prefix-cohorts (a cohort is reaped only when **every** timestamped sibling is older than
+   `abandon_hours`, so an active run is never raced) and alerts loudly on both action and failure.
+
+   **One class has no prefix fence: ACM Private CAs.** A CA has no prefix-able name, so the cohort
+   rule cannot protect it and the reaper judges it on **age alone** — which is how it deleted a
+   production root CA sharing an allowlisted account, hourly, until fixed. A CA tagged
+   `janitor=false` is now skipped outright (key and value stripped, case-insensitive), and a CA
+   whose tags cannot be read is skipped too (fail closed). **If a long-lived resource shares a
+   janitor-allowlisted account, tag it `janitor=false` — and note that tag is honored for ACM PCA
+   only; every other class is still fenced by the test-prefix rule alone.**
 
 **Break-glass (only if the backstops are unavailable):** manually sweep the test account by
 tag/prefix. For the AWS GovCloud account, check for leaked:

--- a/docs/ORG_TERRATEST_HARDENING_RUNBOOK.md
+++ b/docs/ORG_TERRATEST_HARDENING_RUNBOOK.md
@@ -105,13 +105,15 @@ unassociated addresses tagged that `RunId`.
 ## 2b. Extend the janitor to the general terratest account (#234)
 
 **This is a sub-project, not a config edit — flag before starting.** The existing
-`terraform-aws-terratest-janitor` Lambda has scope-specific handlers (`security`, `pca`) covering
+`terratest-janitor` Lambda (in `cs-aws-lab-management/tools/terratest-janitor`) has
+scope-specific handlers (`security`, `pca`) covering
 Config/GuardDuty/CloudTrail/IAM/KMS/S3/logs and Security-Hub/ACM-PCA respectively. The general
 terratest account (`358745275192`) creates **VPC + subnets + NAT + route tables + Network
 Firewall + flow-log roles/policies + KMS aliases + log groups + S3** residue — the network
 classes are **not** covered by either existing handler. Extending the janitor therefore means:
 
-1. Author a new scope (e.g. `network`/`general`) handler in `modules/janitor/lambda` that reaps
+1. Author a new scope (e.g. `network`/`general`) handler in
+   `tools/terratest-janitor/modules/janitor/lambda` that reaps
    the VPC-dependency + NFW + flow-log classes, keyed on the same prefix-cohort-abandonment
    safety model (a cohort is swept only when every timestamped sibling is older than
    `abandon_hours`; hard account allowlist twice; loud-on-action-and-failure SNS).


### PR DESCRIPTION
`Coalfire-CF/terraform-aws-terratest-janitor` has been folded into `Coalfire-CF/cs-aws-lab-management` under `tools/terratest-janitor/` (consolidation PR: Coalfire-CF/cs-aws-lab-management#27). It should never have been a standalone repo. **The standalone has since been DELETED** (not archived), so the links this PR replaces are now dangling 404s rather than merely stale, and the consolidation PR will be the only remote copy of the janitor's source.

**Nothing sourced it as a Terraform module** — an org-wide code search found no `source = ".../terraform-aws-terratest-janitor"` anywhere, and the repo has no tags or releases — so only documentation references change. This is the `Coalfire-CF/Actions` half.

## Changes

**`docs/ORG_TERRATEST.md`** — the "Scheduled reaper" backstop entry:
- link re-pointed to `cs-aws-lab-management/tree/main/tools/terratest-janitor`, with the old repo name kept in the text so the rename is searchable
- **added the safety detail operators actually need**: ACM Private CAs have no prefix-able name, so the prefix-cohort rule cannot fence them and the reaper judges them on **age alone**. That is how it deleted a production root CA that shared a janitor-allowlisted account — every hour, despite the CA being correctly tagged. A CA tagged `janitor=false` is now skipped outright (key and value stripped, case-insensitive) and a CA whose tags cannot be read is skipped too (fail closed). The doc now also says plainly that **`janitor=false` is honored for ACM PCA only** — every other class is still fenced by the test-prefix rule alone — so nobody assumes the tag is a universal opt-out.

**`docs/ORG_TERRATEST_HARDENING_RUNBOOK.md` §2b** ("Extend the janitor to the general terratest account", #234) — re-points the repo name and the `modules/janitor/lambda` path that the sub-project instructions tell an implementer to edit. Those instructions would otherwise send someone to a path in an archived repo.

## Verification

`markdownlint-cli2@0.23.0` clean under the org config for both files. Docs-only; no workflow or action behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
