### PR TITLE
fix(partial-cleanup): an empty partial is 0 lines, not 1

### DIFF
--- a/scripts/terraform-docs-partial-cleanup.sh
+++ b/scripts/terraform-docs-partial-cleanup.sh
@@ -91,7 +91,15 @@ for f in "$@"; do
   esac
 
   in_lines="$(wc -l < "$f" | tr -d ' ')"
-  out_lines="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+  # An empty result is 0 lines, not 1. `printf '%s\n' ""` emits a single newline,
+  # which made a legitimately EMPTY partial look like growth and tripped the
+  # removal-only guard. Measured on the empty _footer.md of
+  # terraform-aws-inventorylambda, managed-ad and trenddsm.
+  if [ -z "$out" ]; then
+    out_lines=0
+  else
+    out_lines="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+  fi
   if [ "$out_lines" -gt "$in_lines" ]; then
     echo "REFUSING ${f}: output ${out_lines} > input ${in_lines}, must be removal-only" >&2
     rc=1; continue

--- a/tests/terraform-docs-partial-cleanup.test.sh
+++ b/tests/terraform-docs-partial-cleanup.test.sh
@@ -149,5 +149,18 @@ cmp -s "${TMP}/g.orig" "${TMP}/g.md" || fail "CHECK=true wrote to the file"
 checks=$((checks + 1))
 echo "OK: CHECK=true reports without writing"
 
-[ "$checks" -ge 17 ] || fail "expected at least 17 checks, ran ${checks}"
+# ---------------------------------------------------------------------------
+# 8. An EMPTY partial is legal (a README whose BEGIN marker is on line 1 yields a
+#    0-byte _header.md). It must not be treated as growth by the removal-only
+#    guard, which is what `printf '%s\n' ""` emitting one newline caused.
+# ---------------------------------------------------------------------------
+: > "${TMP}/empty.md"
+out="$(bash "$CLEANUP" "${TMP}/empty.md" 2>&1)" \
+  || fail "cleanup refused an empty partial: ${out}"
+grep -q "REFUSING" <<<"$out" && fail "cleanup REFUSED an empty partial: ${out}"
+[ -s "${TMP}/empty.md" ] && fail "cleanup wrote content into an empty partial"
+checks=$((checks + 2))
+echo "OK: an empty partial is accepted and left empty"
+
+[ "$checks" -ge 19 ] || fail "expected at least 19 checks, ran ${checks}"
 echo "ALL TESTS PASSED (${checks} checks)"


### PR DESCRIPTION
The removal-only guard compared `printf %s\\n \"\$out\" | wc -l` against the input
line count. For an empty result that prints a single newline, so a legitimately
EMPTY partial read as growth and the guard aborted the repo after its `_header.md`
had already been cleaned.

```text
hit on the empty _footer.md of inventorylambda, managed-ad and trenddsm
tests   19 checks, ALL PASSED
  new case: an empty partial is accepted and left empty
shellcheck -S info scripts/*.sh   exit 0
```