### PR TITLE
chore(md-lint): re-enable MD033, MD034 and MD060

### DIFF
--- a/.github/workflows/org-markdown-lint.yml
+++ b/.github/workflows/org-markdown-lint.yml
@@ -81,6 +81,11 @@ jobs:
             "MD035": { "style": "---" },
             "MD046": { "style": "fenced" },
             "MD048": { "style": "backtick" },
+            // MD060 must name its style. Under a bare "default": true the
+            // implied style is stricter and reports 280 findings across 19
+            // repos; "consistent" reports ZERO across all 334 authored partials
+            // in the fleet, censused with 0.23.0, the version run below.
+            "MD060": { "style": "consistent" },
             // -- cosmetic rules relaxed: formatted well, not perfect --
             "MD001": false,                    // heading levels may skip; renders fine
             "MD004": false,                    // mixed -/* bullets across generated+authored sections
@@ -93,16 +98,22 @@ jobs:
             "MD024": false,                    // duplicate headings (changelogs, per-env sections)
             "MD025": false,                    // multiple H1 (terraform-docs merged READMEs)
             "MD026": false,                    // trailing punctuation in headings
-            "MD033": false,                    // inline HTML
-            "MD034": false,                    // bare URLs
+            "MD029": false,                    // ordered-list numbering style — noisy, no render impact
+            // MD033 and MD034 are ENABLED now. terraform-docs output is exempted
+            // by the markdownlint pragmas inside the generated block, so these
+            // rules apply to authored prose only. `div`, `img` and `sub` stay
+            // allowed because markdown cannot express them and the org uses them
+            // deliberately: three repos centre their logo with
+            // <div align="center"><img ...>, and the org PR template, which is in
+            // 119 repos, uses <sub> for its footer tip.
+            "MD033": { "allowed_elements": ["div", "img", "sub"] },
             "MD036": false,                    // bold-line-as-heading (common authored pattern)
             "MD040": false,                    // fence language tag optional
             "MD041": false,                    // first line need not be a heading
             "MD047": false,                    // single trailing newline — no render impact
             "MD049": false,                    // _em_ vs *em* style
             "MD050": false,                    // __strong__ vs **strong** style
-            "MD051": false,                    // anchor fragments — lychee owns link checking
-            "MD060": false
+            "MD051": false                     // anchor fragments — lychee owns link checking
           }
         }
         JSONC

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -17,6 +17,11 @@
     "MD035": { "style": "---" },
     "MD046": { "style": "fenced" },
     "MD048": { "style": "backtick" },
+    // MD060 must name its style. Under a bare "default": true the implied style
+    // is stricter and reports 280 findings across 19 repos; "consistent" reports
+    // ZERO across all 334 authored partials in the fleet (censused with 0.23.0,
+    // the version this workflow runs).
+    "MD060": { "style": "consistent" },
     // -- cosmetic rules relaxed: formatted well, not perfect --
     "MD001": false,                    // heading levels may skip; renders fine
     "MD004": false,                    // mixed -/* bullets across generated+authored sections
@@ -30,15 +35,21 @@
     "MD025": false,                    // multiple H1 (terraform-docs merged READMEs)
     "MD026": false,                    // trailing punctuation in headings
     "MD029": false,                    // ordered-list numbering style — noisy, no render impact
-    "MD033": false,                    // inline HTML
-    "MD034": false,                    // bare URLs
+    // MD033 and MD034 are ENABLED now. terraform-docs output is exempted by the
+    // markdownlint pragmas inside the generated block (see
+    // templates/terraform-docs/.terraform-docs.yml), so these rules apply to
+    // authored prose only, which is where they catch real problems.
+    // Three elements stay allowed because markdown cannot express them and the
+    // org uses them deliberately: three repos centre their logo with
+    // <div align="center"><img ...>, and the org PR template, which is in 119
+    // repos, uses <sub> for its footer tip.
+    "MD033": { "allowed_elements": ["div", "img", "sub"] },
     "MD036": false,                    // bold-line-as-heading (common authored pattern)
     "MD040": false,                    // fence language tag optional
     "MD041": false,                    // first line need not be a heading
     "MD047": false,                    // single trailing newline — no render impact
     "MD049": false,                    // _em_ vs *em* style
     "MD050": false,                    // __strong__ vs **strong** style
-    "MD051": false,                    // anchor fragments — lychee owns link checking
-    "MD060": false
+    "MD051": false                     // anchor fragments — lychee owns link checking
   }
 }

--- a/docs/ORG_JIRA_SYNC_SETUP.md
+++ b/docs/ORG_JIRA_SYNC_SETUP.md
@@ -25,7 +25,7 @@ Navigate to your repository Settings → Secrets and variables → Actions → S
 - **Description**: Your Jira Cloud API token for authentication
 - **How to get it**:
   1. Log into your Jira account
-  1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+  1. Go to <https://id.atlassian.com/manage-profile/security/api-tokens>
   1. Click "Create API token"
   1. Give it a name (e.g., "GitHub Actions")
   1. Copy the token and save it as a secret


### PR DESCRIPTION
These three rules were disabled because terraform-docs output violates them. The
standard now puts markdownlint pragmas inside the generated block, so they apply
to authored prose only, which is where they catch real problems.

```text
census over all 334 authored partials in the 167 migrated repos, cli2 0.23.0
(the version this workflow runs; package.json pins 0.23.2):
  MD033 / MD034 / MD060 findings   0
  all other rules                  85, IDENTICAL before and after the flip
                                   (MD031 33, MD032 30, MD030 12, MD010 4,
                                    MD059 2, MD045 2, MD056 1, MD055 1)
```

So the flip adds zero new failures. The 85 are pre-existing debt in authored
prose, unrelated to these rules, and are left alone rather than mixed in here.

Two settings needed care:

```text
MD060  must name a style. Under a bare "default": true the implied style is
       stricter and reports 280 findings across 19 repos. "consistent" reports 0.
MD033  allows div, img and sub. Three repos centre their logo with
       <div align="center"><img ...>, and the org PR template (in 119 repos) uses
       <sub>. Markdown cannot express either. Everything else is still flagged.
```

Getting to zero also required content fixes, already merged: 24 repos had bare
URLs wrapped as autolinks, and 6 had a stale duplicate generated block removed
from their partials.

```text
both policy copies: rule settings byte-identical, both parse as JSONC
this repo under the new policy: 37 files, 0 errors
also fixes MD029, which had drifted out of the workflow copy, and one bare URL
```