### PR TITLE
feat(fleet-audit): add org Actions health sweep

### DIFF
--- a/.github/workflows/org-actions-fleet-audit.yml
+++ b/.github/workflows/org-actions-fleet-audit.yml
@@ -1,0 +1,130 @@
+name: Org Actions Fleet Audit
+
+# Read-only Coalfire-CF fleet health sweep. Classifies consumer pin lag,
+# Dependabot auto-merge gaps, and release/tag shape. Writes an artifact plus
+# (full-org runs only) the standing issue "Actions fleet audit" on this repo.
+# Never pushes, opens PRs, merges, or labels consumer repos.
+
+on:
+  schedule:
+    - cron: '47 8 * * 1'   # weekly Monday 08:47 UTC — offset off the hour
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Optional single repo (owner/name) canary. Empty = whole org. Canary does not overwrite the standing issue.'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: actions-fleet-audit-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Classify org repos
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Generate GitHub App token (org-wide reads)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.AUTOMERGE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Sweep and report
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_SCOPE: ${{ inputs.repo || '' }}
+        run: |
+          set -euo pipefail
+          : "${GH_TOKEN:?missing app token}"
+          if [ -n "$REPO_SCOPE" ] && ! printf '%s' "$REPO_SCOPE" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "::error::repo must be owner/name"
+            exit 2
+          fi
+
+          # shellcheck source=scripts/retry-lib.sh
+          . "${GITHUB_WORKSPACE}/scripts/retry-lib.sh"
+
+          # shellcheck disable=SC2329
+          _latest_release() {
+            gh release view --repo "${OWNER}/Actions" --json tagName --jq .tagName 2>/dev/null || return "$RETRY_TRANSIENT_RC"
+          }
+          if ! ACTIONS_VERSION="$(with_retry 3 2 20 -- _latest_release)"; then
+            echo "::error::could not resolve latest Actions release"
+            exit 1
+          fi
+          # shellcheck disable=SC2329
+          _tag_obj() {
+            gh api "repos/${OWNER}/Actions/git/ref/tags/${ACTIONS_VERSION}" --jq '[.object.type, .object.sha] | @tsv' 2>/dev/null || return "$RETRY_TRANSIENT_RC"
+          }
+          if ! TAG_TSV="$(with_retry 3 2 20 -- _tag_obj)"; then
+            echo "::error::could not resolve tag ${ACTIONS_VERSION}"
+            exit 1
+          fi
+          TAG_TYPE="$(printf '%s' "$TAG_TSV" | cut -f1)"
+          ACTIONS_SHA="$(printf '%s' "$TAG_TSV" | cut -f2)"
+          if [ "$TAG_TYPE" = "tag" ]; then
+            # shellcheck disable=SC2329
+            _deref() {
+              gh api "repos/${OWNER}/Actions/git/tags/${ACTIONS_SHA}" --jq '.object.sha' 2>/dev/null || return "$RETRY_TRANSIENT_RC"
+            }
+            if ! ACTIONS_SHA="$(with_retry 3 2 20 -- _deref)"; then
+              echo "::error::could not dereference annotated tag ${ACTIONS_VERSION}"
+              exit 1
+            fi
+          fi
+          echo "Fleet audit — owner=${OWNER} scope=${REPO_SCOPE:-<org>} pin=${ACTIONS_VERSION}@${ACTIONS_SHA}"
+
+          mkdir -p "${RUNNER_TEMP}/fleet-audit"
+          export ACTIONS_SHA ACTIONS_VERSION ORG="$OWNER" REPO="$REPO_SCOPE"
+          set +e
+          bash "${GITHUB_WORKSPACE}/scripts/fleet-audit.sh" \
+            > "${RUNNER_TEMP}/fleet-audit/repos.ndjson"
+          audit_rc=$?
+          set -e
+          ACTIONS_VERSION="$ACTIONS_VERSION" ACTIONS_SHA="$ACTIONS_SHA" \
+            bash "${GITHUB_WORKSPACE}/scripts/fleet-audit-report.sh" \
+            < "${RUNNER_TEMP}/fleet-audit/repos.ndjson" \
+            > "${RUNNER_TEMP}/fleet-audit/report.md"
+
+          cat "${RUNNER_TEMP}/fleet-audit/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$REPO_SCOPE" ]; then
+            export GH_TOKEN="$ISSUE_TOKEN"
+            TITLE="Actions fleet audit"
+            existing="$(gh issue list --repo "${OWNER}/Actions" --state open --limit 50 \
+              --json number,title --jq ".[] | select(.title==\"${TITLE}\") | .number" | head -n1 || true)"
+            if [ -n "$existing" ]; then
+              gh issue edit "$existing" --repo "${OWNER}/Actions" \
+                --body-file "${RUNNER_TEMP}/fleet-audit/report.md"
+              echo "Updated standing issue #${existing}"
+            else
+              gh issue create --repo "${OWNER}/Actions" --title "$TITLE" \
+                --body-file "${RUNNER_TEMP}/fleet-audit/report.md"
+              echo "Opened standing issue"
+            fi
+          else
+            echo "Canary scope ${REPO_SCOPE} — standing issue not updated"
+          fi
+
+          exit "$audit_rc"
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fleet-audit-report
+          path: ${{ runner.temp }}/fleet-audit/
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Called on merge to main.
 | Jira Sync | `org-jira-sync.yml` | Syncs GitHub issues to Jira (Cloud or Data Center) |
 | Terraform Version Check | `org-terraform-version-check.yml` | Scheduled check for new Terraform versions, auto-creates PRs |
 | Repo Bootstrap | `org-repo-bootstrap.yml` | Daily sweeper that opens baseline-adoption PRs (pinned caller bundle from `templates/bootstrap/`) on org repos that never adopted the standard workflows ([docs](docs/ORG_REPO_BOOTSTRAP.md)) |
+| Fleet Audit | `org-actions-fleet-audit.yml` | Weekly read-only org sweep: Actions pin lag, Dependabot auto-merge gaps, release/tag shape. Standing issue + artifact ([docs](docs/ORG_ACTIONS_FLEET_AUDIT.md)) |
 
 ### Legacy / Internal
 

--- a/docs/ORG_ACTIONS_FLEET_AUDIT.md
+++ b/docs/ORG_ACTIONS_FLEET_AUDIT.md
@@ -1,0 +1,93 @@
+# Org Actions fleet audit
+
+Read-only health sweep of `Coalfire-CF` consumer repos: Actions pin lag, Dependabot auto-merge gaps, and release/tag shape. Producer YAML smells are out of scope; see [RESEARCH_workflow-audit-2026-08-11.md](RESEARCH_workflow-audit-2026-08-11.md).
+
+**Decision:** report only. The sweeper never pushes, opens PRs, merges, or labels consumer repos. The only write is the standing issue `Actions fleet audit` on `Coalfire-CF/Actions` (full-org runs) plus the workflow artifact.
+
+Design: [docs/superpowers/specs/2026-08-20-org-actions-fleet-audit-design.md](superpowers/specs/2026-08-20-org-actions-fleet-audit-design.md).
+
+## How it works
+
+1. Resolve the latest `Coalfire-CF/Actions` release tag and commit SHA (RFC-0008 pin).
+1. Enumerate non-archived, non-fork org repos. Skip `.github` and `.allstar`. Do **not** skip `Actions` (producer) or `bootstrap-exempt` (still classified, `exempt: true`).
+1. Per repo, fetch workflows, `dependabot.yml`, open PRs, tags, releases, repo rulesets, and a capped set of `.tf` files.
+1. Classify into NDJSON, then markdown.
+
+Unreadable metadata or contents: `status=SKIP`, `skip_reason=unreadable`. Never a PASS from a failed read.
+
+## Status
+
+| status | Meaning |
+| --- | --- |
+| `FAIL` | At least one fail-severity finding |
+| `PASS` | No fail findings. Warn findings are allowed |
+| `SKIP` | Infra filter or unreadable |
+
+## Check catalog
+
+Fail:
+
+- `pin-lag` — SHA or `# vX.Y.Z` older than this run's Actions release
+- `pin-bad-ref` — `@main`, branch, or moving major (`@v1`)
+- `pin-sha-no-comment` — 40-hex SHA without `# vX.Y.Z`
+- `pin-mixed` — more than one Actions SHA or version comment in the repo
+- `no-caller` — no `Coalfire-CF/Actions` `uses:` and no `org-release.yml`
+- `automerge-missing-caller` — adopted (`org-release.yml` present) but missing `org-dependabot.yml` or `org-dependabot-auto-merge.yml`
+- `dependabot-missing-gha` — adopted, `dependabot.yml` has no `github-actions` ecosystem
+- `dependabot-unlabeled` — open github-actions Dependabot PR with no `merge/approved|blocked|skipped`
+- `automerge-approved-unmerged` — open Dependabot PR labeled `merge/approved` (reconcile / ruleset bypass path)
+- `automerge-tf-block-on-actions` — github-actions Dependabot PR labeled `blocked/terraform-no-tests`
+- `ruleset-no-bypass` — repo-level `pull_request` ruleset without Integration bypass for App `3436395`
+- `source-pin-fail` / `source-pin-warn` — Coalfire-CF Terraform `source` classes, sampled from **root-level** `*.tf` files (not nested modules)
+- `release-no-tags` — `org-release.yml` present, zero `v*` git tags
+- `release-please-stale` — open `release-please--branches--*` PR
+- `terraform-missing-gates` — HCL repo, adopted, missing validate/fmt/docs callers
+
+Warn:
+
+- `pin-bare-tag` — `@vX.Y.Z` with no SHA
+- `automerge-blocked` — open Dependabot PR labeled `merge/blocked`
+- `source-pin-warn` — Terraform `?ref=vX.Y.Z` tag
+- `release-tag-no-github-release` — `v*` tags, no GitHub Release objects
+- `bootstrap-pr-open` — open `bootstrap/*` PR
+- `orphan-caller` — uses apply/plan/source-pin/version-band reusables (zero-fleet in the 2026-08-11 audit)
+
+`Coalfire-CF/Actions` is `role=producer`. Local `./` refs are not consumer pins. `pin-lag` / `no-caller` do not apply.
+
+## Run locally
+
+Prerequisites: `gh` authenticated with org read, `jq`.
+
+```bash
+ACTIONS_VERSION="$(gh release view --repo Coalfire-CF/Actions --json tagName --jq .tagName)"
+# Resolve the tag object to a 40-hex commit (annotated tags need a deref).
+ACTIONS_SHA="$(git ls-remote --tags https://github.com/Coalfire-CF/Actions.git "refs/tags/${ACTIONS_VERSION}^{}" | awk '{print $1}')"
+# Fallback if the peeled ref is missing:
+[ -n "$ACTIONS_SHA" ] || ACTIONS_SHA="$(gh api "repos/Coalfire-CF/Actions/git/ref/tags/${ACTIONS_VERSION}" --jq .object.sha)"
+
+export ACTIONS_VERSION ACTIONS_SHA ORG=Coalfire-CF
+
+# Canary
+REPO=Coalfire-CF/Actions ./scripts/fleet-audit.sh | ./scripts/fleet-audit-report.sh
+
+# Full org (slow; thousands of API reads)
+./scripts/fleet-audit.sh | tee /tmp/fleet-audit.ndjson | ./scripts/fleet-audit-report.sh
+```
+
+Snapshot fixtures (no network): `FLEET_AUDIT_SNAPSHOT=dir ./scripts/fleet-audit.sh`. Layout is in the design spec.
+
+Tests: `bash tests/fleet-audit.test.sh`
+
+## CI
+
+[`.github/workflows/org-actions-fleet-audit.yml`](../.github/workflows/org-actions-fleet-audit.yml): weekly Monday 08:47 UTC, plus `workflow_dispatch`. App token (`AUTOMERGE_CLIENT_ID` / `AUTOMERGE_APP_PRIVATE_KEY`) for org reads. `GITHUB_TOKEN` upserts the standing issue on full-org runs only. A `repo=` canary does not overwrite that issue.
+
+## After the report
+
+Triage order:
+
+1. Auto-merge wiring gaps vs stuck `merge/approved` (repo ruleset bypass).
+1. Pin lag with an open Dependabot PR (land via existing auto-merge / reconcile).
+1. Pin lag with no Dependabot PR (`dependabot.yml` / grouping).
+1. Stale release-please PRs (tags never cut).
+1. `@main` / bare-tag callers.

--- a/docs/RESEARCH_actions-fleet-audit-2026-08-20.md
+++ b/docs/RESEARCH_actions-fleet-audit-2026-08-20.md
@@ -490,6 +490,5 @@ Pin: `v0.18.1` @ `23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4`
 | `Coalfire-CF/terraform-google-palo-alto` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
 | `Coalfire-CF/terraform-google-palo-alto` | fail | v0.17.0@43274fdf vs v0.18.1@23c6c8bc |
 | `Coalfire-CF/terraform-google-cloud-sql` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
-| `Coalfire-CF/terraform-google-cloud-sql` | fail | v0.17.0@43274fdf vs v
 
 ... truncated (120792 bytes). Full report is the workflow artifact.

--- a/docs/RESEARCH_actions-fleet-audit-2026-08-20.md
+++ b/docs/RESEARCH_actions-fleet-audit-2026-08-20.md
@@ -1,0 +1,495 @@
+# Actions fleet audit — 2026-08-20 evidence snapshot
+
+Live read-only sweep of non-archived, non-fork `Coalfire-CF` repos against Actions `v0.18.1` (`23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4`).
+
+**Canary:** `Coalfire-CF/Actions` classified `role=producer`, `status=PASS`, no consumer pin-lag. `Coalfire-CF/terraform-aws-gitlab` classified `FAIL` with `pin-lag` (pins at `v0.16.1`).
+
+**Method notes**
+
+- Classifier: `scripts/fleet-audit.sh`. Report: `scripts/fleet-audit-report.sh`.
+- Terraform `source` pins sampled from **root-level** `*.tf` only.
+- First pass treated `package-ecosystem: "github-actions"` (quoted) as missing. That was a classifier bug (238 false `dependabot-missing-gha`). Script now accepts optional quotes. This snapshot was corrected by re-reading those `dependabot.yml` files; `dependabot-missing-gha` dropped to 0.
+- `bootstrap-exempt` repos were still classified. None in this run.
+- Full tables below. Standing issue title: `Actions fleet audit`.
+
+# Actions fleet audit
+
+Pin: `v0.18.1` @ `23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4`
+
+| metric | count |
+| --- | --- |
+| total | 241 |
+| PASS | 1 |
+| FAIL | 240 |
+| SKIP | 0 |
+| bootstrap-exempt | 0 |
+
+## Counts by check
+
+| id | repos |
+| --- | --- |
+| `automerge-approved-unmerged` | 16 |
+| `automerge-blocked` | 40 |
+| `automerge-missing-caller` | 25 |
+| `dependabot-unlabeled` | 67 |
+| `no-caller` | 1 |
+| `pin-lag` | 239 |
+| `pin-mixed` | 78 |
+| `pin-sha-no-comment` | 1 |
+| `release-no-tags` | 43 |
+| `release-please-stale` | 215 |
+| `release-tag-no-github-release` | 6 |
+| `source-pin-warn` | 2 |
+| `terraform-missing-gates` | 16 |
+
+## automerge-approved-unmerged
+
+| repo | severity | detail |
+| --- | --- | --- |
+| `Coalfire-CF/upwind-gov` | fail | PR #120 labeled merge/approved |
+| `Coalfire-CF/proliance-cli` | fail | PR #14 labeled merge/approved |
+| `Coalfire-CF/proliance-cli` | fail | PR #15 labeled merge/approved |
+| `Coalfire-CF/proliance-cli` | fail | PR #16 labeled merge/approved |
+| `Coalfire-CF/proliance-cli` | fail | PR #21 labeled merge/approved |
+| `Coalfire-CF/proliance-cli` | fail | PR #22 labeled merge/approved |
+| `Coalfire-CF/proliance-cli` | fail | PR #23 labeled merge/approved |
+| `Coalfire-CF/proliance-workspace` | fail | PR #356 labeled merge/approved |
+| `Coalfire-CF/proliance-workspace` | fail | PR #357 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-lb` | fail | PR #172 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-s3` | fail | PR #189 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-s3` | fail | PR #191 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-private-certificate-authority` | fail | PR #198 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-private-certificate-authority` | fail | PR #199 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-private-certificate-authority` | fail | PR #201 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-private-certificate-authority` | fail | PR #203 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-inventorylambda` | fail | PR #194 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-inventorylambda` | fail | PR #195 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-inventorylambda` | fail | PR #196 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-inventorylambda` | fail | PR #197 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-account-setup` | fail | PR #273 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-account-setup` | fail | PR #274 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-account-setup` | fail | PR #275 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-account-setup` | fail | PR #276 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-account-setup` | fail | PR #277 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-security-hub` | fail | PR #229 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-eks-compliance-scanner` | fail | PR #223 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-iam-identity-center` | fail | PR #266 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-iam-identity-center` | fail | PR #269 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-iam-identity-center` | fail | PR #270 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-iam-identity-center` | fail | PR #271 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-organization` | fail | PR #200 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-organization` | fail | PR #201 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-organization` | fail | PR #202 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-organization` | fail | PR #203 labeled merge/approved |
+| `Coalfire-CF/terraform-aws-organization` | fail | PR #204 labeled merge/approved |
+| `Coalfire-CF/Remediation-Of-Threats-Through-Issue-Entry` | fail | PR #18 labeled merge/approved |
+| `Coalfire-CF/Remediation-Of-Threats-Through-Issue-Entry` | fail | PR #19 labeled merge/approved |
+| `Coalfire-CF/Remediation-Of-Threats-Through-Issue-Entry` | fail | PR #20 labeled merge/approved |
+| `Coalfire-CF/Remediation-Of-Threats-Through-Issue-Entry` | fail | PR #21 labeled merge/approved |
+| `Coalfire-CF/Remediation-Of-Threats-Through-Issue-Entry` | fail | PR #22 labeled merge/approved |
+| `Coalfire-CF/cs-scm` | fail | PR #32 labeled merge/approved |
+| `Coalfire-CF/cs-go-bundler` | fail | PR #21 labeled merge/approved |
+| `Coalfire-CF/cs-go-bundler` | fail | PR #22 labeled merge/approved |
+| `Coalfire-CF/cs-go-bundler` | fail | PR #23 labeled merge/approved |
+| `Coalfire-CF/cs-go-bundler` | fail | PR #24 labeled merge/approved |
+| `Coalfire-CF/cs-go-bundler` | fail | PR #25 labeled merge/approved |
+| `Coalfire-CF/npm` | fail | PR #25 labeled merge/approved |
+| `Coalfire-CF/npm` | fail | PR #32 labeled merge/approved |
+| `Coalfire-CF/npm` | fail | PR #34 labeled merge/approved |
+
+## automerge-blocked
+
+| repo | severity | detail |
+| --- | --- | --- |
+| `Coalfire-CF/upwind-gov` | warn | PR #203 merge/blocked (dep/pip,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/upwind-gov` | warn | PR #206 merge/blocked (dep/pip,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #103 merge/blocked (check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,dep/other,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #108 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #114 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #120 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #138 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #140 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #141 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #144 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #150 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #151 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #152 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #153 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/changelog-safe,check/semver-patch,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #155 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/changelog-safe,check/semver-patch,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #162 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #166 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #169 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #177 merge/blocked (check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,dep/other,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #184 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/changelog-safe,check/semver-patch,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #187 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #204 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #208 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #213 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #215 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/changelog-safe,check/semver-patch,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #239 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #242 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #243 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #245 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #246 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #247 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #251 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #255 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #258 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #259 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #260 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #307 merge/blocked (check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,dep/other,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #313 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #315 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #316 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #317 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #319 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #321 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #322 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #324 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #346 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #353 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #355 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #386 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #387 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #388 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #389 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #402 merge/blocked (check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,dep/other,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #408 merge/blocked (check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,dep/other,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #423 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #56 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #61 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #62 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #77 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #92 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #94 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-dev-conmon` | warn | PR #99 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/terraform-google-secret-manager` | warn | PR #36 merge/blocked (dependencies,github_actions,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/terraform-google-kms` | warn | PR #34 merge/blocked (dependencies,github_actions,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/terraform-google-project` | warn | PR #35 merge/blocked (dependencies,github_actions,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/terraform-google-service-account` | warn | PR #40 merge/blocked (dependencies,github_actions,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/terraform-google-cloud-storage` | warn | PR #33 merge/blocked (dependencies,github_actions,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/terraform-google-cloud-router` | warn | PR #33 merge/blocked (dependencies,github_actions,dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/cf-sre-claude-skills` | warn | PR #18 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/CF-AWS-Bottlerocket-CIS` | warn | PR #10 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/CF-AWS-Bottlerocket-CIS` | warn | PR #11 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/CF-AWS-Bottlerocket-CIS` | warn | PR #14 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/CF-AWS-Bottlerocket-CIS` | warn | PR #9 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/mt-ops-toolkit` | warn | PR #109 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/mt-ops-toolkit` | warn | PR #117 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/mt-ops-toolkit` | warn | PR #152 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/mt-ops-toolkit` | warn | PR #52 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/mt-ops-toolkit` | warn | PR #53 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/proliance-platform` | warn | PR #40 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/consolidated-inventory` | warn | PR #29 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/consolidated-inventory` | warn | PR #6 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/consolidated-inventory` | warn | PR #8 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/packer-aws` | warn | PR #139 merge/blocked (dep/pip,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/cs-staffing` | warn | PR #137 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/onyx-licenser` | warn | PR #10 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/onyx-licenser` | warn | PR #5 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/onyx-licenser` | warn | PR #6 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/proliance-cli` | warn | PR #17 merge/blocked (check/osv-clear,check/scorecard-pass,dep/github-actions,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/proliance-cli` | warn | PR #18 merge/blocked (check/osv-clear,dep/github-actions,check/semver-major,check/changelog-breaking,ai/breaking-suspected,check/scorecard-low,risk/high,merge/blocked,blocked/major-bump,blocked/low-scorecard) |
+| `Coalfire-CF/proliance-cli` | warn | PR #19 merge/blocked (check/osv-clear,check/scorecard-pass,dep/github-actions,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/proliance-cli` | warn | PR #20 merge/blocked (check/osv-clear,check/scorecard-pass,dep/github-actions,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cf-minfanger-claude-testing` | warn | PR #19 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/cf-minfanger-claude-testing` | warn | PR #35 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/cf-minfanger-claude-testing` | warn | PR #37 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/ansible-azure` | warn | PR #15 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/go-github-stats` | warn | PR #66 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/proliance-workspace` | warn | PR #76 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/smarshgov-aws` | warn | PR #102 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/smarshgov-aws` | warn | PR #105 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/smarshgov-aws` | warn | PR #108 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/smarshgov-aws` | warn | PR #109 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/smarshgov-aws` | warn | PR #49 merge/blocked (check/osv-clear,check/scorecard-pass,dep/pip,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cf-minfanger-skills` | warn | PR #8 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/onyx2` | warn | PR #1001 merge/blocked (check/osv-clear,check/scorecard-pass,dep/other,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/onyx2` | warn | PR #995 merge/blocked (check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump,dep/docker) |
+| `Coalfire-CF/onyx2` | warn | PR #997 merge/blocked (check/osv-clear,check/scorecard-pass,dep/other,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/onyx2` | warn | PR #998 merge/blocked (check/osv-clear,check/scorecard-pass,dep/other,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/images` | warn | PR #278 merge/blocked (dep/docker,check/osv-clear,check/scorecard-pass,risk/high,check/semver-major,check/changelog-breaking,ai/breaking-suspected,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/images` | warn | PR #284 merge/blocked (dep/docker,check/osv-clear,check/scorecard-pass,risk/high,check/semver-major,check/changelog-breaking,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/images` | warn | PR #287 merge/blocked (dep/docker,check/osv-clear,check/scorecard-pass,risk/high,check/semver-major,check/changelog-breaking,ai/breaking-suspected,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/optum-conmon` | warn | PR #4 merge/blocked (dep/github-actions,check/semver-major,check/changelog-breaking,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/optum-conmon` | warn | PR #5 merge/blocked (dep/github-actions,check/semver-major,check/changelog-breaking,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/optum-conmon` | warn | PR #8 merge/blocked (dep/pip,check/semver-major,check/changelog-breaking,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/cs-os-images` | warn | PR #32 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-os-images` | warn | PR #34 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-os-images` | warn | PR #6 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | warn | PR #19 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | warn | PR #20 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/ansible-aws` | warn | PR #365 merge/blocked (dependencies,python,dep/pip,check/osv-clear,check/scorecard-pass,merge/blocked,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/cs-scm` | warn | PR #33 merge/blocked (check/osv-clear,risk/high,dep/pip,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #11 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #12 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #13 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #14 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #15 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #17 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #19 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #21 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #22 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #24 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #25 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #26 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #40 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #8 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/coalforge-dashboard` | warn | PR #9 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-pipeline-runner` | warn | PR #16 merge/blocked (dep/github-actions,check/semver-major,check/changelog-breaking,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-pipeline-runner` | warn | PR #17 merge/blocked (dep/github-actions,check/semver-major,check/changelog-breaking,ai/breaking-suspected,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-pipeline-runner` | warn | PR #18 merge/blocked (dep/github-actions,check/semver-major,check/changelog-breaking,ai/breaking-suspected,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-pipeline-runner` | warn | PR #19 merge/blocked (dep/github-actions,check/semver-major,check/changelog-breaking,check/osv-clear,check/scorecard-pass,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/evidence-capture` | warn | PR #11 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/evidence-capture` | warn | PR #4 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/evidence-capture` | warn | PR #5 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/image-bakery` | warn | PR #15 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/azure-policy-management` | warn | PR #11 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/azure-policy-management` | warn | PR #13 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/azure-policy-management` | warn | PR #17 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/azure-policy-management` | warn | PR #18 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump,ai/breaking-suspected) |
+| `Coalfire-CF/azure-policy-management` | warn | PR #8 merge/blocked (dep/pip,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-jim-industries` | warn | PR #6 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-jim-industries` | warn | PR #7 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-jim-industries` | warn | PR #8 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #20 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #21 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #22 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #23 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #24 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #26 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #27 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #29 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/npm` | warn | PR #31 merge/blocked (dep/other,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-stoker-poam` | warn | PR #10 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-low,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump,blocked/low-scorecard) |
+| `Coalfire-CF/cs-stoker-poam` | warn | PR #11 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-stoker-poam` | warn | PR #12 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-stoker-poam` | warn | PR #13 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-stoker-poam` | warn | PR #14 merge/blocked (dep/github-actions,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,ai/breaking-suspected,risk/high,merge/blocked,blocked/major-bump) |
+| `Coalfire-CF/cs-onyx-parsers` | warn | PR #114 merge/blocked (dependencies,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/cs-onyx-parsers` | warn | PR #115 merge/blocked (dependencies,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/cs-onyx-parsers` | warn | PR #117 merge/blocked (dependencies,dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/driftctlGov` | warn | PR #43 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/driftctlGov` | warn | PR #44 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/driftctlGov` | warn | PR #45 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/driftctlGov` | warn | PR #46 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+| `Coalfire-CF/driftctlGov` | warn | PR #51 merge/blocked (dep/github-actions,merge/blocked,check/osv-clear,check/scorecard-pass,check/semver-major,check/changelog-breaking,risk/high,blocked/major-bump) |
+
+## automerge-missing-caller
+
+| repo | severity | detail |
+| --- | --- | --- |
+| `Coalfire-CF/terraform-google-secops` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-elasticache` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-prismacloud` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-managed-ad` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-nexpose` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-google-burpsuite` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-okta-stig` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-azurerm-VM-Linux-SS` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-azurerm-vm-windows-scale-set` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-azurerm-NAT-GW` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-azurerm-GitHub` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-azurerm-galleryimage-definition` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-azurerm-automation-account` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/Coalfire-AWS-RAMPpak` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-clientvpn` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-active-directory` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/Remediation-Of-Threats-Through-Issue-Entry` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-google-iap-ingress` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/CS-Azure-RA` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/terraform-aws-backup` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/cs-support-scripts` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/Coalfire-GCP-RAMPpak` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/cs-onyx-parsers` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+| `Coalfire-CF/driftctlGov` | fail | need org-dependabot.yml and org-dependabot-auto-merge.yml callers |
+
+## dependabot-unlabeled
+
+| repo | severity | detail |
+| --- | --- | --- |
+| `Coalfire-CF/cs-delta` | fail | PR #269 has no merge/* label |
+| `Coalfire-CF/cf-sre-claude-skills` | fail | PR #51 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-MySQL-Flexible` | fail | PR #135 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-firewall` | fail | PR #138 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-splunk` | fail | PR #115 has no merge/* label |
+| `Coalfire-CF/ansible-azure` | fail | PR #34 has no merge/* label |
+| `Coalfire-CF/terraform-aws-elasticache` | fail | PR #75 has no merge/* label |
+| `Coalfire-CF/terraform-aws-elasticache` | fail | PR #76 has no merge/* label |
+| `Coalfire-CF/terraform-aws-elasticache` | fail | PR #77 has no merge/* label |
+| `Coalfire-CF/terraform-aws-lambda` | fail | PR #149 has no merge/* label |
+| `Coalfire-CF/onyx2` | fail | PR #999 has no merge/* label |
+| `Coalfire-CF/terraform-aws-security-hub` | fail | PR #231 has no merge/* label |
+| `Coalfire-CF/cs-delta-client-onboarding` | fail | PR #57 has no merge/* label |
+| `Coalfire-CF/images` | fail | PR #286 has no merge/* label |
+| `Coalfire-CF/images` | fail | PR #288 has no merge/* label |
+| `Coalfire-CF/images` | fail | PR #289 has no merge/* label |
+| `Coalfire-CF/cs-anthracite` | fail | PR #507 has no merge/* label |
+| `Coalfire-CF/cs-anthracite` | fail | PR #508 has no merge/* label |
+| `Coalfire-CF/optum-conmon` | fail | PR #16 has no merge/* label |
+| `Coalfire-CF/terraform-google-burpsuite` | fail | PR #129 has no merge/* label |
+| `Coalfire-CF/terraform-google-burpsuite` | fail | PR #130 has no merge/* label |
+| `Coalfire-CF/terraform-google-burpsuite` | fail | PR #132 has no merge/* label |
+| `Coalfire-CF/terraform-google-burpsuite` | fail | PR #133 has no merge/* label |
+| `Coalfire-CF/terraform-google-burpsuite` | fail | PR #136 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-tenable.sc` | fail | PR #155 has no merge/* label |
+| `Coalfire-CF/cs-os-images` | fail | PR #40 has no merge/* label |
+| `Coalfire-CF/terraform-okta-stig` | fail | PR #121 has no merge/* label |
+| `Coalfire-CF/terraform-okta-stig` | fail | PR #122 has no merge/* label |
+| `Coalfire-CF/terraform-okta-stig` | fail | PR #123 has no merge/* label |
+| `Coalfire-CF/terraform-okta-stig` | fail | PR #124 has no merge/* label |
+| `Coalfire-CF/terraform-okta-stig` | fail | PR #131 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-VM-Linux-SS` | fail | PR #111 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-VM-Linux-SS` | fail | PR #112 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-VM-Linux-SS` | fail | PR #113 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-VM-Linux-SS` | fail | PR #114 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-vm-windows-scale-set` | fail | PR #115 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-vm-windows-scale-set` | fail | PR #116 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-vm-windows-scale-set` | fail | PR #117 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-vm-windows-scale-set` | fail | PR #118 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-NAT-GW` | fail | PR #64 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-NAT-GW` | fail | PR #65 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-NAT-GW` | fail | PR #66 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-NAT-GW` | fail | PR #67 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-GitHub` | fail | PR #65 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-GitHub` | fail | PR #66 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-GitHub` | fail | PR #67 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-GitHub` | fail | PR #68 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-galleryimage-definition` | fail | PR #84 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-galleryimage-definition` | fail | PR #85 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-galleryimage-definition` | fail | PR #86 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-galleryimage-definition` | fail | PR #88 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-galleryimage-definition` | fail | PR #90 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-automation-account` | fail | PR #92 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-automation-account` | fail | PR #93 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-automation-account` | fail | PR #94 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-automation-account` | fail | PR #96 has no merge/* label |
+| `Coalfire-CF/terraform-azurerm-automation-account` | fail | PR #98 has no merge/* label |
+| `Coalfire-CF/Coalfire-AWS-RAMPpak` | fail | PR #71 has no merge/* label |
+| `Coalfire-CF/Coalfire-AWS-RAMPpak` | fail | PR #72 has no merge/* label |
+| `Coalfire-CF/Coalfire-AWS-RAMPpak` | fail | PR #73 has no merge/* label |
+| `Coalfire-CF/Coalfire-AWS-RAMPpak` | fail | PR #75 has no merge/* label |
+| `Coalfire-CF/Coalfire-AWS-RAMPpak` | fail | PR #77 has no merge/* label |
+| `Coalfire-CF/terraform-aws-clientvpn` | fail | PR #67 has no merge/* label |
+| `Coalfire-CF/terraform-aws-clientvpn` | fail | PR #68 has no merge/* label |
+| `Coalfire-CF/terraform-aws-active-directory` | fail | PR #303 has no merge/* label |
+| `Coalfire-CF/terraform-aws-active-directory` | fail | PR #304 has no merge/* label |
+| `Coalfire-CF/terraform-aws-active-directory` | fail | PR #305 has no merge/* label |
+| `Coalfire-CF/terraform-aws-active-directory` | fail | PR #306 has no merge/* label |
+| `Coalfire-CF/terraform-aws-active-directory` | fail | PR #307 has no merge/* label |
+| `Coalfire-CF/terraform-aws-aquasec` | fail | PR #119 has no merge/* label |
+| `Coalfire-CF/cs-bstest02` | fail | PR #74 has no merge/* label |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | fail | PR #19 has no merge/* label |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | fail | PR #48 has no merge/* label |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | fail | PR #49 has no merge/* label |
+| `Coalfire-CF/Coalfire-Azure-RAMPpak` | fail | PR #52 has no merge/* label |
+| `Coalfire-CF/terraform-aws-iam-identity-center` | fail | PR #272 has no merge/* label |
+| `Coalfire-CF/terraform-aws-organization` | fail | PR #210 has no merge/* label |
+| `Coalfire-CF/ansible-aws` | fail | PR #373 has no merge/* label |
+| `Coalfire-CF/ansible-aws` | fail | PR #374 has no merge/* label |
+| `Coalfire-CF/ansible-aws` | fail | PR #375 has no merge/* label |
+| `Coalfire-CF/ansible-aws` | fail | PR #376 has no merge/* label |
+| `Coalfire-CF/ansible-aws` | fail | PR #378 has no merge/* label |
+| `Coalfire-CF/cs-did-deep-purple` | fail | PR #1 has no merge/* label |
+| `Coalfire-CF/cs-scm` | fail | PR #34 has no merge/* label |
+| `Coalfire-CF/terraform-google-iap-ingress` | fail | PR #95 has no merge/* label |
+| `Coalfire-CF/terraform-google-iap-ingress` | fail | PR #96 has no merge/* label |
+| `Coalfire-CF/terraform-google-iap-ingress` | fail | PR #97 has no merge/* label |
+| `Coalfire-CF/terraform-google-iap-ingress` | fail | PR #98 has no merge/* label |
+| `Coalfire-CF/terraform-google-iap-ingress` | fail | PR #99 has no merge/* label |
+| `Coalfire-CF/CS-Azure-RA` | fail | PR #195 has no merge/* label |
+| `Coalfire-CF/CS-Azure-RA` | fail | PR #196 has no merge/* label |
+| `Coalfire-CF/CS-Azure-RA` | fail | PR #197 has no merge/* label |
+| `Coalfire-CF/CS-Azure-RA` | fail | PR #198 has no merge/* label |
+| `Coalfire-CF/CS-Azure-RA` | fail | PR #199 has no merge/* label |
+| `Coalfire-CF/proliance-live-template` | fail | PR #8 has no merge/* label |
+| `Coalfire-CF/ansible-google` | fail | PR #11 has no merge/* label |
+| `Coalfire-CF/cs-go-bundler` | fail | PR #28 has no merge/* label |
+| `Coalfire-CF/coalforge-dashboard` | fail | PR #39 has no merge/* label |
+| `Coalfire-CF/org-opa-policies` | fail | PR #28 has no merge/* label |
+| `Coalfire-CF/terraform-aws-backup` | fail | PR #95 has no merge/* label |
+| `Coalfire-CF/terraform-aws-backup` | fail | PR #96 has no merge/* label |
+| `Coalfire-CF/terraform-aws-backup` | fail | PR #97 has no merge/* label |
+| `Coalfire-CF/terraform-aws-backup` | fail | PR #98 has no merge/* label |
+| `Coalfire-CF/terraform-aws-backup` | fail | PR #99 has no merge/* label |
+| `Coalfire-CF/proliance-dev` | fail | PR #29 has no merge/* label |
+| `Coalfire-CF/packer-azure` | fail | PR #14 has no merge/* label |
+| `Coalfire-CF/cs-pipeline-runner` | fail | PR #22 has no merge/* label |
+| `Coalfire-CF/MTCS` | fail | PR #143 has no merge/* label |
+| `Coalfire-CF/evidence-capture` | fail | PR #12 has no merge/* label |
+| `Coalfire-CF/terraform-aws-eck-aws-ingestion` | fail | PR #14 has no merge/* label |
+| `Coalfire-CF/proliance-policies` | fail | PR #9 has no merge/* label |
+| `Coalfire-CF/cs-test` | fail | PR #3 has no merge/* label |
+| `Coalfire-CF/cs-test` | fail | PR #7 has no merge/* label |
+| `Coalfire-CF/terraform-aws-vault-enterprise-mvp` | fail | PR #42 has no merge/* label |
+| `Coalfire-CF/image-bakery` | fail | PR #24 has no merge/* label |
+| `Coalfire-CF/terraform-azure-vpn-gateway` | fail | PR #14 has no merge/* label |
+| `Coalfire-CF/proliance-docs` | fail | PR #7 has no merge/* label |
+| `Coalfire-CF/proliance-modules` | fail | PR #92 has no merge/* label |
+| `Coalfire-CF/cs-support-scripts` | fail | PR #43 has no merge/* label |
+| `Coalfire-CF/cs-support-scripts` | fail | PR #44 has no merge/* label |
+| `Coalfire-CF/cs-support-scripts` | fail | PR #45 has no merge/* label |
+| `Coalfire-CF/cs-support-scripts` | fail | PR #46 has no merge/* label |
+| `Coalfire-CF/ansible-collection-elasticsearch` | fail | PR #6 has no merge/* label |
+| `Coalfire-CF/prowler-claude-did-projects` | fail | PR #6 has no merge/* label |
+| `Coalfire-CF/cs-pak-sbom` | fail | PR #13 has no merge/* label |
+| `Coalfire-CF/azure-policy-management` | fail | PR #21 has no merge/* label |
+| `Coalfire-CF/ansible-collection-aws` | fail | PR #6 has no merge/* label |
+| `Coalfire-CF/sre-icm-sre-sprint-planning` | fail | PR #10 has no merge/* label |
+| `Coalfire-CF/Coalfire-GCP-RAMPpak` | fail | PR #53 has no merge/* label |
+| `Coalfire-CF/Coalfire-GCP-RAMPpak` | fail | PR #54 has no merge/* label |
+| `Coalfire-CF/Coalfire-GCP-RAMPpak` | fail | PR #55 has no merge/* label |
+| `Coalfire-CF/Coalfire-GCP-RAMPpak` | fail | PR #56 has no merge/* label |
+| `Coalfire-CF/packer-google` | fail | PR #18 has no merge/* label |
+| `Coalfire-CF/cs-jim-industries` | fail | PR #11 has no merge/* label |
+| `Coalfire-CF/cs-onyx-parsers` | fail | PR #116 has no merge/* label |
+| `Coalfire-CF/cs-onyx-parsers` | fail | PR #118 has no merge/* label |
+
+## no-caller
+
+| repo | severity | detail |
+| --- | --- | --- |
+| `Coalfire-CF/PUBSEC-GovRAMP-Agent-Workspace` | fail | no Coalfire-CF/Actions uses: and no org-release.yml |
+
+## pin-lag
+
+| repo | severity | detail |
+| --- | --- | --- |
+| `Coalfire-CF/cs-delta` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/cs-delta` | fail | v0.17.0@43274fdf vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-aws-gitlab` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-aws-vpc-nfw` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/upwind-gov` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/cs-dev-conmon` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/CF-SecOps-Detection-Repo` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-trend-micro-dsm` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-azurerm-vm-linux` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-security-core` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-azurerm-vm-backup` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-azurerm-vnet` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-secret-manager` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-azurerm-VM-SQL` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-rhel-image-builder` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-azurerm-vm-site-recovery` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-cloud-gke` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-azurerm-Trend-Micro-DSM` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-kms` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-log-export` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-sumologic` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-private-ca` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-private-ca` | fail | v0.17.0@43274fdf vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-project` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-project` | fail | v0.17.0@43274fdf vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-lb` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-service-account` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-folder` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-active-directory` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-active-directory` | fail | v0.17.0@43274fdf vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-private-service-access` | fail | v0.18.0@162d71ff vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-palo-alto` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-palo-alto` | fail | v0.17.0@43274fdf vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-cloud-sql` | fail | v0.16.1@9e201c39 vs v0.18.1@23c6c8bc |
+| `Coalfire-CF/terraform-google-cloud-sql` | fail | v0.17.0@43274fdf vs v
+
+... truncated (120792 bytes). Full report is the workflow artifact.

--- a/docs/superpowers/specs/2026-08-20-org-actions-fleet-audit-design.md
+++ b/docs/superpowers/specs/2026-08-20-org-actions-fleet-audit-design.md
@@ -1,0 +1,119 @@
+# Org Actions fleet audit — design spec (2026-08-20)
+
+**Status:** implemented 2026-08-20 · first live snapshot [docs/RESEARCH_actions-fleet-audit-2026-08-20.md](../../RESEARCH_actions-fleet-audit-2026-08-20.md) · **Runbook:** [docs/ORG_ACTIONS_FLEET_AUDIT.md](../../ORG_ACTIONS_FLEET_AUDIT.md)
+
+## Problem
+
+Consumer repos in `Coalfire-CF` lag the Actions release, miss Dependabot auto-merge wiring, or never cut `v*` tags. The 2026-08-11 workflow audit scored producer YAML. This sweep scores fleet health.
+
+## Shape
+
+Read-only sweeper: `scripts/fleet-audit.sh` (enumerate + classify) + `scripts/fleet-audit-report.sh` (NDJSON to markdown) + `.github/workflows/org-actions-fleet-audit.yml` (weekly + dispatch).
+
+**Decision:** report only. No consumer pushes, PRs, merges, or label changes. The only write is a standing issue on `Coalfire-CF/Actions` plus the workflow artifact.
+
+**Decision:** `bootstrap-exempt` repos are still classified. They get `exempt: true`. Lag stays visible.
+
+**Decision:** `Coalfire-CF/Actions` is `role=producer`. Local `./` workflow refs are not consumer pins. Pin-lag / no-caller do not apply. Other checks still run.
+
+## Check catalog
+
+| id | severity | When |
+|---|---|---|
+| `pin-lag` | fail | A `Coalfire-CF/Actions/.github/workflows/*.yml@<sha> # vX.Y.Z` pin is older than the run's `ACTIONS_SHA` / `ACTIONS_VERSION` |
+| `pin-bad-ref` | fail | Pin ref is `@main`, a branch, or a moving major (`@v1`) |
+| `pin-bare-tag` | warn | Pin is `@vX.Y.Z` with no 40-hex SHA (RFC-0008 transitional) |
+| `pin-sha-no-comment` | fail | 40-hex SHA with no `# vX[.Y[.Z]]` comment |
+| `pin-mixed` | fail | Two or more distinct Actions SHAs or version comments in one repo |
+| `no-caller` | fail | No `Coalfire-CF/Actions` workflow `uses:` and no `.github/workflows/org-release.yml` (bootstrap gap) |
+| `automerge-missing-caller` | fail | Missing `org-dependabot.yml` or `org-dependabot-auto-merge.yml` under `.github/workflows/` (after adoption: has `org-release.yml`) |
+| `dependabot-missing-gha` | fail | Adopted, but `.github/dependabot.yml` missing `package-ecosystem: github-actions` |
+| `dependabot-unlabeled` | fail | Open `dependabot[bot]` PR that touches workflows / github-actions and has none of `merge/approved`, `merge/blocked`, `merge/skipped` |
+| `automerge-approved-unmerged` | fail | Open Dependabot PR labeled `merge/approved` (reconcile/ruleset path) |
+| `automerge-blocked` | warn | Open Dependabot PR labeled `merge/blocked` (reason labels in `detail`) |
+| `automerge-tf-block-on-actions` | fail | Open github-actions Dependabot PR labeled `blocked/terraform-no-tests` |
+| `ruleset-no-bypass` | fail | Repo-level ruleset with a `pull_request` rule and no Integration bypass for `AUTOMERGE_APP_ID` (default `3436395`) |
+| `source-pin-fail` | fail | Coalfire-CF Terraform `source` FAIL-class on root-level `*.tf` (same rules as `source-pin-check.sh`) |
+| `source-pin-warn` | warn | Coalfire-CF Terraform `source` WARN-class (tag `?ref=`) |
+| `release-no-tags` | fail | Has `org-release.yml` caller and zero `v*` git tags |
+| `release-tag-no-github-release` | warn | `v*` tags exist but no GitHub Release objects |
+| `release-please-stale` | fail | Open PR whose head branch matches `release-please--branches--*` |
+| `terraform-missing-gates` | fail | Languages include HCL, adopted, missing caller files `org-terraform-validate.yml` / `org-terraform-fmt.yml` / `org-terraform-docs.yml` |
+| `bootstrap-pr-open` | warn | Open PR on `bootstrap/*` or labeled `bootstrap/proposed` |
+| `orphan-caller` | warn | `uses:` of `org-terraform-apply.yml`, `org-terraform-plan.yml`, `org-terraform-source-pin.yml`, or `org-terraform-version-band.yml` |
+
+Unreadable metadata or contents: repo `status=SKIP`, `skip_reason=unreadable`. Never emit PASS from a failed read.
+
+Infra skip (enumerate filter, same as bootstrap): `Actions` is not skipped (producer). Skip `.github`, `.allstar`, archived, forks.
+
+## Per-repo JSON (NDJSON, one object per line)
+
+```json
+{
+  "repo": "Coalfire-CF/example",
+  "role": "consumer",
+  "exempt": false,
+  "status": "FAIL",
+  "skip_reason": "",
+  "is_terraform": true,
+  "has_org_release": true,
+  "pins": [
+    {
+      "file": ".github/workflows/org-release.yml",
+      "workflow": "org-release.yml",
+      "ref": "abc...",
+      "version": "v0.12.1",
+      "shape": "sha-comment"
+    }
+  ],
+  "findings": [
+    { "id": "pin-lag", "severity": "fail", "detail": "v0.12.1 vs v0.18.1" }
+  ]
+}
+```
+
+`status`: `SKIP` (unreadable/infra) · `FAIL` (any fail finding) · `PASS` (no fail findings; warn findings allowed).
+
+Pin `shape`: `sha-comment` · `sha-no-comment` · `bare-tag` · `bad-ref` · `local`.
+
+## Report + standing issue
+
+`fleet-audit-report.sh` reads NDJSON on stdin. Writes markdown: current pin, counts, then one table per check id that fired.
+
+Standing issue title (exact): `Actions fleet audit`
+
+Upsert: search open issues with that title on `Coalfire-CF/Actions`; edit body if found, else create. Body is the report markdown, truncated to 60_000 characters with a pointer to the artifact if truncated.
+
+## Snapshot mode (tests)
+
+`FLEET_AUDIT_SNAPSHOT=<dir>` skips `gh`. Directory layout:
+
+```
+<meta.json>           # nameWithOwner, default_branch, repositoryTopics, isFork, isArchived
+<languages.json>      # GitHub languages API object
+<workflows/*.yml>
+<dependabot.yml>      # optional, maps to .github/dependabot.yml
+<prs.json>            # gh pr list --json number,title,author,labels,headRefName,files
+<tags.json>           # array of {name}
+<releases.json>       # array of {tagName}
+<rulesets.json>       # repo rulesets array
+<tf/*.tf>             # optional Terraform sources
+```
+
+## Env
+
+| Var | Default | Meaning |
+|---|---|---|
+| `ORG` | `Coalfire-CF` | GitHub org |
+| `REPO` | empty | Single `owner/name` canary |
+| `ACTIONS_SHA` | required (live) | Current Actions release commit |
+| `ACTIONS_VERSION` | required (live) | Current tag, e.g. `v0.18.1` |
+| `AUTOMERGE_APP_ID` | `3436395` | ci-automerge-app |
+| `FLEET_AUDIT_SNAPSHOT` | empty | Fixture dir (no network) |
+| `GH_TOKEN` | from environment | App token in CI |
+
+## Rejected
+
+- Mutation / auto-bump PRs: Dependabot + bootstrap already exist.
+- Skipping `bootstrap-exempt`: hides lag.
+- Slack on every run: extra secret surface; issue + artifact is enough.

--- a/scripts/fleet-audit-report.sh
+++ b/scripts/fleet-audit-report.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# fleet-audit-report.sh — roll fleet-audit NDJSON (stdin) into markdown.
+# Truncates to FLEET_AUDIT_MAX_BYTES (default 60000) for GitHub issue bodies.
+
+set -euo pipefail
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
+
+MAX="${FLEET_AUDIT_MAX_BYTES:-60000}"
+ACTIONS_VERSION="${ACTIONS_VERSION:-unknown}"
+ACTIONS_SHA="${ACTIONS_SHA:-unknown}"
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+cat > "$TMP"
+
+if [ ! -s "$TMP" ]; then
+  echo "# Actions fleet audit"
+  echo
+  echo "No repo rows. Empty enumeration."
+  exit 0
+fi
+
+# Tolerate trailing whitespace; skip blank lines.
+FILTERED="$(mktemp)"
+trap 'rm -f "$TMP" "$FILTERED"' EXIT
+grep -v '^[[:space:]]*$' "$TMP" > "$FILTERED" || true
+[ -s "$FILTERED" ] || {
+  echo "# Actions fleet audit"
+  echo
+  echo "No repo rows. Empty enumeration."
+  exit 0
+}
+
+counts="$(jq -s '{
+  total: length,
+  pass: [.[] | select(.status=="PASS")] | length,
+  fail: [.[] | select(.status=="FAIL")] | length,
+  skip: [.[] | select(.status=="SKIP")] | length,
+  exempt: [.[] | select(.exempt==true)] | length
+}' "$FILTERED")"
+
+{
+  echo "# Actions fleet audit"
+  echo
+  echo "Pin: \`${ACTIONS_VERSION}\` @ \`${ACTIONS_SHA}\`"
+  echo
+  echo "| metric | count |"
+  echo "| --- | --- |"
+  echo "| total | $(jq -r .total <<<"$counts") |"
+  echo "| PASS | $(jq -r .pass <<<"$counts") |"
+  echo "| FAIL | $(jq -r .fail <<<"$counts") |"
+  echo "| SKIP | $(jq -r .skip <<<"$counts") |"
+  echo "| bootstrap-exempt | $(jq -r .exempt <<<"$counts") |"
+  echo
+
+  ids="$(jq -s -r '[.[].findings[]? | .id] | unique | .[]' "$FILTERED")"
+  if [ -z "$ids" ]; then
+    echo "No findings."
+  else
+    echo "## Counts by check"
+    echo
+    echo "| id | repos |"
+    echo "| --- | --- |"
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      n="$(jq -s --arg id "$id" '[.[] | select(any(.findings[]?; .id==$id))] | length' "$FILTERED")"
+      echo "| \`${id}\` | ${n} |"
+    done <<< "$ids"
+    echo
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      echo "## ${id}"
+      echo
+      echo "| repo | severity | detail |"
+      echo "| --- | --- | --- |"
+      jq -s -r --arg id "$id" '
+        .[] as $r
+        | $r.findings[]?
+        | select(.id==$id)
+        | "| `\($r.repo)` | \(.severity) | \( (.detail // "") | gsub("\\|"; "\\|") ) |"
+      ' "$FILTERED"
+      echo
+    done <<< "$ids"
+  fi
+
+  skips="$(jq -s -r '[.[] | select(.status=="SKIP") | .repo] | .[]' "$FILTERED")"
+  if [ -n "$skips" ]; then
+    echo "## SKIP"
+    echo
+    echo "| repo | reason |"
+    echo "| --- | --- |"
+    jq -s -r '.[] | select(.status=="SKIP") | "| `\(.repo)` | \(.skip_reason) |"' "$FILTERED"
+    echo
+  fi
+} > "${TMP}.md"
+
+body="$(cat "${TMP}.md")"
+bytes="$(printf '%s' "$body" | wc -c | tr -d ' ')"
+if [ "$bytes" -gt "$MAX" ]; then
+  printf '%s\n' "${body:0:$((MAX - 80))}"
+  echo
+  echo "... truncated (${bytes} bytes). Full report is the workflow artifact."
+else
+  printf '%s\n' "$body"
+fi
+rm -f "${TMP}.md"

--- a/scripts/fleet-audit-report.sh
+++ b/scripts/fleet-audit-report.sh
@@ -99,7 +99,13 @@ counts="$(jq -s '{
 body="$(cat "${TMP}.md")"
 bytes="$(printf '%s' "$body" | wc -c | tr -d ' ')"
 if [ "$bytes" -gt "$MAX" ]; then
-  printf '%s\n' "${body:0:$((MAX - 80))}"
+  # Cut whole lines only. A mid-line cut emits a half-written table row, which
+  # markdownlint rejects as MD055 (missing trailing pipe).
+  LC_ALL=C awk -v max="$((MAX - 120))" '
+    { n = length($0) + 1 }
+    used + n > max { exit }
+    { print; used += n }
+  ' "${TMP}.md"
   echo
   echo "... truncated (${bytes} bytes). Full report is the workflow artifact."
 else

--- a/scripts/fleet-audit.sh
+++ b/scripts/fleet-audit.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+#
+# fleet-audit.sh — read-only Coalfire-CF Actions fleet classifier.
+# Live mode enumerates org repos via gh (GET only). Snapshot mode
+# (FLEET_AUDIT_SNAPSHOT) classifies a fixture tree for tests.
+#
+# Stdout: one JSON object per repo (NDJSON). Logs on stderr.
+# Exit 0 for well-formed runs (including SKIP rows). Exit 2 on usage error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/retry-lib.sh
+. "${SCRIPT_DIR}/retry-lib.sh"
+
+ORG="${ORG:-Coalfire-CF}"
+REPO="${REPO:-}"
+AUTOMERGE_APP_ID="${AUTOMERGE_APP_ID:-3436395}"
+FLEET_AUDIT_SNAPSHOT="${FLEET_AUDIT_SNAPSHOT:-}"
+TF_FETCH_CAP="${TF_FETCH_CAP:-80}"
+
+log() { echo "[fleet-audit] $*" >&2; }
+
+usage_exit() { echo "usage: $*" >&2; exit 2; }
+
+command -v jq >/dev/null || usage_exit "jq is required"
+
+if [ -z "$FLEET_AUDIT_SNAPSHOT" ]; then
+  [ -n "${ACTIONS_SHA:-}" ] || usage_exit "ACTIONS_SHA required"
+  [ -n "${ACTIONS_VERSION:-}" ] || usage_exit "ACTIONS_VERSION required"
+  case "$ACTIONS_SHA" in
+    *[!0-9a-fA-F]*|"") usage_exit "ACTIONS_SHA must be 40-hex" ;;
+  esac
+  [ "${#ACTIONS_SHA}" -eq 40 ] || usage_exit "ACTIONS_SHA must be 40-hex"
+fi
+
+# Snapshot mode can omit pins for the unreadable-meta case.
+ACTIONS_SHA="${ACTIONS_SHA:-0000000000000000000000000000000000000000}"
+ACTIONS_VERSION="${ACTIONS_VERSION:-v0.0.0}"
+
+# Used via with_retry in live enumerate (shellcheck cannot see the call).
+# shellcheck disable=SC2329
+_gh_read_once() {
+  local out rc
+  set +e
+  out="$(gh "$@" 2>/tmp/fleet-audit-gh.err)"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    if grep -qiE 'rate limit|timeout|502|503|secondary rate' /tmp/fleet-audit-gh.err 2>/dev/null; then
+      return "$RETRY_TRANSIENT_RC"
+    fi
+    return "$rc"
+  fi
+  printf '%s' "$out"
+  return 0
+}
+
+gh_read() { with_retry 3 2 20 -- _gh_read_once "$@"; }
+
+ver_norm() { printf '%s' "$1" | sed -E 's/^[vV]//'; }
+
+ver_lt() {
+  local a b
+  a="$(ver_norm "$1")"
+  b="$(ver_norm "$2")"
+  [ "$a" = "$b" ] && return 1
+  [ "$(printf '%s\n%s\n' "$a" "$b" | sort -V | head -n1)" = "$a" ]
+}
+
+tag_name() {
+  local raw="$1"
+  raw="${raw#refs/tags/}"
+  printf '%s' "$raw"
+}
+
+is_v_tag() {
+  printf '%s' "$(tag_name "$1")" | grep -qE '^v[0-9]'
+}
+
+add_finding() {
+  jq -n --arg id "$1" --arg severity "$2" --arg detail "$3" \
+    '{id:$id,severity:$severity,detail:$detail}' >> "$FINDINGS"
+}
+
+add_pin() {
+  jq -n --arg file "$1" --arg workflow "$2" --arg ref "$3" \
+    --arg version "$4" --arg shape "$5" \
+    '{file:$file,workflow:$workflow,ref:$ref,version:$version,shape:$shape}' >> "$PINS"
+}
+
+pr_login() {
+  jq -r '.author.login // .author // ""' <<<"$1" 2>/dev/null || true
+}
+
+pr_label_names() {
+  jq -r '[.labels[]? | (.name // .)] | .[]' <<<"$1" 2>/dev/null || true
+}
+
+pr_is_dependabot() {
+  local login
+  login="$(pr_login "$1")"
+  case "$login" in
+    dependabot|'dependabot[bot]'|'app/dependabot') return 0 ;;
+  esac
+  return 1
+}
+
+pr_is_actions_bump() {
+  local pr="$1"
+  echo "$pr" | jq -e '
+    (.headRefName // "" | test("github_actions";"i"))
+    or (.title // "" | test("github-actions|Coalfire-CF/Actions";"i"))
+    or ([.files[]? | .path // empty] | any(test("^\\.github/workflows/")))
+  ' >/dev/null 2>&1
+}
+
+pr_has_label() {
+  printf '%s' "$(pr_label_names "$1")" | grep -qxF "$2"
+}
+
+scan_source_pins() {
+  local tfdir="$1"
+  [ -d "$tfdir" ] || return 0
+  local file lineno content url ref has_comment
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    lineno=0
+    while IFS= read -r content || [ -n "$content" ]; do
+      lineno=$((lineno + 1))
+      printf '%s' "$content" | grep -qE 'source[[:space:]]*=[[:space:]]*"github\.com/Coalfire-CF/' || continue
+      url="$(printf '%s' "$content" | sed -E 's/.*"(github\.com\/Coalfire-CF\/[^"]*)".*/\1/')"
+      has_comment=false
+      if printf '%s' "$content" | grep -Eq '#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+'; then
+        has_comment=true
+      fi
+      if [[ "$url" != *"?ref="* ]]; then
+        add_finding source-pin-fail fail "unpinned source (no ?ref=): ${url}"
+        continue
+      fi
+      ref="${url#*\?ref=}"
+      ref="${ref%%[/&]*}"
+      if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        if [[ "$has_comment" != "true" ]]; then
+          add_finding source-pin-fail fail "bare SHA source without # vX.Y.Z: ${url}"
+        fi
+      elif [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        add_finding source-pin-warn warn "tag ref ${ref} on ${url}"
+      else
+        add_finding source-pin-fail fail "mutable source ref='${ref}': ${url}"
+      fi
+    done < "$file"
+  done < <(find "$tfdir" -type f -name '*.tf' 2>/dev/null || true)
+}
+
+classify_snapshot() {
+  local dir="$1"
+  local repo role exempt status skip_reason has_org_release is_terraform
+  local wf workflows_dir meta langs
+  FINDINGS="$(mktemp)"
+  PINS="$(mktemp)"
+  : >"$FINDINGS"
+  : >"$PINS"
+
+  emit_and_cleanup() {
+    local findings_json pins_json
+    findings_json="$(jq -s 'unique_by({id,detail})' "$FINDINGS")"
+    pins_json="$(jq -s '.' "$PINS")"
+    jq -c -n \
+      --arg repo "$repo" \
+      --arg role "$role" \
+      --argjson exempt "$exempt" \
+      --arg status "$status" \
+      --arg skip_reason "$skip_reason" \
+      --argjson is_terraform "$is_terraform" \
+      --argjson has_org_release "$has_org_release" \
+      --argjson pins "$pins_json" \
+      --argjson findings "$findings_json" \
+      '{
+        repo:$repo, role:$role, exempt:$exempt, status:$status,
+        skip_reason:$skip_reason, is_terraform:$is_terraform,
+        has_org_release:$has_org_release, pins:$pins, findings:$findings
+      }'
+    rm -f "$FINDINGS" "$PINS"
+  }
+
+  repo="unknown"
+  role="consumer"
+  exempt=false
+  status="SKIP"
+  skip_reason="unreadable"
+  has_org_release=false
+  is_terraform=false
+
+  meta="${dir}/meta.json"
+  if [ ! -f "$meta" ]; then
+    emit_and_cleanup
+    return 0
+  fi
+
+  repo="$(jq -r '.nameWithOwner // .full_name // empty' "$meta")"
+  [ -n "$repo" ] || { emit_and_cleanup; return 0; }
+
+  if jq -e '.isArchived == true or .archived == true or .isFork == true or .fork == true' "$meta" >/dev/null 2>&1; then
+    skip_reason="infra"
+    emit_and_cleanup
+    return 0
+  fi
+
+  case "$repo" in
+    "${ORG}/.github"|"${ORG}/.allstar")
+      skip_reason="infra"
+      emit_and_cleanup
+      return 0
+      ;;
+  esac
+
+  if [ "$repo" = "${ORG}/Actions" ]; then
+    role="producer"
+  fi
+
+  if jq -e '[.repositoryTopics[]? | .name] + (.topics // []) | index("bootstrap-exempt") != null' "$meta" >/dev/null 2>&1; then
+    exempt=true
+  fi
+
+  skip_reason=""
+  langs="${dir}/languages.json"
+  if [ -f "$langs" ] && jq -e '.HCL != null' "$langs" >/dev/null 2>&1; then
+    is_terraform=true
+  fi
+
+  workflows_dir="${dir}/workflows"
+  if [ -f "${workflows_dir}/org-release.yml" ] || [ -f "${workflows_dir}/org-release.yaml" ]; then
+    has_org_release=true
+  fi
+
+  local -a pin_shas=() pin_vers=()
+  local has_remote_actions=false
+  if [ -d "$workflows_dir" ]; then
+    while IFS= read -r wf; do
+      [ -n "$wf" ] || continue
+      local lineno=0 content token ref has_comment workflow shape version
+      while IFS= read -r content || [ -n "$content" ]; do
+        lineno=$((lineno + 1))
+        printf '%s' "$content" | grep -qE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]' || continue
+        printf '%s' "$content" | grep -qE '^[[:space:]]*#' && continue
+        token="${content#*uses:}"
+        token="$(printf '%s' "$token" | sed -E 's/^[[:space:]]+//')"
+        token="${token%%[[:space:]]*}"
+        token="${token%\"}"; token="${token#\"}"
+        token="${token%\'}"; token="${token#\'}"
+        [[ "$token" == ./* || "$token" == ../* ]] && continue
+        printf '%s' "$token" | grep -qE 'Coalfire-CF/Actions/\.github/workflows/' || continue
+        has_remote_actions=true
+        workflow="$(printf '%s' "$token" | sed -E 's#.*\.github/workflows/([^@]+)@.*#\1#')"
+        ref="${token##*@}"
+        has_comment=false
+        version=""
+        if printf '%s' "$content" | grep -Eq '#[[:space:]]*v[0-9]+(\.[0-9]+)*'; then
+          has_comment=true
+          version="$(printf '%s' "$content" | sed -E 's/.*#[[:space:]]*(v[0-9]+(\.[0-9]+)*).*/\1/')"
+        fi
+        case "$workflow" in
+          org-terraform-apply.yml|org-terraform-plan.yml|org-terraform-source-pin.yml|org-terraform-version-band.yml)
+            add_finding orphan-caller warn "uses ${workflow}"
+            ;;
+        esac
+        if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+          if [[ "$has_comment" != "true" ]]; then
+            shape="sha-no-comment"
+            add_finding pin-sha-no-comment fail "${wf##*/}@${ref}"
+          else
+            shape="sha-comment"
+            pin_shas+=("$ref")
+            pin_vers+=("$version")
+            if [ "$role" != "producer" ]; then
+              if [ "$ref" != "$ACTIONS_SHA" ] || ver_lt "$version" "$ACTIONS_VERSION"; then
+                add_finding pin-lag fail "${version}@${ref:0:8} vs ${ACTIONS_VERSION}@${ACTIONS_SHA:0:8}"
+              fi
+            fi
+          fi
+        elif [[ "$ref" =~ ^v[0-9]+$ ]]; then
+          shape="bad-ref"
+          add_finding pin-bad-ref fail "${workflow}@${ref}"
+        elif [[ "$ref" =~ ^v[0-9]+(\.[0-9]+)+$ ]]; then
+          shape="bare-tag"
+          add_finding pin-bare-tag warn "${workflow}@${ref}"
+        else
+          shape="bad-ref"
+          add_finding pin-bad-ref fail "${workflow}@${ref}"
+        fi
+        add_pin ".github/workflows/${wf##*/}" "$workflow" "$ref" "$version" "$shape"
+      done < "$wf"
+    done < <(find "$workflows_dir" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+  fi
+
+  if [ "$role" != "producer" ] && [ "$has_remote_actions" = false ] && [ "$has_org_release" = false ]; then
+    add_finding no-caller fail "no Coalfire-CF/Actions uses: and no org-release.yml"
+  fi
+
+  local uniq_shas uniq_vers
+  if [ "${#pin_shas[@]}" -gt 1 ]; then
+    uniq_shas="$(printf '%s\n' "${pin_shas[@]}" | sort -u | wc -l | tr -d ' ')"
+    uniq_vers="$(printf '%s\n' "${pin_vers[@]}" | sort -u | wc -l | tr -d ' ')"
+    if [ "$uniq_shas" -gt 1 ] || [ "$uniq_vers" -gt 1 ]; then
+      add_finding pin-mixed fail "distinct SHAs=${uniq_shas} versions=${uniq_vers}"
+    fi
+  fi
+
+  if [ "$has_org_release" = true ] && [ "$role" != "producer" ]; then
+    local has_dep_wf=false has_am_wf=false
+    if [ -f "${workflows_dir}/org-dependabot.yml" ] || [ -f "${workflows_dir}/org-dependabot.yaml" ]; then
+      has_dep_wf=true
+    fi
+    if [ -f "${workflows_dir}/org-dependabot-auto-merge.yml" ] || [ -f "${workflows_dir}/org-dependabot-auto-merge.yaml" ]; then
+      has_am_wf=true
+    fi
+    if [ "$has_dep_wf" = false ] || [ "$has_am_wf" = false ]; then
+      add_finding automerge-missing-caller fail "need org-dependabot.yml and org-dependabot-auto-merge.yml callers"
+    fi
+    if [ ! -f "${dir}/dependabot.yml" ] || ! grep -qE 'package-ecosystem:[[:space:]]*"?github-actions"?' "${dir}/dependabot.yml"; then
+      add_finding dependabot-missing-gha fail "dependabot.yml missing github-actions ecosystem"
+    fi
+  fi
+
+  local prs="${dir}/prs.json"
+  if [ -f "$prs" ]; then
+    local pr n labels
+    while IFS= read -r pr; do
+      [ -n "$pr" ] || continue
+      n="$(jq -r '.number' <<<"$pr")"
+      if pr_is_dependabot "$pr"; then
+        labels="$(pr_label_names "$pr" | tr '\n' ',' | sed 's/,$//')"
+        if pr_has_label "$pr" "merge/approved"; then
+          add_finding automerge-approved-unmerged fail "PR #${n} labeled merge/approved"
+        fi
+        if pr_has_label "$pr" "merge/blocked"; then
+          add_finding automerge-blocked warn "PR #${n} merge/blocked (${labels})"
+        fi
+        if pr_is_actions_bump "$pr"; then
+          if pr_has_label "$pr" "blocked/terraform-no-tests"; then
+            add_finding automerge-tf-block-on-actions fail "PR #${n} github-actions bump labeled blocked/terraform-no-tests"
+          fi
+          if ! pr_has_label "$pr" "merge/approved" \
+            && ! pr_has_label "$pr" "merge/blocked" \
+            && ! pr_has_label "$pr" "merge/skipped"; then
+            add_finding dependabot-unlabeled fail "PR #${n} has no merge/* label"
+          fi
+        fi
+      fi
+      local head
+      head="$(jq -r '.headRefName // empty' <<<"$pr")"
+      if [[ "$head" == bootstrap/* ]] || pr_has_label "$pr" "bootstrap/proposed"; then
+        add_finding bootstrap-pr-open warn "PR #${n} ${head}"
+      fi
+      if [[ "$head" == release-please--branches--* ]]; then
+        add_finding release-please-stale fail "PR #${n} ${head}"
+      fi
+    done < <(jq -c '.[]' "$prs" 2>/dev/null || true)
+  fi
+
+  local rules="${dir}/rulesets.json"
+  if [ -f "$rules" ]; then
+    if jq -e --argjson app "$AUTOMERGE_APP_ID" '
+      [.[] | select((.rules // []) | map(.type) | index("pull_request") != null)
+          | select(((.bypass_actors // []) | map(.actor_id) | index($app)) | not)
+      ] | length > 0
+    ' "$rules" >/dev/null 2>&1; then
+      add_finding ruleset-no-bypass fail "repo pull_request ruleset missing automerge app ${AUTOMERGE_APP_ID} bypass"
+    fi
+  fi
+
+  scan_source_pins "${dir}/tf"
+
+  local tags="${dir}/tags.json"
+  local releases="${dir}/releases.json"
+  local has_vtag=false has_gh_rel=false
+  if [ -f "$tags" ]; then
+    local t
+    while IFS= read -r t; do
+      [ -n "$t" ] || continue
+      if is_v_tag "$t"; then has_vtag=true; break; fi
+    done < <(jq -r '.[] | (.name // .ref // .)' "$tags" 2>/dev/null || true)
+  fi
+  if [ -f "$releases" ] && jq -e 'length > 0' "$releases" >/dev/null 2>&1; then
+    has_gh_rel=true
+  fi
+  if [ "$has_org_release" = true ] && [ "$has_vtag" = false ]; then
+    add_finding release-no-tags fail "org-release.yml present but no v* git tags"
+  fi
+  if [ "$has_vtag" = true ] && [ "$has_gh_rel" = false ]; then
+    add_finding release-tag-no-github-release warn "v* tags present but no GitHub Releases"
+  fi
+
+  if [ "$is_terraform" = true ] && [ "$has_org_release" = true ]; then
+    local missing=""
+    [ -f "${workflows_dir}/org-terraform-validate.yml" ] || [ -f "${workflows_dir}/org-terraform-validate.yaml" ] || missing="${missing} validate"
+    [ -f "${workflows_dir}/org-terraform-fmt.yml" ] || [ -f "${workflows_dir}/org-terraform-fmt.yaml" ] || missing="${missing} fmt"
+    [ -f "${workflows_dir}/org-terraform-docs.yml" ] || [ -f "${workflows_dir}/org-terraform-docs.yaml" ] || missing="${missing} docs"
+    if [ -n "$missing" ]; then
+      add_finding terraform-missing-gates fail "adopted terraform repo missing caller(s):${missing}"
+    fi
+  fi
+
+  if jq -s -e '[.[] | select(.severity == "fail")] | length > 0' "$FINDINGS" >/dev/null 2>&1; then
+    status="FAIL"
+  else
+    status="PASS"
+  fi
+  emit_and_cleanup
+}
+
+# shellcheck disable=SC2329
+fetch_snapshot() {
+  local dest="$1" target="$2"
+  mkdir -p "$dest/workflows" "$dest/tf"
+  local meta
+  if ! meta="$(gh_read api "repos/${target}")"; then
+    return 1
+  fi
+  printf '%s' "$meta" | jq '{
+    nameWithOwner: .full_name,
+    default_branch: (.default_branch // "main"),
+    isFork: (.fork // false),
+    isArchived: (.archived // false),
+    repositoryTopics: [(.topics // [])[] | {name: .}]
+  }' > "$dest/meta.json"
+
+  local langs
+  if langs="$(gh_read api "repos/${target}/languages")"; then
+    printf '%s' "$langs" > "$dest/languages.json"
+  else
+    echo '{}' > "$dest/languages.json"
+  fi
+
+  local listing path b64
+  if listing="$(gh_read api "repos/${target}/contents/.github/workflows")"; then
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      printf '%s' "$path" | grep -qE '\.ya?ml$' || continue
+      b64="$(gh_read api "repos/${target}/contents/${path}" --jq '.content // empty' || true)"
+      [ -n "$b64" ] || continue
+      printf '%s' "$b64" | tr -d '\n ' | base64 -d > "$dest/workflows/$(basename "$path")" 2>/dev/null \
+        || printf '%s' "$b64" | tr -d '\n ' | base64 --decode > "$dest/workflows/$(basename "$path")"
+    done < <(printf '%s' "$listing" | jq -r '.[]? | select(.type=="file") | .path')
+  fi
+
+  b64="$(gh_read api "repos/${target}/contents/.github/dependabot.yml" --jq '.content // empty' || true)"
+  if [ -n "${b64:-}" ]; then
+    printf '%s' "$b64" | tr -d '\n ' | base64 -d > "$dest/dependabot.yml" 2>/dev/null \
+      || printf '%s' "$b64" | tr -d '\n ' | base64 --decode > "$dest/dependabot.yml"
+  fi
+
+  if jq -e '.HCL != null' "$dest/languages.json" >/dev/null 2>&1; then
+    local root
+    if root="$(gh_read api "repos/${target}/contents/")"; then
+      while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        b64="$(gh_read api "repos/${target}/contents/${path}" --jq '.content // empty' || true)"
+        [ -n "$b64" ] || continue
+        printf '%s' "$b64" | tr -d '\n ' | base64 -d > "$dest/tf/$(basename "$path")" 2>/dev/null \
+          || printf '%s' "$b64" | tr -d '\n ' | base64 --decode > "$dest/tf/$(basename "$path")"
+      done < <(printf '%s' "$root" | jq -r '.[]? | select(.type=="file" and (.name | endswith(".tf"))) | .path' | head -n "$TF_FETCH_CAP")
+    fi
+  fi
+
+  local prs
+  if prs="$(gh_read pr list -R "$target" --state open --limit 100 --json number,title,author,labels,headRefName)"; then
+    printf '%s' "$prs" > "$dest/prs.json"
+  else
+    echo '[]' > "$dest/prs.json"
+  fi
+
+  local tags
+  if tags="$(gh_read api "repos/${target}/git/matching-refs/tags/v")"; then
+    printf '%s' "$tags" | jq '[.[] | {name: .ref}]' > "$dest/tags.json"
+  else
+    echo '[]' > "$dest/tags.json"
+  fi
+
+  local rel
+  if rel="$(gh_read api "repos/${target}/releases?per_page=5")"; then
+    printf '%s' "$rel" | jq '[.[] | {tagName}]' > "$dest/releases.json" 2>/dev/null || echo '[]' > "$dest/releases.json"
+  else
+    echo '[]' > "$dest/releases.json"
+  fi
+
+  local rules
+  if rules="$(gh_read api "repos/${target}/rulesets?includes_parents=false")"; then
+    printf '%s' "$rules" > "$dest/rulesets.json"
+  else
+    echo '[]' > "$dest/rulesets.json"
+  fi
+  return 0
+}
+
+if [ -n "$FLEET_AUDIT_SNAPSHOT" ]; then
+  classify_snapshot "$FLEET_AUDIT_SNAPSHOT"
+  exit 0
+fi
+
+command -v gh >/dev/null || usage_exit "gh is required"
+
+REPOS=""
+if [ -n "$REPO" ]; then
+  printf '%s' "$REPO" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' || usage_exit "REPO must be owner/name"
+  REPOS="$REPO"
+else
+  # Invoked through with_retry; shellcheck misses the indirect call.
+  # shellcheck disable=SC2329
+  _list_repos() {
+    gh repo list "$ORG" --limit 1000 --no-archived \
+      --json nameWithOwner,isFork \
+      --jq '.[] | select(.isFork | not) | .nameWithOwner' 2>/dev/null || return "$RETRY_TRANSIENT_RC"
+  }
+  if ! REPOS="$(with_retry 3 2 20 -- _list_repos)"; then
+    log "gh repo list failed after retries"
+    exit 1
+  fi
+  REPOS="$(printf '%s\n' "$REPOS" | grep -vE "^${ORG}/(\.github|\.allstar)$" || true)"
+fi
+
+log "org=${ORG} scope=${REPO:-<org>} pin=${ACTIONS_VERSION}@${ACTIONS_SHA}"
+
+rc=0
+while IFS= read -r target; do
+  [ -n "$target" ] || continue
+  log "classify ${target}"
+  snap="$(mktemp -d)"
+  if ! fetch_snapshot "$snap" "$target"; then
+    jq -c -n --arg repo "$target" '{
+      repo:$repo, role:"consumer", exempt:false, status:"SKIP",
+      skip_reason:"unreadable", is_terraform:false, has_org_release:false,
+      pins:[], findings:[]
+    }'
+    rm -rf "$snap"
+    continue
+  fi
+  classify_snapshot "$snap" || rc=1
+  rm -rf "$snap"
+done <<< "$REPOS"
+
+exit "$rc"

--- a/scripts/fleet-audit.sh
+++ b/scripts/fleet-audit.sh
@@ -38,8 +38,7 @@ fi
 ACTIONS_SHA="${ACTIONS_SHA:-0000000000000000000000000000000000000000}"
 ACTIONS_VERSION="${ACTIONS_VERSION:-v0.0.0}"
 
-# Used via with_retry in live enumerate (shellcheck cannot see the call).
-# shellcheck disable=SC2329
+# shellcheck disable=SC2317,SC2329  # invoked indirectly via `with_retry -- _gh_read_once` (SC2317/SC2329 are the version-dependent codes for the same "unreachable/unused function" false positive)
 _gh_read_once() {
   local out rc
   set +e
@@ -506,8 +505,7 @@ if [ -n "$REPO" ]; then
   printf '%s' "$REPO" | grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' || usage_exit "REPO must be owner/name"
   REPOS="$REPO"
 else
-  # Invoked through with_retry; shellcheck misses the indirect call.
-  # shellcheck disable=SC2329
+  # shellcheck disable=SC2317,SC2329  # invoked indirectly via `with_retry -- _list_repos` (SC2317/SC2329 are the version-dependent codes for the same "unreachable/unused function" false positive)
   _list_repos() {
     gh repo list "$ORG" --limit 1000 --no-archived \
       --json nameWithOwner,isFork \

--- a/tests/fleet-audit.test.sh
+++ b/tests/fleet-audit.test.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+#
+# Meta-test for scripts/fleet-audit.sh and scripts/fleet-audit-report.sh.
+# Snapshot mode (FLEET_AUDIT_SNAPSHOT) classifies fixture trees with no gh.
+# A mock gh that rejects writes proves live enumerate issues zero mutations.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+AUDIT="${REPO_ROOT}/scripts/fleet-audit.sh"
+REPORT="${REPO_ROOT}/scripts/fleet-audit-report.sh"
+
+fail() { echo "NOT OK: $1"; exit 1; }
+ok() { echo "OK: $1"; }
+
+[ -f "$AUDIT" ] || fail "helper not found at $AUDIT"
+[ -f "$REPORT" ] || fail "helper not found at $REPORT"
+chmod +x "$AUDIT" "$REPORT"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+CURRENT_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OLD_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+export ACTIONS_SHA="$CURRENT_SHA"
+export ACTIONS_VERSION="v0.18.1"
+export AUTOMERGE_APP_ID="3436395"
+
+empty_json_files() {
+  local d="$1"
+  printf '%s\n' '{}' > "$d/languages.json"
+  printf '%s\n' '[]' > "$d/prs.json"
+  printf '%s\n' '[]' > "$d/tags.json"
+  printf '%s\n' '[]' > "$d/releases.json"
+  printf '%s\n' '[]' > "$d/rulesets.json"
+}
+
+write_meta() {
+  local d="$1" name="$2"
+  cat > "$d/meta.json" <<EOF
+{"nameWithOwner":"${name}","default_branch":"main","isFork":false,"isArchived":false,"repositoryTopics":[]}
+EOF
+}
+
+run_snap() {
+  local d="$1"
+  FLEET_AUDIT_SNAPSHOT="$d" bash "$AUDIT"
+}
+
+assert_finding() {
+  local json="$1" id="$2"
+  printf '%s' "$json" | jq -e --arg id "$id" '.findings[] | select(.id == $id)' >/dev/null \
+    || fail "expected finding $id in: $json"
+}
+
+assert_no_finding() {
+  local json="$1" id="$2"
+  if printf '%s' "$json" | jq -e --arg id "$id" '.findings[] | select(.id == $id)' >/dev/null 2>&1; then
+    fail "did not expect finding $id in: $json"
+  fi
+}
+
+# ---- pin-lag + sha-comment ----
+SNAP="$WORK/lag"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/lag-repo"
+empty_json_files "$SNAP"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${OLD_SHA} # v0.12.1
+EOF
+OUT="$(run_snap "$SNAP")" || fail "lag snapshot rc"
+assert_finding "$OUT" "pin-lag"
+printf '%s' "$OUT" | jq -e '.status == "FAIL"' >/dev/null || fail "lag status FAIL"
+ok "pin-lag"
+
+# ---- @main ----
+SNAP="$WORK/main"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/main-repo"
+empty_json_files "$SNAP"
+cat > "$SNAP/workflows/ci.yml" <<'EOF'
+jobs:
+  t:
+    uses: Coalfire-CF/Actions/.github/workflows/org-gitleaks-pr.yml@main
+EOF
+OUT="$(run_snap "$SNAP")" || fail "main snapshot rc"
+assert_finding "$OUT" "pin-bad-ref"
+ok "pin-bad-ref"
+
+# ---- bare tag ----
+SNAP="$WORK/bare"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/bare-repo"
+empty_json_files "$SNAP"
+cat > "$SNAP/workflows/ci.yml" <<'EOF'
+jobs:
+  t:
+    uses: Coalfire-CF/Actions/.github/workflows/org-gitleaks-pr.yml@v0.18.1
+EOF
+OUT="$(run_snap "$SNAP")" || fail "bare snapshot rc"
+assert_finding "$OUT" "pin-bare-tag"
+ok "pin-bare-tag"
+
+# ---- SHA no comment ----
+SNAP="$WORK/nocomment"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/nocomment-repo"
+empty_json_files "$SNAP"
+cat > "$SNAP/workflows/ci.yml" <<EOF
+jobs:
+  t:
+    uses: Coalfire-CF/Actions/.github/workflows/org-gitleaks-pr.yml@${CURRENT_SHA}
+EOF
+OUT="$(run_snap "$SNAP")" || fail "nocomment snapshot rc"
+assert_finding "$OUT" "pin-sha-no-comment"
+ok "pin-sha-no-comment"
+
+# ---- mixed pins ----
+SNAP="$WORK/mixed"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/mixed-repo"
+empty_json_files "$SNAP"
+cat > "$SNAP/workflows/a.yml" <<EOF
+jobs:
+  t:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/b.yml" <<EOF
+jobs:
+  t:
+    uses: Coalfire-CF/Actions/.github/workflows/org-gitleaks-pr.yml@${OLD_SHA} # v0.12.1
+EOF
+OUT="$(run_snap "$SNAP")" || fail "mixed snapshot rc"
+assert_finding "$OUT" "pin-mixed"
+ok "pin-mixed"
+
+# ---- no-caller ----
+SNAP="$WORK/nocall"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/empty-repo"
+empty_json_files "$SNAP"
+echo "name: local" > "$SNAP/workflows/ci.yml"
+OUT="$(run_snap "$SNAP")" || fail "nocall snapshot rc"
+assert_finding "$OUT" "no-caller"
+ok "no-caller"
+
+# ---- producer: local refs, not no-caller / pin-lag ----
+SNAP="$WORK/producer"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/Actions"
+empty_json_files "$SNAP"
+cat > "$SNAP/workflows/dependabot-auto-merge.yml" <<'EOF'
+jobs:
+  t:
+    uses: ./.github/workflows/org-dependabot-auto-merge.yml
+EOF
+OUT="$(run_snap "$SNAP")" || fail "producer snapshot rc"
+printf '%s' "$OUT" | jq -e '.role == "producer"' >/dev/null || fail "producer role"
+assert_no_finding "$OUT" "no-caller"
+assert_no_finding "$OUT" "pin-lag"
+ok "producer local refs"
+
+# ---- current pin PASS (adopted, automerge + dependabot present) ----
+SNAP="$WORK/pass"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/pass-repo"
+empty_json_files "$SNAP"
+printf '%s\n' '{"HCL": 100}' > "$SNAP/languages.json"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot-auto-merge.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-terraform-validate.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-terraform-fmt.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-terraform-docs.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/dependabot.yml" <<'EOF'
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    groups:
+      org-actions:
+        patterns: ["Coalfire-CF/*"]
+EOF
+printf '%s\n' '[{"name":"v1.0.0"}]' > "$SNAP/tags.json"
+printf '%s\n' '[{"tagName":"v1.0.0"}]' > "$SNAP/releases.json"
+OUT="$(run_snap "$SNAP")" || fail "pass snapshot rc"
+printf '%s' "$OUT" | jq -e '.status == "PASS"' >/dev/null || fail "expected PASS: $OUT"
+ok "current pin PASS"
+
+# ---- automerge-missing-caller + dependabot-missing-gha ----
+SNAP="$WORK/amiss"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/amiss-repo"
+empty_json_files "$SNAP"
+printf '%s\n' '[{"name":"v1.0.0"}]' > "$SNAP/tags.json"
+printf '%s\n' '[{"tagName":"v1.0.0"}]' > "$SNAP/releases.json"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+OUT="$(run_snap "$SNAP")" || fail "amiss snapshot rc"
+assert_finding "$OUT" "automerge-missing-caller"
+assert_finding "$OUT" "dependabot-missing-gha"
+ok "automerge-missing-caller + dependabot-missing-gha"
+
+# ---- Dependabot PR classifications ----
+SNAP="$WORK/prs"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/prs-repo"
+empty_json_files "$SNAP"
+printf '%s\n' '[{"name":"v1.0.0"}]' > "$SNAP/tags.json"
+printf '%s\n' '[{"tagName":"v1.0.0"}]' > "$SNAP/releases.json"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot-auto-merge.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/dependabot.yml" <<'EOF'
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+EOF
+cat > "$SNAP/prs.json" <<'EOF'
+[
+  {
+    "number": 1,
+    "title": "chore(deps): bump Coalfire-CF/Actions",
+    "author": {"login": "dependabot[bot]"},
+    "labels": [],
+    "headRefName": "dependabot/github_actions/x",
+    "files": [{"path": ".github/workflows/org-release.yml"}]
+  },
+  {
+    "number": 2,
+    "title": "chore(deps): bump actions/checkout",
+    "author": {"login": "dependabot[bot]"},
+    "labels": [{"name": "merge/approved"}],
+    "headRefName": "dependabot/github_actions/y",
+    "files": [{"path": ".github/workflows/ci.yml"}]
+  },
+  {
+    "number": 3,
+    "title": "chore(deps): bump hashicorp/aws",
+    "author": {"login": "dependabot[bot]"},
+    "labels": [{"name": "merge/blocked"}, {"name": "blocked/known-vuln"}],
+    "headRefName": "dependabot/terraform/z",
+    "files": [{"path": "main.tf"}]
+  },
+  {
+    "number": 4,
+    "title": "chore(deps): bump Coalfire-CF/Actions",
+    "author": {"login": "dependabot[bot]"},
+    "labels": [{"name": "blocked/terraform-no-tests"}, {"name": "merge/skipped"}],
+    "headRefName": "dependabot/github_actions/z",
+    "files": [{"path": ".github/workflows/org-release.yml"}]
+  }
+]
+EOF
+OUT="$(run_snap "$SNAP")" || fail "prs snapshot rc"
+assert_finding "$OUT" "dependabot-unlabeled"
+assert_finding "$OUT" "automerge-approved-unmerged"
+assert_finding "$OUT" "automerge-blocked"
+assert_finding "$OUT" "automerge-tf-block-on-actions"
+ok "dependabot PR classifications"
+
+# ---- ruleset-no-bypass ----
+SNAP="$WORK/rules"; mkdir -p "$SNAP/workflows"
+write_meta "$SNAP" "Coalfire-CF/rules-repo"
+empty_json_files "$SNAP"
+printf '%s\n' '[{"name":"v1.0.0"}]' > "$SNAP/tags.json"
+printf '%s\n' '[{"tagName":"v1.0.0"}]' > "$SNAP/releases.json"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot-auto-merge.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/dependabot.yml" <<'EOF'
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+EOF
+cat > "$SNAP/rulesets.json" <<'EOF'
+[
+  {
+    "id": 9,
+    "name": "pr",
+    "bypass_actors": [],
+    "rules": [{"type": "pull_request"}]
+  }
+]
+EOF
+OUT="$(run_snap "$SNAP")" || fail "rules snapshot rc"
+assert_finding "$OUT" "ruleset-no-bypass"
+ok "ruleset-no-bypass"
+
+# ---- release / source-pin / terraform gates / bootstrap / orphan ----
+SNAP="$WORK/rest"; mkdir -p "$SNAP/workflows" "$SNAP/tf"
+write_meta "$SNAP" "Coalfire-CF/rest-repo"
+empty_json_files "$SNAP"
+printf '%s\n' '{"HCL": 1}' > "$SNAP/languages.json"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot-auto-merge.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/orphan.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-apply.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/dependabot.yml" <<'EOF'
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+EOF
+cat > "$SNAP/tf/main.tf" <<'EOF'
+module "x" {
+  source = "github.com/Coalfire-CF/terraform-aws-vpc?ref=main"
+}
+EOF
+cat > "$SNAP/prs.json" <<'EOF'
+[
+  {
+    "number": 10,
+    "title": "chore(bootstrap): baseline",
+    "author": {"login": "ci-automerge-app[bot]"},
+    "labels": [{"name": "bootstrap/proposed"}],
+    "headRefName": "bootstrap/baseline-v0.18.1",
+    "files": []
+  },
+  {
+    "number": 11,
+    "title": "chore(main): release 1.2.3",
+    "author": {"login": "release-please[bot]"},
+    "labels": [{"name": "autorelease: pending"}],
+    "headRefName": "release-please--branches--main",
+    "files": []
+  }
+]
+EOF
+OUT="$(run_snap "$SNAP")" || fail "rest snapshot rc"
+assert_finding "$OUT" "release-no-tags"
+assert_finding "$OUT" "source-pin-fail"
+assert_finding "$OUT" "terraform-missing-gates"
+assert_finding "$OUT" "bootstrap-pr-open"
+assert_finding "$OUT" "release-please-stale"
+assert_finding "$OUT" "orphan-caller"
+ok "release/source-pin/terraform/bootstrap/orphan"
+
+# ---- source-pin-warn + release-tag-no-github-release + exempt ----
+SNAP="$WORK/warns"; mkdir -p "$SNAP/workflows" "$SNAP/tf"
+cat > "$SNAP/meta.json" <<'EOF'
+{"nameWithOwner":"Coalfire-CF/warn-repo","default_branch":"main","isFork":false,"isArchived":false,"repositoryTopics":[{"name":"bootstrap-exempt"}]}
+EOF
+empty_json_files "$SNAP"
+printf '%s\n' '[{"name":"v1.0.0"}]' > "$SNAP/tags.json"
+printf '%s\n' '[]' > "$SNAP/releases.json"
+cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/workflows/org-dependabot-auto-merge.yml" <<EOF
+jobs:
+  d:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@${CURRENT_SHA} # v0.18.1
+EOF
+cat > "$SNAP/dependabot.yml" <<'EOF'
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+EOF
+cat > "$SNAP/tf/main.tf" <<'EOF'
+module "x" {
+  source = "github.com/Coalfire-CF/terraform-aws-vpc?ref=v2.2.6" # v2.2.6
+}
+EOF
+OUT="$(run_snap "$SNAP")" || fail "warns snapshot rc"
+assert_finding "$OUT" "source-pin-warn"
+assert_finding "$OUT" "release-tag-no-github-release"
+printf '%s' "$OUT" | jq -e '.exempt == true' >/dev/null || fail "exempt true"
+printf '%s' "$OUT" | jq -e '.status == "PASS"' >/dev/null || fail "warn-only PASS: $OUT"
+ok "warn-only PASS + exempt"
+
+# ---- unreadable snapshot (missing meta) ----
+SNAP="$WORK/bad"; mkdir -p "$SNAP"
+OUT="$(run_snap "$SNAP")" || fail "unreadable should rc 0"
+printf '%s' "$OUT" | jq -e '.status == "SKIP" and .skip_reason == "unreadable"' >/dev/null \
+  || fail "unreadable SKIP: $OUT"
+ok "unreadable SKIP"
+
+# ---- report ----
+MD="$(printf '%s\n' "$OUT" "$(run_snap "$WORK/lag")" | bash "$REPORT")" || fail "report rc"
+printf '%s' "$MD" | grep -q "Actions fleet audit" || fail "report title"
+printf '%s' "$MD" | grep -q "pin-lag" || fail "report pin-lag section"
+printf '%s' "$MD" | grep -q "Coalfire-CF/lag-repo" || fail "report names repo"
+ok "report markdown"
+
+# ---- live enumerate: mock gh, reject writes ----
+BIN="$WORK/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${GH_TRACE:?}"
+for a in "$@"; do
+  case "$a" in
+    --method|PUT|POST|PATCH|-X) echo "MOCK: write rejected" >&2; exit 90 ;;
+  esac
+done
+[ "$1" = "pr" ] && [ "$2" = "create" ] && { echo "MOCK: pr create rejected" >&2; exit 90; }
+[ "$1" = "pr" ] && [ "$2" = "merge" ] && { echo "MOCK: pr merge rejected" >&2; exit 90; }
+if [ "$1" = "repo" ] && [ "$2" = "list" ]; then
+  echo '[{"nameWithOwner":"Coalfire-CF/skip-me","isFork":true,"isArchived":false,"repositoryTopics":[]}]'
+  exit 0
+fi
+exit 0
+MOCK
+chmod +x "$BIN/gh"
+export GH_TRACE="$WORK/gh.trace"
+: > "$GH_TRACE"
+PATH="$BIN:$PATH" ORG=Coalfire-CF REPO="" bash "$AUDIT" >"$WORK/live.out" 2>"$WORK/live.err" || fail "live enumerate rc"
+if grep -qE 'write rejected|pr create|pr merge' "$WORK/live.err"; then
+  fail "live path attempted a write"
+fi
+ok "live enumerate zero writes"
+
+echo "ALL OK"
+exit 0

--- a/tests/fleet-audit.test.sh
+++ b/tests/fleet-audit.test.sh
@@ -452,6 +452,30 @@ printf '%s' "$MD" | grep -q "pin-lag" || fail "report pin-lag section"
 printf '%s' "$MD" | grep -q "Coalfire-CF/lag-repo" || fail "report names repo"
 ok "report markdown"
 
+# ---- truncation cuts on a line boundary (MD055: no half-written table row) ----
+: > "$WORK/many.ndjson"
+i=0
+while [ "$i" -lt 60 ]; do
+  SNAP="$WORK/bulk"; rm -rf "$SNAP"; mkdir -p "$SNAP/workflows"
+  write_meta "$SNAP" "Coalfire-CF/bulk-repo-${i}"
+  empty_json_files "$SNAP"
+  cat > "$SNAP/workflows/org-release.yml" <<EOF
+jobs:
+  release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@${OLD_SHA} # v0.12.1
+EOF
+  run_snap "$SNAP" >> "$WORK/many.ndjson"
+  i=$((i + 1))
+done
+TRUNC="$(FLEET_AUDIT_MAX_BYTES=2000 bash "$REPORT" < "$WORK/many.ndjson")"
+printf '%s' "$TRUNC" | grep -q "truncated" || fail "expected truncation marker"
+while IFS= read -r line; do
+  case "$line" in
+    "|"*) printf '%s' "$line" | grep -qE '\|[[:space:]]*$' || fail "truncated table row: $line" ;;
+  esac
+done <<< "$TRUNC"
+ok "truncation preserves whole table rows"
+
 # ---- live enumerate: mock gh, reject writes ----
 BIN="$WORK/bin"; mkdir -p "$BIN"
 cat > "$BIN/gh" <<'MOCK'


### PR DESCRIPTION
## Summary
- add a weekly read-only fleet audit for Actions pin lag, Dependabot merge gaps, ruleset bypass, and release/tag drift
- publish NDJSON, markdown, a standing issue, and a dated baseline snapshot
- document the check catalog, fixture mode, and remediation order

## Impact
No consumer repositories are modified. Full-org runs update the `Actions fleet audit` issue; scoped canaries only publish artifacts.

## Validation
- `bash tests/fleet-audit.test.sh`
- `shellcheck scripts/fleet-audit.sh scripts/fleet-audit-report.sh`
- `SHELLCHECK_OPTS='-S warning' actionlint .github/workflows/org-actions-fleet-audit.yml`

Full `tests/*.test.sh` reaches the pre-existing example-pin failure on `main`: docs still reference v0.18.0 while the manifest is v0.18.1.

Made with [Cursor](https://cursor.com)