### PR TITLE
fix(dependabot): collapse per-directory module fan-out with group-by

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,13 +22,25 @@ updates:
         update-types: ["minor", "patch"]
   # npm (#204): this repo ships package.json + package-lock.json (markdownlint-cli2),
   # which org-dependabot.yml maps to the npm ecosystem — so the dogfood must declare
-  # it too, or advisories against the pinned tree open no bump PRs. The generator
-  # emits groups only for github-actions (the Coalfire-CF/* first-party split does
-  # not apply to npm), so npm is a plain block; majors arrive as singleton PRs.
+  # it too, or advisories against the pinned tree open no bump PRs. Mirrors the
+  # generator's non-actions shape: directories: (plural) + group-by: dependency-name,
+  # so a dependency spanning multiple dirs collapses into one PR instead of one PR
+  # per directory. No update-types -> majors are included; group-by keeps each PR to
+  # a single dependency, so a major only blocks its own PR at the auto-merge gate.
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      npm:
+        applies-to: version-updates
+        group-by: dependency-name
+        patterns: ["*"]
+      npm-security:
+        applies-to: security-updates
+        group-by: dependency-name
+        patterns: ["*"]

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -269,13 +269,32 @@ jobs:
               # Resolve the dep/* label for this ecosystem
               local dep_label="${ECOSYSTEM_LABELS[$ecosystem]:-dep/other}"
 
+              # Collect the non-excluded dirs for this ecosystem
+              local kept_dirs=()
               for d in "${dirs[@]}"; do
                 if is_excluded "$d"; then
                   log "  Excluding $ecosystem: $d (matched exclude pattern)"
                   continue
                 fi
-                has_entries=true
-                cat <<YAML
+                kept_dirs+=("$d")
+              done
+              if (( ${#kept_dirs[@]} == 0 )); then
+                continue
+              fi
+              has_entries=true
+
+              if [[ "$ecosystem" == "github-actions" ]]; then
+                # github-actions is forced to "/" (one dir, no fan-out). Keep the
+                # singular directory: entry + the two-group split verbatim.
+                # Group version bumps (minor+patch only — majors stay
+                # individually-reviewable singletons; the pipeline gates them
+                # regardless). TWO homogeneous groups: org callers score 0 on
+                # OpenSSF Scorecard (no data), and the first-party waiver is
+                # all-must-match — a mixed group would chronically block on
+                # low-scorecard. Split groups keep waiver semantics coherent.
+                # NOTE: keep this groups block byte-identical to the fleet injector's.
+                for d in "${kept_dirs[@]}"; do
+                  cat <<YAML
             - package-ecosystem: "${ecosystem}"
               directory: "${d}"
               schedule:
@@ -287,15 +306,6 @@ jobs:
               labels:
                 - "${dep_label}"
           YAML
-                # Group github-actions version bumps (minor+patch only —
-                # majors stay individually-reviewable singletons; the pipeline
-                # gates them regardless). TWO homogeneous groups: org callers
-                # score 0 on OpenSSF Scorecard (no data), and the first-party
-                # waiver is all-must-match — a mixed group would chronically
-                # block on low-scorecard. Split groups keep waiver semantics
-                # coherent by construction.
-                # NOTE: keep this block byte-identical to the fleet injector's.
-                if [[ "$ecosystem" == "github-actions" ]]; then
                   cat <<'YAML'
               groups:
                 org-actions:
@@ -308,9 +318,45 @@ jobs:
                   exclude-patterns: ["Coalfire-CF/*"]
                   update-types: ["minor", "patch"]
           YAML
-                fi
-                log "  Found ${ecosystem} in ${d}"
-              done
+                  log "  Found ${ecosystem} in ${d}"
+                done
+              else
+                # Every other ecosystem: ONE entry listing all dirs under
+                # directories: (plural) with group-by: dependency-name, so a
+                # dependency referenced in real + example + test dirs collapses
+                # into a single PR instead of one PR per directory. No
+                # update-types -> majors are included; group-by keeps each PR to
+                # one dependency, so a major only blocks its own PR at the gate.
+                local directories_block=""
+                for d in "${kept_dirs[@]}"; do
+                  directories_block+="      - \"${d}\""$'\n'
+                done
+                directories_block="${directories_block%$'\n'}"
+                cat <<YAML
+            - package-ecosystem: "${ecosystem}"
+              directories:
+          ${directories_block}
+              schedule:
+                interval: "${DEFAULT_INTERVAL}"
+                time: "${STAGGER_TIME}"
+              commit-message:
+                prefix: "chore"
+                include: "scope"
+              labels:
+                - "${dep_label}"
+              groups:
+                ${ecosystem}:
+                  applies-to: version-updates
+                  group-by: dependency-name
+                  patterns: ["*"]
+                ${ecosystem}-security:
+                  applies-to: security-updates
+                  group-by: dependency-name
+                  patterns: ["*"]
+          YAML
+                log "  Found ${ecosystem} in ${#kept_dirs[@]} dir(s)"
+              fi
+
             done
 
             # If no entries were found, emit an empty list so YAML stays valid

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Issue labels:
     |-- auto-merge-decide.test.sh
     |-- cache-integrity.test.sh
     |-- cache-read.test.sh
+    |-- dependabot-refresh.test.sh
     |-- example-pin-check.test.sh
     |-- fixtures
     |   |-- auto-merge-decide

--- a/tests/dependabot-refresh.test.sh
+++ b/tests/dependabot-refresh.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Meta-test for the Dependabot config generator embedded in
+# .github/workflows/org-dependabot.yml.
+#
+# The generator body is an embedded <<'BASH' heredoc (it runs in the consumer
+# checkout, so it can't source from Actions at runtime). This test extracts that
+# heredoc, strips the 10-space YAML block-scalar indent, and runs it against
+# fixture trees to prove:
+#   1. Non-github-actions ecosystems collapse every manifest-bearing directory
+#      into ONE entry with `directories:` (plural) + `group-by: dependency-name`,
+#      so a dependency in real + example + test dirs lands as one PR, not N.
+#   2. github-actions stays byte-identical (singular `directory: "/"` + its
+#      org-actions/third-party split, majors excluded).
+#   3. Output is deterministic (idempotent re-runs -> zero diff).
+#   4. The empty-repo `[]` fallback still emits valid YAML.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WF="${REPO_ROOT}/.github/workflows/org-dependabot.yml"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---- portability: the STAGGER slot uses sha256sum (absent on macOS) ----
+SHIM="${WORK}/shim"; mkdir -p "$SHIM"
+if ! command -v sha256sum >/dev/null 2>&1; then
+  printf '#!/usr/bin/env bash\nshasum -a 256 "$@"\n' > "${SHIM}/sha256sum"
+  chmod +x "${SHIM}/sha256sum"
+fi
+export PATH="${SHIM}:${PATH}"
+
+# ---- extract the embedded script and strip the 10-space block-scalar indent ----
+SCRIPT="${WORK}/dependabot_refresh.sh"
+awk '
+  /cat > \/tmp\/dependabot_refresh\.sh <<'"'"'BASH'"'"'/ {grab=1; next}
+  grab && /^          BASH[[:space:]]*$/ {grab=0}
+  grab {print}
+' "$WF" | sed 's/^          //' > "$SCRIPT"
+[ -s "$SCRIPT" ] || fail "failed to extract embedded generator script from $WF"
+
+render() {
+  # render <repo_root> <out_file>
+  local root="$1" out="$2"
+  REPO_ROOT="$root" DEPB_PATH="$out" GITHUB_REPOSITORY="Coalfire-CF/terraform-aws-example" \
+    bash "$SCRIPT" >/dev/null 2>&1 || true
+  [ -f "$out" ] || fail "generator produced no file at $out"
+}
+
+# ---- fixture: same module family across real + example + test dirs, plus 2 npm dirs ----
+FX="${WORK}/repo"
+mkdir -p "${FX}/examples/complete" "${FX}/test/fixtures/foo" "${FX}/frontend" "${FX}/.github/workflows"
+cat > "${FX}/versions.tf" <<'EOF'
+terraform { required_providers { aws = { source = "hashicorp/aws", version = "5.0.0" } } }
+module "vpc" { source = "terraform-aws-modules/vpc/aws" version = "5.0.0" }
+EOF
+cp "${FX}/versions.tf" "${FX}/examples/complete/main.tf"
+cp "${FX}/versions.tf" "${FX}/test/fixtures/foo/main.tf"
+echo '{"name":"root"}' > "${FX}/package.json"
+echo '{"name":"frontend"}' > "${FX}/frontend/package.json"
+printf 'name: ci\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps: []\n' > "${FX}/.github/workflows/ci.yml"
+
+OUT="${WORK}/out.yml"
+render "$FX" "$OUT"
+
+countc() { grep -c "$1" "$OUT" | tr -d ' '; }
+
+# 1. exactly one entry per ecosystem (fan-out collapsed)
+[ "$(countc 'package-ecosystem: "terraform"')" = "1" ] || fail "expected exactly 1 terraform entry"
+[ "$(countc 'package-ecosystem: "npm"')" = "1" ]       || fail "expected exactly 1 npm entry"
+[ "$(countc 'package-ecosystem: "github-actions"')" = "1" ] || fail "expected 1 github-actions entry"
+
+# 2. only github-actions uses singular `directory:`; terraform+npm use plural `directories:`
+[ "$(grep -cE '^    directory:' "$OUT")" = "1" ]   || fail "expected exactly 1 singular 'directory:' (github-actions)"
+[ "$(grep -cE '^    directories:' "$OUT")" = "2" ] || fail "expected 2 plural 'directories:' (terraform + npm)"
+
+# 3. terraform lists all three dirs under one entry
+grep -q '      - "/examples/complete"' "$OUT"  || fail "terraform missing /examples/complete in directories list"
+grep -q '      - "/test/fixtures/foo"' "$OUT"  || fail "terraform missing /test/fixtures/foo in directories list"
+
+# 4. group-by: dependency-name on both non-actions ecosystems (2 groups each = 4)
+[ "$(countc 'group-by: dependency-name')" = "4" ] || fail "expected 4 group-by lines (terraform x2 + npm x2)"
+[ "$(countc 'applies-to: security-updates')" = "2" ] || fail "expected a security-updates group per non-actions ecosystem"
+
+# 5. non-actions groups omit update-types (majors included). Only the two
+#    github-actions groups carry update-types, so a global count of 2 proves it.
+[ "$(countc 'update-types:')" = "2" ] || fail "update-types must appear ONLY on the 2 github-actions groups"
+
+# 6. github-actions block byte-unchanged (org-actions/third-party split intact)
+grep -q 'org-actions:' "$OUT" || fail "github-actions org-actions group missing"
+grep -q 'exclude-patterns: \["Coalfire-CF/\*"\]' "$OUT" || fail "github-actions third-party exclude missing"
+
+echo "OK: fan-out collapsed — terraform/npm one grouped entry across dirs; github-actions unchanged"
+
+# ---- determinism: same inputs -> byte-identical output ----
+OUT2="${WORK}/out2.yml"
+render "$FX" "$OUT2"
+diff -q "$OUT" "$OUT2" >/dev/null || fail "non-deterministic: two renders of the same tree differ"
+echo "OK: deterministic — repeated renders are byte-identical"
+
+# ---- empty-repo fallback: valid YAML with an empty updates list ----
+EMPTY="${WORK}/empty"; mkdir -p "$EMPTY"
+OUT3="${WORK}/empty.yml"
+render "$EMPTY" "$OUT3"
+grep -q '^updates:' "$OUT3" || fail "empty-repo output missing 'updates:'"
+grep -qE '^\s*\[\]' "$OUT3" || fail "empty-repo output missing '[]' fallback"
+echo "OK: empty repo emits valid 'updates: []' fallback"
+
+# ---- best-effort YAML validity (skipped if no parser available) ----
+if command -v yq >/dev/null 2>&1; then
+  yq eval '.updates | length' "$OUT" >/dev/null || fail "yq could not parse generated YAML"
+  echo "OK: yq parses the generated dependabot.yml"
+elif python3 -c 'import yaml' >/dev/null 2>&1; then
+  python3 -c 'import sys,yaml; yaml.safe_load(open(sys.argv[1]))' "$OUT" || fail "PyYAML could not parse generated YAML"
+  echo "OK: PyYAML parses the generated dependabot.yml"
+else
+  echo "SKIP: no yq / PyYAML available for semantic YAML validation"
+fi
+
+echo "ALL OK: dependabot-refresh generator produces grouped, cross-directory config"


### PR DESCRIPTION
## Summary

Consumer repos get 5-7 Dependabot PRs for a single module/provider bump because the
same dependency is referenced in real code, `examples/*`, and `test/*`, and the fleet
generator emitted one entry per directory (singular `directory:`) with grouping applied
only to `github-actions`.

Non-`github-actions` ecosystems now emit **one** entry with `directories:` (plural) listing
every kept directory, plus two `group-by: dependency-name` groups (version and security
updates). `group-by: dependency-name` is the key that consolidates a dependency across
directories into a single PR. Verified against GitHub docs: without it, a multi-directory
group still opens one PR per directory. No `update-types`, so majors are included; because
`group-by: dependency-name` keeps each PR to one dependency, a major only blocks its own PR
at the auto-merge gate. `github-actions` is unchanged, preserving the byte-identical groups
block shared with the fleet injector and bootstrap template.

Refs:
- <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
- <https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/>

## Files

- `.github/workflows/org-dependabot.yml` - generator emission loop (primary)
- `.github/dependabot.yml` - npm block mirrors the new shape (dogfood)
- `tests/dependabot-refresh.test.sh` - extracts the embedded generator script, renders it
  against a fixture tree, asserts the collapse, determinism, and the empty-repo `[]` fallback

## Rollout note (read before merging the release)

The generator is `workflow_call`, not scheduled. This config reaches a repo when its
`Coalfire-CF/Actions` pin bumps, and the regenerated `dependabot.yml` is committed onto that
first-party PR, which the `org-actions` group auto-merges. So the flip lands without human
review and triggers a one-time close/recreate of that repo's open Dependabot PRs. Pilot on
one real terraform consumer repo (with open Dependabot PRs) before cutting the release:
confirm one PR across dirs, assert exactly one dependency per non-actions PR, and confirm a
real security advisory still opens a PR (check the Dependabot job log, not just YAML
validity). Rollback is per-repo (revert the committed `dependabot.yml`).

## Types of changes
- [x] :bug: Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] **Required:** Tested locally: rendered the generator against a fixture tree; terraform
  (3 dirs) and npm (2 dirs) each collapse to one grouped entry, github-actions unchanged,
  YAML parses. New test passes; `auto-merge-decide` and `reconcile-sweeper` still pass;
  `actionlint` clean.
- [ ] **Required:** All GitHub Actions ran successfully. (Will confirm on CI.)

#### Please check where this code has been tested:
- [x] Locally
