### PR TITLE
docs(pr-template): add bracketed tips and fix the info link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ## Summary
 
-<!-- What does this change, and why? 1-3 sentences. -->
+{Quick summary of what this PR does and why. If it is a breaking change or adds new behavior, say what consumers need to do. Delete the braces when done.}
 
-Closes #
+Closes #{issue number, or delete this line if none}
 
 ## Type of change
 
@@ -13,14 +13,14 @@ Closes #
 
 ## How this was tested
 
-<!-- Commands run and where. e.g. `terraform apply` in Coalfire sandbox, terratest, packer build. -->
+{Commands you ran and where. e.g. `terraform apply` in a Coalfire sandbox, `terratest`, `packer build`. Note anything a reviewer should re-run.}
 
 ## Checklist
 
 - [ ] I understand these changes and have tested them; they work as described (not pasted in unreviewed).
 - [ ] All GitHub Actions passed, or I noted any failures above.
 - [ ] `README.md` / relevant docs updated if behavior changed.
-- [ ] PR title follows conventional-commit format (feeds release-please routing).
+- [ ] PR title follows the [standard commit format](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) (feeds release-please routing).
 - [ ] Reviewer and assignee tagged.
 
-<sub>See the [PR best-practices guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/2648440862/Pull+Request+Best+Practices) before submitting.</sub>
+<sub>New to the process? See the [Release Process guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) for commit and PR standards.</sub>

--- a/templates/bootstrap/common/.github/PULL_REQUEST_TEMPLATE.md.tmpl
+++ b/templates/bootstrap/common/.github/PULL_REQUEST_TEMPLATE.md.tmpl
@@ -1,8 +1,8 @@
 ## Summary
 
-<!-- What does this change, and why? 1-3 sentences. -->
+{Quick summary of what this PR does and why. If it is a breaking change or adds new behavior, say what consumers need to do. Delete the braces when done.}
 
-Closes #
+Closes #{issue number, or delete this line if none}
 
 ## Type of change
 
@@ -13,14 +13,14 @@ Closes #
 
 ## How this was tested
 
-<!-- Commands run and where. e.g. `terraform apply` in Coalfire sandbox, terratest, packer build. -->
+{Commands you ran and where. e.g. `terraform apply` in a Coalfire sandbox, `terratest`, `packer build`. Note anything a reviewer should re-run.}
 
 ## Checklist
 
 - [ ] I understand these changes and have tested them; they work as described (not pasted in unreviewed).
 - [ ] All GitHub Actions passed, or I noted any failures above.
 - [ ] `README.md` / relevant docs updated if behavior changed.
-- [ ] PR title follows conventional-commit format (feeds release-please routing).
+- [ ] PR title follows the [standard commit format](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) (feeds release-please routing).
 - [ ] Reviewer and assignee tagged.
 
-<sub>See the [PR best-practices guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/2648440862/Pull+Request+Best+Practices) before submitting.</sub>
+<sub>New to the process? See the [Release Process guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) for commit and PR standards.</sub>


### PR DESCRIPTION
## Summary

Follow-up polish on the refreshed PR template:

- The additional-info link pointed at an archived page. Swapped it for the current [Release Process guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) (footer + the commit-format checklist item), reworded around the standard commit format.
- Replaced the invisible HTML-comment hints with visible `{braced}` guidance in Summary / Closes / How this was tested, so authors see the prompt inline and delete the braces as they fill it in.
- Kept `.github/PULL_REQUEST_TEMPLATE.md` and the org-repo-bootstrap bundle copy identical.

## Type of change

- [x] Docs / chore

## How this was tested

- markdownlint clean; `tests/repo-bootstrap.test.sh` still passes (bundle still 9 files); both files byte-identical.

## Checklist

- [x] I understand these changes and have tested them; they work as described.