### PR TITLE
fix(supply-chain): evaluate OSV GitHub Actions range advisories locally (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Issue labels:
     |-- retry-lib.test.sh
     |-- source-pin-check.test.sh
     |-- stagger-slot.test.sh
+    |-- supply-chain-osv-range.test.sh
     |-- terratest-rerun.test.sh
     |-- terratest-telemetry.test.sh
     |-- tree-readme-section.test.sh

--- a/scripts/supply-chain-check.sh
+++ b/scripts/supply-chain-check.sh
@@ -61,6 +61,85 @@ AGG_SC_PASS="true"
 AGG_SC_SCORE=""
 AGG_CACHE_HIT="true"
 
+# osv_range_verdict <dep> <osv_ecosystem> <version> — issue #153 fallback.
+# The versioned /v1/query is blind to GitHub Actions advisories that encode
+# affected versions as a RANGE with an empty versions[] array. This re-queries
+# OSV WITHOUT a version and evaluates affected[].ranges locally against
+# <version>. It mutates OSV_CLEAR / OSV_VULNS / CHECK_ERRORS in check_one:
+#   affected      -> OSV_CLEAR=false, OSV_VULNS = matching advisories (hard block)
+#   clear         -> no change (only older versions were in range)
+#   indeterminate -> CHECK_ERRORS++ (a range we can't order — e.g. a SHA/pre-release
+#                    target, or a GIT-type range — routes to manual review, fail closed)
+# Version ordering handles numeric git tags (0, 41, 46.0.1), which is what OSV
+# GitHub Actions ranges use; anything non-numeric is treated as unevaluable.
+osv_range_verdict() {
+  local dep="$1" eco="$2" ver="$3" pkg_payload pkg_response result verdict ids
+  pkg_payload=$(jq -n --arg pkg "$dep" --arg eco "$eco" \
+    '{package: {name: $pkg, ecosystem: $eco}}')
+  if ! pkg_response=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
+    http_retryable --max-time 30 \
+    -X POST "https://api.osv.dev/v1/query" \
+    -H "Content-Type: application/json" \
+    -d "$pkg_payload"); then
+    echo "::warning::OSV package-only query FAILED for ${dep} — failing closed"
+    CHECK_ERRORS=$((CHECK_ERRORS + 1))
+    return
+  fi
+  result=$(printf '%s' "$pkg_response" | jq -c --arg ver "$ver" --arg pkg "$dep" --arg eco "$eco" '
+    def parts($s):
+      ($s | ltrimstr("v")) as $c
+      | if ($c | test("^[0-9]+(\\.[0-9]+)*$")) then ($c | split(".") | map(tonumber)) else null end;
+    ($ver | parts(.)) as $vp
+    | def hit($r):
+        if ($r.type != "ECOSYSTEM" and $r.type != "SEMVER") then "indeterminate"
+        elif $vp == null then "indeterminate"
+        else
+          ((([$r.events[] | .introduced | values])[0]) // "0") as $introS
+          | (([$r.events[] | .fixed | values])[0]) as $fixedS
+          | (([$r.events[] | .last_affected | values])[0]) as $laS
+          | parts($introS) as $intro
+          | (if $fixedS == null then null else parts($fixedS) end) as $fixed
+          | (if $laS == null then null else parts($laS) end) as $la
+          | if ($intro == null) or ($fixedS != null and $fixed == null) or ($laS != null and $la == null)
+              then "indeterminate"
+            elif ($vp >= $intro)
+                 and ( ($fixed != null and $vp < $fixed)
+                       or ($la != null and $vp <= $la)
+                       or ($fixed == null and $la == null) )
+              then "affected"
+            else "clear" end
+        end;
+      [ .vulns[] as $v
+        | ($v.affected // [])[]
+        | select(.package.name == $pkg and .package.ecosystem == $eco)
+        | { id: $v.id,
+            hits: ( [ (.ranges // [])[] | hit(.) ]
+                    + [ if ((.versions // []) | any(. == $ver)) then "affected" else empty end ] ) }
+      ] as $per
+      | [ $per[].hits[] ] as $all
+      | if ($all | any(. == "affected"))
+          then { verdict: "affected", ids: [ $per[] | select(.hits | any(. == "affected")) | .id ] }
+        elif ($all | any(. == "indeterminate"))
+          then { verdict: "indeterminate", ids: [] }
+        else { verdict: "clear", ids: [] } end
+  ' 2>/dev/null) || result=""
+  verdict=$(printf '%s' "$result" | jq -r '.verdict // "indeterminate"' 2>/dev/null || echo "indeterminate")
+  case "$verdict" in
+    affected)
+      OSV_CLEAR="false"
+      ids=$(printf '%s' "$result" | jq -c '.ids')
+      OSV_VULNS=$(printf '%s' "$pkg_response" | jq --argjson ids "$ids" \
+        '[.vulns[] | select(.id as $i | $ids | index($i))]')
+      echo "::warning::Found range-based known vulnerabilities for ${dep}@${ver} (ids: $(printf '%s' "$result" | jq -r '.ids | join(",")'))"
+      ;;
+    clear) : ;;
+    *)
+      echo "::warning::OSV range advisory for ${dep} could not be evaluated for version ${ver} — failing closed to manual review"
+      CHECK_ERRORS=$((CHECK_ERRORS + 1))
+      ;;
+  esac
+}
+
 check_one() {
 local DEP_NAME="$1" TO_VERSION="$2"
 # Per-dependency error baseline (#194/H1): if THIS dependency's checks error, we
@@ -135,6 +214,7 @@ if [ "$CACHE_HIT" = "false" ]; then
       --arg ver "$TO_VERSION" \
       --arg eco "$OSV_ECOSYSTEM" \
       '{package: {name: $pkg, ecosystem: $eco}, version: $ver}')
+    OSV_QUERY_OK="true"
     if ! OSV_RESPONSE=$(with_retry "$RETRY_MAX" "$RETRY_BASE" "$RETRY_CAP" -- \
       http_retryable --max-time 30 \
       -X POST "https://api.osv.dev/v1/query" \
@@ -143,12 +223,24 @@ if [ "$CACHE_HIT" = "false" ]; then
       echo "::warning::OSV query FAILED for ${DEP_NAME}@${TO_VERSION} — failing closed"
       CHECK_ERRORS=$((CHECK_ERRORS + 1))
       OSV_RESPONSE='{"vulns":[]}'
+      OSV_QUERY_OK="false"
     fi
     OSV_VULNS=$(echo "$OSV_RESPONSE" | jq '.vulns // []')
     VULN_COUNT=$(echo "$OSV_VULNS" | jq 'length')
     if [ "$VULN_COUNT" -gt 0 ]; then
       OSV_CLEAR="false"
       echo "::warning::Found ${VULN_COUNT} known vulnerabilities for ${DEP_NAME}@${TO_VERSION}"
+    elif [ "$OSV_QUERY_OK" = "true" ] && [ "$OSV_ECOSYSTEM" = "GitHub Actions" ]; then
+      # Issue #153: the versioned /v1/query above is BLIND to GitHub Actions
+      # advisories that encode affected versions as a RANGE with an empty
+      # versions[] array (e.g. GHSA-mrrh-fwg8-r2c3, the tj-actions/changed-files
+      # compromise). OSV can't order git-tag versions server-side, so a
+      # version-included query never matches that class and the gate stays
+      # clear on a known-bad bump. Re-query WITHOUT the version and evaluate the
+      # ranges locally. Scoped to GitHub Actions: ecosystems OSV can order
+      # (npm/PyPI/Go/...) already get correct server-side range matching from
+      # the fast path, so they keep the single-call behaviour.
+      osv_range_verdict "$DEP_NAME" "$OSV_ECOSYSTEM" "$TO_VERSION"
     fi
   else
     echo "No OSV ecosystem mapping for '${ECOSYSTEM}' — skipping OSV check"

--- a/tests/supply-chain-osv-range.test.sh
+++ b/tests/supply-chain-osv-range.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# supply-chain-osv-range.test.sh — issue #153
+#
+# The OSV known-vuln gate queried POST /v1/query with {package, version}. For
+# the GitHub Actions ecosystem, advisories that encode affected versions as a
+# RANGE with an empty versions[] array (e.g. GHSA-mrrh-fwg8-r2c3, the
+# tj-actions/changed-files compromise) never match a version-included query —
+# OSV can't order git-tag versions server-side. So blocked/known-vuln could
+# never fire on that advisory class.
+#
+# Fix (direction #3): keep the fast versioned query; when it returns empty AND
+# the ecosystem is GitHub Actions, re-query WITHOUT the version and evaluate
+# affected[].ranges locally against the target version.
+#
+# The mock curl below distinguishes the two OSV calls by whether the POST body
+# carries a "version" field, so these cases genuinely exercise the fallback:
+# delete the fallback and case 1/3 flip to osv_clear=true (mutation-proof).
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUPPLY="${REPO_ROOT}/scripts/supply-chain-check.sh"
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -f "$SUPPLY" ] || fail "supply-chain-check.sh not found at $SUPPLY"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+# fake aws: S3 cp only (up/down against $FAKE_S3_DIR); everything else is a no-op.
+cat > "$BIN/aws" <<'AWS'
+#!/usr/bin/env bash
+set -u
+key_to_path() { printf '%s' "$1" | sed 's#[/:]#_#g'; }
+svc="$1"; shift
+if [ "$svc" = "s3" ] && [ "${1:-}" = "cp" ]; then
+  src="$2"; dst="$3"
+  if [[ "$src" == s3://* ]]; then
+    key="${src#s3://*/}"; f="$FAKE_S3_DIR/$(key_to_path "$key")"
+    [ -f "$f" ] && { cp "$f" "$dst"; exit 0; }; exit 1
+  elif [[ "$dst" == s3://* ]]; then
+    key="${dst#s3://*/}"; mkdir -p "$FAKE_S3_DIR"
+    cp "$src" "$FAKE_S3_DIR/$(key_to_path "$key")"
+    [ -n "${UPLOAD_LOG:-}" ] && printf '%s\n' "$key" >> "$UPLOAD_LOG"
+  fi
+fi
+exit 0
+AWS
+chmod +x "$BIN/aws"
+
+# fake curl: emit `body\ncode`. The OSV branch splits on the POST -d payload:
+# a body carrying "version" is the fast versioned query (returns empty here);
+# a body without it is the package-only range query (returns the advisories).
+cat > "$BIN/curl" <<'CURL'
+#!/usr/bin/env bash
+set -u
+url=""; data=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "-d" ] && data="$a"
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$url" in
+  *api.osv.dev*)
+    case "$data" in
+      *'"version"'*) printf '%s\n%s' "${OSV_VER_BODY:-{\"vulns\":[]\}}" "200" ;;
+      *)             printf '%s\n%s' "${OSV_PKG_BODY:-{\"vulns\":[]\}}" "200" ;;
+    esac ;;
+  *securityscorecards.dev*) printf '%s\n%s' "${SC_BODY:-{\"score\":9.5\}}" "200" ;;
+  *) printf '\n000' ;;
+esac
+CURL
+chmod +x "$BIN/curl"
+
+# Real tj-actions/changed-files advisories (trimmed): both ECOSYSTEM ranges with
+# an empty versions[] — GHSA-mcph fixed at 41, GHSA-mrrh fixed at 46.0.1.
+PKG_BODY='{"vulns":[
+  {"id":"GHSA-mcph-m25j-8j63","affected":[{"package":{"name":"tj-actions/changed-files","ecosystem":"GitHub Actions"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"41"}]}]}]},
+  {"id":"GHSA-mrrh-fwg8-r2c3","affected":[{"package":{"name":"tj-actions/changed-files","ecosystem":"GitHub Actions"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"},{"fixed":"46.0.1"}]}]}]}
+]}'
+
+b64() { printf '%b' "$1" | base64 | tr -d '\n'; }
+
+# run_case <name> <to_version> : drive one dep bump, echo "<osv_clear> <check_errors>"
+run_case() {
+  local to="$2" gho="$WORK/gho_$1" s3="$WORK/s3_$1"
+  mkdir -p "$s3"; : > "$gho"
+  (
+    export PATH="$BIN:$PATH" FAKE_S3_DIR="$s3" GITHUB_OUTPUT="$gho"
+    export S3_BUCKET=test-bucket CACHE_TTL_DAYS=30 SCORECARD_THRESHOLD=7
+    export ECOSYSTEM=github-actions RETRY_MAX=1 JITTER_MAX_SECONDS=0
+    local deps; deps="$(b64 "tj-actions/changed-files\t0\t${to}\n")"
+    export DEPS_B64="$deps"
+    export OSV_VER_BODY='{"vulns":[]}' OSV_PKG_BODY="$PKG_BODY" SC_BODY='{"score":9.5}'
+    bash "$SUPPLY" >>"$WORK/log_$1" 2>&1
+  ) || fail "$1: script aborted: $(cat "$WORK/log_$1")"
+  echo "$(grep '^osv_clear=' "$gho" | tail -1 | cut -d= -f2) $(grep '^check_errors=' "$gho" | tail -1 | cut -d= -f2)"
+}
+
+# Case 1: bump to v40 — in range of BOTH advisories (< 41). Versioned query is
+# blind; the range fallback must block.
+r=$(run_case affected 40)
+[ "$r" = "false 0" ] || fail "#153 case1: v40 is range-affected, expected 'false 0', got '$r'"
+echo "OK: #153 range-affected version (v40) blocks via package-only fallback"
+
+# Case 2: bump to v46.0.1 — the fix version for mrrh and past mcph's fix. No
+# range contains it: must stay clear, no manual-review noise.
+r=$(run_case fixed 46.0.1)
+[ "$r" = "true 0" ] || fail "#153 case2: v46.0.1 is fixed, expected 'true 0', got '$r'"
+echo "OK: #153 fixed version (v46.0.1) stays clear (no false positive)"
+
+# Case 3: bump to v46.0.0 — still inside mrrh's range (< 46.0.1). Must block.
+r=$(run_case boundary 46.0.0)
+[ "$r" = "false 0" ] || fail "#153 case3: v46.0.0 is range-affected, expected 'false 0', got '$r'"
+echo "OK: #153 boundary version (v46.0.0) blocks (< fixed 46.0.1)"
+
+# Case 4: an unparseable target version with a live range advisory can't be
+# range-evaluated — fail closed to manual review (check_errors), not auto-clear.
+r=$(run_case indeterminate "deadbeef")
+[ "$r" = "true 1" ] || fail "#153 case4: unparseable version, expected 'true 1' (manual review), got '$r'"
+echo "OK: #153 unevaluable version fails closed to manual review (check_errors=1)"
+
+echo "ALL OK: supply-chain-osv-range"


### PR DESCRIPTION
Closes #153.

## Problem

The auto-merge supply-chain gate's OSV check queries `POST /v1/query` with `{package, version}`. For the GitHub Actions ecosystem, advisories that express affected versions as a RANGE with an empty `versions[]` array never match a version-included query: OSV cannot order git-tag versions server-side, so it returns no match for any version. `blocked/known-vuln` could therefore never fire on that advisory class, and a Dependabot bump TO a range-flagged malicious action version would pass the vuln gate.

Confirmed live against `tj-actions/changed-files` (the GHSA-mrrh-fwg8-r2c3 compromise): a versioned query for v40 returns 0 vulns, but two ECOSYSTEM-range advisories exist (fixed at 41 and 46.0.1).

## Fix

Issue direction #3: keep the fast versioned query. Only when it returns empty AND the ecosystem is GitHub Actions, re-query WITHOUT the version and evaluate `affected[].ranges` locally against the target version.

- **affected** (`introduced <= target < fixed`, or `<= last_affected`) -> `osv_clear=false`, hard block, advisory ids attached to the reason
- **clear** (only older versions were in range) -> unchanged
- **indeterminate** (a range we cannot order: a SHA or pre-release target, or a GIT-type range) -> `check_errors++`, fail closed to manual review

Ecosystems OSV can order (npm/PyPI/Go/...) already get correct server-side range matching from the fast path, so they keep the single-call behaviour. GitHub Actions clean bumps now cost one extra OSV call.

## Testing

- `tests/supply-chain-osv-range.test.sh` (new): drives the real tj-actions advisories through a mock that distinguishes the versioned and package-only OSV calls. Cases: v40 and v46.0.0 block, v46.0.1 stays clear (no false positive), an unparseable target fails closed to manual review. Deleting the fallback flips the affected cases to clear (mutation-proof).
- Verified the range evaluator against **live** OSV data: v40/v45/v46.0.0 -> affected, v46.0.1/v47 -> clear.
- Regression: `cache-integrity`, `cache-read`, `auto-merge-decide` all pass.

## Types of changes
- [x] :bug: Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have tested the proposed changes to code, and they are working.

#### Please check where this code has been tested:
- [x] Locally