### PR TITLE
docs(examples): refresh caller pins to v0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ permissions:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     secrets: inherit
     with:
       slack_channel_id: 'C0123456789'
@@ -106,7 +106,7 @@ Access to private Terraform module repositories is controlled using a GitHub App
 # Private repo — pass app credentials for module access
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
     secrets:
@@ -116,7 +116,7 @@ jobs:
 # Public repo — no app credentials needed
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
 ```
@@ -136,7 +136,7 @@ Wrapper around [terraform-docs GitHub Actions](https://github.com/terraform-docs
 # Root module and submodules
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       recursive: true
 ```

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -224,7 +224,7 @@ Run the label sync workflow on each repo before enabling auto-merge:
 ```yaml
 jobs:
   sync-labels:
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     secrets: inherit
 ```
 
@@ -251,7 +251,7 @@ jobs:
     if: >-
       github.event_name == 'check_suite' ||
       github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     secrets: inherit
 ```
 
@@ -283,9 +283,9 @@ pass `actions_ref`:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
-      actions_ref: 43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+      actions_ref: 162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     secrets: inherit
 ```
 

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -193,7 +193,7 @@ concurrency:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       test_mode: pr
       go_version: "1.26"
@@ -241,7 +241,7 @@ concurrency:
 
 jobs:
   terratest-azure:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       test_mode: pr
       go_version: "1.26"
@@ -277,7 +277,7 @@ concurrency:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       test_mode: pr
       go_version: "1.26"
@@ -300,7 +300,7 @@ on:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       test_mode: release
       go_version: "1.26"
@@ -309,7 +309,7 @@ jobs:
 
   release-clean:
     needs: terratest
-    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       tag_name: ${{ github.event.release.tag_name }}
 ```
@@ -483,7 +483,7 @@ permissions:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@43274fdf0406920dfa1e5fd05cac5d8d10951c96 # v0.17.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
     with:
       test_directory: test
       test_timeout: 45m


### PR DESCRIPTION
Release 0.18.0 bumped the manifest, so example pins advertising v0.17.0 fail `tests/example-pin-check.test.sh` on the next PR that touches scripts, tests or workflows. Same follow-up as #298 did for v0.17.0.

```text
14 example pins -> 162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
example-pin-check   ALL TESTS PASSED (was failing on main)
markdownlint 0.23.0 0 errors
```