### PR TITLE
docs(examples): refresh caller pins to v0.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ permissions:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     secrets: inherit
     with:
       slack_channel_id: 'C0123456789'
@@ -106,7 +106,7 @@ Access to private Terraform module repositories is controlled using a GitHub App
 # Private repo — pass app credentials for module access
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
     secrets:
@@ -116,7 +116,7 @@ jobs:
 # Public repo — no app credentials needed
 jobs:
   validate:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       terraform_version: '1.15.7' # or omit to use .terraform-version
 ```
@@ -136,7 +136,7 @@ Wrapper around [terraform-docs GitHub Actions](https://github.com/terraform-docs
 # Root module and submodules
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       recursive: true
 ```

--- a/docs/ORG_DEPENDABOT_AUTO_MERGE.md
+++ b/docs/ORG_DEPENDABOT_AUTO_MERGE.md
@@ -224,7 +224,7 @@ Run the label sync workflow on each repo before enabling auto-merge:
 ```yaml
 jobs:
   sync-labels:
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-label-sync.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     secrets: inherit
 ```
 
@@ -251,7 +251,7 @@ jobs:
     if: >-
       github.event_name == 'check_suite' ||
       github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     secrets: inherit
 ```
 
@@ -283,9 +283,9 @@ pass `actions_ref`:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: <YOUR_ORG>/Actions/.github/workflows/org-dependabot-auto-merge.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
-      actions_ref: 162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+      actions_ref: 23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     secrets: inherit
 ```
 

--- a/docs/ORG_TERRATEST.md
+++ b/docs/ORG_TERRATEST.md
@@ -193,7 +193,7 @@ concurrency:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       test_mode: pr
       go_version: "1.26"
@@ -241,7 +241,7 @@ concurrency:
 
 jobs:
   terratest-azure:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       test_mode: pr
       go_version: "1.26"
@@ -277,7 +277,7 @@ concurrency:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       test_mode: pr
       go_version: "1.26"
@@ -300,7 +300,7 @@ on:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       test_mode: release
       go_version: "1.26"
@@ -309,7 +309,7 @@ jobs:
 
   release-clean:
     needs: terratest
-    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release-clean.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       tag_name: ${{ github.event.release.tag_name }}
 ```
@@ -483,7 +483,7 @@ permissions:
 
 jobs:
   terratest:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@162d71ff9bace6c2994b3b8d9e5bfc33f6b54eed # v0.18.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terratest.yml@23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4 # v0.18.1
     with:
       test_directory: test
       test_timeout: 45m


### PR DESCRIPTION
## Summary

- Release 0.18.1 (#310) bumped `.release-please-manifest.json` but left the copy-paste caller examples pinned at `v0.18.0` / `162d71ff`, so `tests/example-pin-check.test.sh` has been failing on `main` ever since.
- Points all 14 examples in `README.md`, `docs/ORG_DEPENDABOT_AUTO_MERGE.md`, and `docs/ORG_TERRATEST.md` at `v0.18.1` / `23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4`.
- Tag SHA verified live: `gh api repos/Coalfire-CF/Actions/git/ref/tags/v0.18.1` resolves to `23c6c8bc526102ed041f2e08a363e5ea2c2f0ec4`.

Refs #221 — the guard catches the drift, but the SHA still has to be refreshed by hand, since a release cannot know its own tag SHA at release-PR time.

## Test plan

- [x] `bash tests/example-pin-check.test.sh` → `OK: all 14 example pin(s) advertise v0.18.1`
- [x] `npx markdownlint-cli2@0.23.0` on the three changed files → 0 errors
- [x] No occurrences of the old SHA remain in `README.md` or `docs/`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)