### PR TITLE
fix(pr-template): wrap lines <=100 for strict-MD013 consumer repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ## Summary
 
-{Quick summary of what this PR does and why. If it is a breaking change or adds new behavior, say what consumers need to do. Delete the braces when done.}
+{Quick summary of what this PR does and why. If it is a breaking change or adds
+new behavior, note what consumers need to do. Delete the braces when done.}
 
 Closes #{issue number, or delete this line if none}
 
@@ -13,14 +14,17 @@ Closes #{issue number, or delete this line if none}
 
 ## How this was tested
 
-{Commands you ran and where. e.g. `terraform apply` in a Coalfire sandbox, `terratest`, `packer build`. Note anything a reviewer should re-run.}
+{Commands you ran and where, e.g. `terraform apply` in a Coalfire sandbox,
+`terratest`, `packer build`. Note anything a reviewer should re-run.}
 
 ## Checklist
 
-- [ ] I understand these changes and have tested them; they work as described (not pasted in unreviewed).
+- [ ] I understand these changes and have tested them; they work (not pasted in unreviewed).
 - [ ] All GitHub Actions passed, or I noted any failures above.
 - [ ] `README.md` / relevant docs updated if behavior changed.
-- [ ] PR title follows the [standard commit format](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) (feeds release-please routing).
+- [ ] PR title uses the [standard commit format][rp] (feeds release-please).
 - [ ] Reviewer and assignee tagged.
 
-<sub>New to the process? See the [Release Process guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) for commit and PR standards.</sub>
+<sub>New to the process? See the [Release Process guide][rp] for commit and PR standards.</sub>
+
+[rp]: https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process

--- a/scripts/pr-template-sweep.sh
+++ b/scripts/pr-template-sweep.sh
@@ -75,20 +75,44 @@ for name in "${REPO_LIST[@]}"; do
     opened=$((opened+1)); continue
   fi
 
-  # Default branch head sha, create branch, update file, open PR.
+  # ---- Idempotent, branch-aware delivery: converge whatever partial state exists. ----
   base="$(gh api "repos/${repo}" --jq '.default_branch')"
-  base_sha="$(gh api "repos/${repo}/git/ref/heads/${base}" --jq '.object.sha')"
-  gh api -X POST "repos/${repo}/git/refs" -f ref="refs/heads/${BRANCH}" -f sha="${base_sha}" >/dev/null 2>&1 \
-    || log "  branch ${BRANCH} may already exist on ${repo}; continuing"
 
-  if ! gh api -X PUT "repos/${repo}/contents/${TARGET_PATH}" \
-        -f message="chore: refresh PR template" \
-        -f content="${NEW_B64}" \
-        -f sha="${file_sha}" \
-        -f branch="${BRANCH}" >/dev/null 2>&1; then
-    log "ERROR ${repo} — contents PUT failed"; errors=$((errors+1)); continue
+  # If the working branch already exists, update the file against ITS current sha
+  # (a re-run after a partial sweep); otherwise create the branch off the default head.
+  br_meta="$(gh api "repos/${repo}/contents/${TARGET_PATH}?ref=${BRANCH}" --jq '{sha:.sha, content:(.content|gsub("\n";""))}' 2>/dev/null || true)"
+  br_file_sha="$(printf '%s' "$br_meta" | jq -r '.sha // empty' 2>/dev/null || true)"
+  if [ -n "$br_file_sha" ]; then
+    # Branch exists. Skip the PUT if it already carries the canonical content.
+    br_norm="$(printf '%s' "$br_meta" | jq -r '.content // empty' | base64 -d 2>/dev/null | base64 | tr -d '\n')"
+    if [ "$br_norm" = "$NEW_B64" ]; then
+      put_sha="SKIP"
+    else
+      put_sha="$br_file_sha"
+    fi
+  else
+    base_sha="$(gh api "repos/${repo}/git/ref/heads/${base}" --jq '.object.sha')"
+    if ! gh api -X POST "repos/${repo}/git/refs" -f ref="refs/heads/${BRANCH}" -f sha="${base_sha}" >/dev/null 2>&1; then
+      log "ERROR ${repo} — could not create branch ${BRANCH}"; errors=$((errors+1)); continue
+    fi
+    put_sha="$file_sha"   # sha of the file on the default branch
   fi
 
+  if [ "$put_sha" != "SKIP" ]; then
+    if ! gh api -X PUT "repos/${repo}/contents/${TARGET_PATH}" \
+          -f message="chore: refresh PR template" \
+          -f content="${NEW_B64}" \
+          -f sha="${put_sha}" \
+          -f branch="${BRANCH}" >/dev/null 2>&1; then
+      log "ERROR ${repo} — contents PUT failed"; errors=$((errors+1)); continue
+    fi
+  fi
+
+  # Open a PR only if one is not already open for this branch (idempotent re-runs).
+  existing_pr="$(gh pr list --repo "${repo}" --head "${BRANCH}" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+  if [ -n "$existing_pr" ]; then
+    log "UPDATED ${repo} — refreshed existing PR #${existing_pr}"; opened=$((opened+1)); continue
+  fi
   if gh pr create --repo "${repo}" --base "${base}" --head "${BRANCH}" \
        --title "${PR_TITLE}" \
        --body "Standardizes \`${TARGET_PATH}\` to the current org default (summary-first, trimmed checklist). Opened by scripts/pr-template-sweep.sh." >/dev/null 2>&1; then

--- a/templates/bootstrap/common/.github/PULL_REQUEST_TEMPLATE.md.tmpl
+++ b/templates/bootstrap/common/.github/PULL_REQUEST_TEMPLATE.md.tmpl
@@ -1,6 +1,7 @@
 ## Summary
 
-{Quick summary of what this PR does and why. If it is a breaking change or adds new behavior, say what consumers need to do. Delete the braces when done.}
+{Quick summary of what this PR does and why. If it is a breaking change or adds
+new behavior, note what consumers need to do. Delete the braces when done.}
 
 Closes #{issue number, or delete this line if none}
 
@@ -13,14 +14,17 @@ Closes #{issue number, or delete this line if none}
 
 ## How this was tested
 
-{Commands you ran and where. e.g. `terraform apply` in a Coalfire sandbox, `terratest`, `packer build`. Note anything a reviewer should re-run.}
+{Commands you ran and where, e.g. `terraform apply` in a Coalfire sandbox,
+`terratest`, `packer build`. Note anything a reviewer should re-run.}
 
 ## Checklist
 
-- [ ] I understand these changes and have tested them; they work as described (not pasted in unreviewed).
+- [ ] I understand these changes and have tested them; they work (not pasted in unreviewed).
 - [ ] All GitHub Actions passed, or I noted any failures above.
 - [ ] `README.md` / relevant docs updated if behavior changed.
-- [ ] PR title follows the [standard commit format](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) (feeds release-please routing).
+- [ ] PR title uses the [standard commit format][rp] (feeds release-please).
 - [ ] Reviewer and assignee tagged.
 
-<sub>New to the process? See the [Release Process guide](https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process) for commit and PR standards.</sub>
+<sub>New to the process? See the [Release Process guide][rp] for commit and PR standards.</sub>
+
+[rp]: https://coalfire.atlassian.net/wiki/spaces/CEHOME/pages/3496312888/Release+Process


### PR DESCRIPTION
## Summary

Follow-up fix. The braced-tips template merged in #292 has lines up to 175 chars. The Actions repo and the org md-lint default both set `MD013: false`, so it passed here and on ~37 of the 38 fleet PRs, but repos that ship their own `.markdownlint-cli2.jsonc` re-enabling `MD013: {line_length: 100}` (e.g. `cs-delta`) failed md-lint.

- Wrap the braced hints and use a reference-style link (`[rp]`) for the Release Process URL; longest line is now 95. Verified against a strict MD013:100 config.
- Make `scripts/pr-template-sweep.sh` idempotent (update existing branch against its own sha, reuse open PR) so the partially-run sweep can be re-driven to convergence.

## Type of change

- [x] Bug fix (non-breaking)

## How this was tested

- Strict `markdownlint-cli2 --config MD013:100` on the template: 0 issues, max line 95.
- Live canary on `cs-delta` #150 (the strict repo that failed): branch updated in place, md-lint now passes.
- shellcheck clean; `tests/repo-bootstrap.test.sh` passes (bundle still 9 files).