### PR TITLE
feat(terraform-docs): remove orphaned generated content from partials

### DIFF
--- a/scripts/terraform-docs-partial-cleanup.sh
+++ b/scripts/terraform-docs-partial-cleanup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# terraform-docs-partial-cleanup.sh — remove ORPHANED generated content from
+# _header.md / _footer.md.
+#
+# Some repos carried a stale terraform-docs block OUTSIDE their BEGIN/END markers
+# (an older generator, or the pre-commit-terraform docs hook with its own
+# markers). The marker split correctly preserved that text as authored prose, so
+# the migrated README shows Requirements/Providers/Modules/Resources/Inputs/
+# Outputs TWICE: once stale from the partial, once freshly generated.
+#
+# This removes only the orphaned copies. It is REMOVAL-ONLY by construction: the
+# output is asserted to be no longer than the input, and the removed line count is
+# reported so a human can check it.
+#
+# What it removes:
+#   1  a pre-commit-terraform docs hook block, marker to marker. The opening
+#      marker is spelled "BEGINNING OF", not "BEGIN OF".
+#   2  a `## <generated-section>` heading plus its table, but ONLY when that
+#      table really looks generated: `<a name="..."` anchors, or a
+#      registry.terraform.io link, which is what the Resources table uses.
+#   3  a `## Tree` section, retired fleet-wide.
+#
+# The patterns are written literally inside the awk program on purpose. Passing
+# them with `awk -v` silently corrupts them: awk processes escape sequences in a
+# -v value, so `\]` and `\(` lose their backslashes, the regex becomes invalid,
+# awk exits non-zero, and the caller sees "nothing to remove".
+#
+# Usage:
+#   terraform-docs-partial-cleanup.sh <file>...              rewrite in place
+#   CHECK=true terraform-docs-partial-cleanup.sh <file>...    report only
+set -uo pipefail
+
+CHECK="${CHECK:-false}"
+[ "$#" -gt 0 ] || { echo "usage: $0 [CHECK=true] <file>..." >&2; exit 2; }
+
+AWK_PROG='
+function flush_pending() { for (i = 1; i <= np; i++) print pending[i]; np = 0 }
+BEGIN { mode = "copy"; np = 0; nrem = 0 }
+
+# 1. pre-commit-terraform docs hook block
+mode == "copy" && /<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->/ { mode = "pchook"; nrem++; next }
+mode == "pchook" { nrem++; if ($0 ~ /<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->/) mode = "copy"; next }
+
+# 3. Tree section, up to the next h1/h2
+mode == "copy" && /^## +Tree[ \t]*$/ { mode = "tree"; nrem++; next }
+mode == "tree" { if ($0 ~ /^##? +/) { mode = "copy" } else { nrem++; next } }
+
+# 2. generated section: buffer the heading, decide once the table appears
+mode == "copy" && /^## (Requirements|Providers|Modules|Resources|Inputs|Outputs)[ \t]*$/ {
+  mode = "maybe"; np = 0; pending[++np] = $0; held = 1; next
+}
+mode == "maybe" {
+  if ($0 ~ /^[ \t]*$/ || $0 ~ /^\|/) {
+    pending[++np] = $0
+    if ($0 ~ /<a name="(requirement|provider|module|resource|input|output)_/) generated = 1
+    if ($0 ~ /\]\(https:\/\/registry\.terraform\.io\//) generated = 1
+    next
+  }
+  if (generated) { nrem += np } else { flush_pending() }
+  generated = 0; np = 0; held = 0; mode = "copy"
+  if ($0 ~ /^## (Requirements|Providers|Modules|Resources|Inputs|Outputs)[ \t]*$/) { mode = "maybe"; pending[++np] = $0; held = 1; next }
+  if ($0 ~ /^## +Tree[ \t]*$/) { mode = "tree"; nrem++; next }
+  print; next
+}
+
+mode == "copy" { print }
+
+END {
+  if (mode == "maybe") { if (generated) nrem += np; else flush_pending() }
+  print "___REMOVED___" nrem > "/dev/stderr"
+}
+'
+
+rc=0
+for f in "$@"; do
+  [ -f "$f" ] || { echo "not a file: $f" >&2; rc=1; continue; }
+  err="$(mktemp)"
+  if ! out="$(awk "$AWK_PROG" "$f" 2>"$err")"; then
+    echo "REFUSING ${f}: awk failed: $(tr -d '\n' < "$err" | head -c 200)" >&2
+    rm -f "$err"; rc=1; continue
+  fi
+  n_removed="$(sed -n 's/^___REMOVED___//p' "$err")"
+  rm -f "$err"
+  # An unparseable count means the program did not reach END; never write then.
+  case "$n_removed" in
+    ""|*[!0-9]*) echo "REFUSING ${f}: no removal count reported" >&2; rc=1; continue ;;
+  esac
+
+  in_lines="$(wc -l < "$f" | tr -d ' ')"
+  out_lines="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+  if [ "$out_lines" -gt "$in_lines" ]; then
+    echo "REFUSING ${f}: output ${out_lines} > input ${in_lines}, must be removal-only" >&2
+    rc=1; continue
+  fi
+
+  if [ "$n_removed" -eq 0 ]; then
+    echo "  ${f}: nothing to remove"
+    continue
+  fi
+  echo "  ${f}: removed ${n_removed} line(s) of orphaned generated content (${in_lines} -> ${out_lines})"
+  [ "$CHECK" = "true" ] || printf '%s\n' "$out" > "$f"
+done
+exit "$rc"

--- a/scripts/terraform-docs-partial-cleanup.sh
+++ b/scripts/terraform-docs-partial-cleanup.sh
@@ -34,6 +34,9 @@ set -uo pipefail
 CHECK="${CHECK:-false}"
 [ "$#" -gt 0 ] || { echo "usage: $0 [CHECK=true] <file>..." >&2; exit 2; }
 
+# The `$0` and `$1` below are awk fields, not shell parameters, so the single
+# quotes are required and SC2016 does not apply.
+# shellcheck disable=SC2016
 AWK_PROG='
 function flush_pending() { for (i = 1; i <= np; i++) print pending[i]; np = 0 }
 BEGIN { mode = "copy"; np = 0; nrem = 0 }

--- a/tests/terraform-docs-partial-cleanup.test.sh
+++ b/tests/terraform-docs-partial-cleanup.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/terraform-docs-partial-cleanup.sh.
+#
+# This script deletes lines from authored partials, so the assertions that matter
+# are the ones proving it does NOT delete too much. Every check is mutation-proved:
+# the false-positive guard uses a table that is deliberately NOT generated and
+# asserts it survives.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CLEANUP="${REPO_ROOT}/scripts/terraform-docs-partial-cleanup.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+[ -x "$CLEANUP" ] || fail "cleanup script missing or not executable: ${CLEANUP}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+checks=0
+
+# ---------------------------------------------------------------------------
+# 1. An orphaned generated section is removed; prose before AND after survives.
+# ---------------------------------------------------------------------------
+cat > "${TMP}/a.md" <<'MD'
+# Title
+
+Keep this intro.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
+
+## Contributing
+
+Keep this outro.
+MD
+bash "$CLEANUP" "${TMP}/a.md" >/dev/null || fail "cleanup exited non-zero on a.md"
+grep -q '^## Requirements' "${TMP}/a.md" && fail "generated heading survived"
+grep -q 'requirement_terraform' "${TMP}/a.md" && fail "generated table row survived"
+grep -q 'Keep this intro.' "${TMP}/a.md" || fail "prose BEFORE the orphan was deleted"
+grep -q 'Keep this outro.' "${TMP}/a.md" || fail "prose AFTER the orphan was deleted"
+grep -q '^## Contributing' "${TMP}/a.md" || fail "heading after the orphan was deleted"
+checks=$((checks + 5))
+echo "OK: orphaned generated section removed, surrounding prose intact"
+
+# ---------------------------------------------------------------------------
+# 2. FALSE-POSITIVE GUARD. An AUTHORED table under a generated-looking heading
+#    must survive, because it carries no generated signature. Without this the
+#    script would silently eat hand-written tables.
+# ---------------------------------------------------------------------------
+cat > "${TMP}/b.md" <<'MD'
+## Inputs
+
+| Setting | Meaning |
+|---------|---------|
+| retention | how long we keep logs |
+
+## Notes
+
+after
+MD
+cp "${TMP}/b.md" "${TMP}/b.orig"
+bash "$CLEANUP" "${TMP}/b.md" >/dev/null || fail "cleanup exited non-zero on b.md"
+cmp -s "${TMP}/b.orig" "${TMP}/b.md" \
+  || fail "an AUTHORED table under '## Inputs' was modified; it has no generated marker"
+checks=$((checks + 1))
+echo "OK: authored table under a generated-style heading is left untouched"
+
+# ---------------------------------------------------------------------------
+# 3. The Resources table is generated via registry links, not <a name=>.
+# ---------------------------------------------------------------------------
+cat > "${TMP}/c.md" <<'MD'
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+
+## Keep
+
+kept
+MD
+bash "$CLEANUP" "${TMP}/c.md" >/dev/null || fail "cleanup exited non-zero on c.md"
+grep -q 'registry.terraform.io' "${TMP}/c.md" && fail "generated Resources table survived"
+grep -q '^## Keep' "${TMP}/c.md" || fail "heading after Resources was deleted"
+checks=$((checks + 2))
+echo "OK: generated Resources table detected via its registry link"
+
+# ---------------------------------------------------------------------------
+# 4. pre-commit-terraform hook block. The opening marker is "BEGINNING OF".
+# ---------------------------------------------------------------------------
+cat > "${TMP}/d.md" <<'MD'
+before
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+junk
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+after
+MD
+bash "$CLEANUP" "${TMP}/d.md" >/dev/null || fail "cleanup exited non-zero on d.md"
+grep -q 'PRE-COMMIT-TERRAFORM' "${TMP}/d.md" && fail "hook markers survived"
+grep -q '^before$' "${TMP}/d.md" || fail "text before the hook block was deleted"
+grep -q '^after$'  "${TMP}/d.md" || fail "text after the hook block was deleted"
+checks=$((checks + 3))
+echo "OK: pre-commit-terraform hook block removed, surrounding text intact"
+
+# ---------------------------------------------------------------------------
+# 5. Tree section removed, following heading kept.
+# ---------------------------------------------------------------------------
+printf '## Tree\n\n```text\n.\n|-- main.tf\n```\n\n## After\n\nkept\n' > "${TMP}/e.md"
+bash "$CLEANUP" "${TMP}/e.md" >/dev/null || fail "cleanup exited non-zero on e.md"
+grep -q '^## Tree' "${TMP}/e.md" && fail "Tree heading survived"
+grep -q 'main.tf' "${TMP}/e.md" && fail "Tree body survived"
+grep -q '^## After' "${TMP}/e.md" || fail "heading after Tree was deleted"
+checks=$((checks + 3))
+echo "OK: Tree section removed, following heading kept"
+
+# ---------------------------------------------------------------------------
+# 6. A clean file is untouched, and the script is idempotent.
+# ---------------------------------------------------------------------------
+printf '# Title\n\nJust prose.\n' > "${TMP}/f.md"
+cp "${TMP}/f.md" "${TMP}/f.orig"
+bash "$CLEANUP" "${TMP}/f.md" >/dev/null || fail "cleanup exited non-zero on a clean file"
+cmp -s "${TMP}/f.orig" "${TMP}/f.md" || fail "a clean file was modified"
+cp "${TMP}/a.md" "${TMP}/a.second"
+bash "$CLEANUP" "${TMP}/a.second" >/dev/null || fail "second pass exited non-zero"
+cmp -s "${TMP}/a.md" "${TMP}/a.second" || fail "not idempotent: a second pass changed the file again"
+checks=$((checks + 2))
+echo "OK: clean file untouched, and the pass is idempotent"
+
+# ---------------------------------------------------------------------------
+# 7. CHECK=true must report without writing.
+# ---------------------------------------------------------------------------
+cat > "${TMP}/g.md" <<'MD'
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | the id |
+MD
+cp "${TMP}/g.md" "${TMP}/g.orig"
+CHECK=true bash "$CLEANUP" "${TMP}/g.md" >/dev/null || fail "CHECK mode exited non-zero"
+cmp -s "${TMP}/g.orig" "${TMP}/g.md" || fail "CHECK=true wrote to the file"
+checks=$((checks + 1))
+echo "OK: CHECK=true reports without writing"
+
+[ "$checks" -ge 17 ] || fail "expected at least 17 checks, ran ${checks}"
+echo "ALL TESTS PASSED (${checks} checks)"


### PR DESCRIPTION
Six migrated repos show Requirements through Outputs TWICE. Their original README
carried a stale terraform-docs block OUTSIDE the markers (an older generator, or
the pre-commit-terraform docs hook with its own markers), so the marker split
correctly preserved it as authored prose and the generator then emitted a fresh
copy alongside it.

```text
verified on terraform-aws-trenddsm main: 2x "## Requirements", 2x "## Inputs"
affected: trenddsm, jira, nessus-pro, managed-ad, securitycore, inventorylambda
```

Removal-only by construction, and the output is asserted to be no longer than the
input. Removes: the pre-commit hook block, a generated section heading plus its
table, and a retired `## Tree` section.

```text
tests   17 checks, ALL PASSED
  false-positive guard: an AUTHORED table under `## Inputs` survives
  byte-identical, because it has no generated signature
  Resources tables are detected by their registry.terraform.io links
  idempotent; CHECK=true reports without writing

on the 6 real partials, prose that FOLLOWED the orphan survived:
  inventorylambda ## License, managed-ad #### Code Location,
  trenddsm ## Contributing   and 0 generated anchors remain in any of them
shellcheck -S warning   exit 0
```

Note for reviewers: the regexes are literal inside the awk program on purpose.
Passing them with `awk -v` processes escape sequences in the value, stripping the
backslashes from `\]` and `\(`, which makes the regex invalid and turns a silent
awk failure into a misleading "nothing to remove".